### PR TITLE
Allow to propagate query params to sdk

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -50,6 +50,7 @@ const decartClientOptionsSchema = z
     baseUrl: z.url().optional(),
     proxy: proxySchema.optional(),
     integration: z.string().optional(),
+    queryParams: z.any().optional(),
   })
   .refine(
     (data) => {
@@ -72,12 +73,16 @@ export type DecartClientOptions =
       apiKey?: never;
       baseUrl?: string;
       integration?: string;
+      /** Additional query parameters to append to the WebSocket connection URL */
+      queryParams?: Record<string, string>;
     }
   | {
       proxy?: never;
       apiKey?: string;
       baseUrl?: string;
       integration?: string;
+      /** Additional query parameters to append to the WebSocket connection URL */
+      queryParams?: Record<string, string>;
     };
 
 /**
@@ -145,7 +150,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
   } else {
     baseUrl = parsedOptions.data.baseUrl || "https://api.decart.ai";
   }
-  const { integration } = parsedOptions.data;
+  const { integration, queryParams } = parsedOptions.data;
 
   // Realtime (WebRTC) always requires direct API access with API key
   // Proxy mode is only for HTTP endpoints (process, queue, tokens)
@@ -155,6 +160,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
     baseUrl: wsBaseUrl,
     apiKey: apiKey || "",
     integration,
+    queryParams,
   });
 
   const process = createProcessClient({

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -26,6 +26,8 @@ export type RealTimeClientOptions = {
   baseUrl: string;
   apiKey: string;
   integration?: string;
+  /** Additional query parameters to append to the WebSocket connection URL */
+  queryParams?: Record<string, string>;
 };
 
 const realTimeClientInitialStateSchema = modelStateSchema;
@@ -90,7 +92,7 @@ export type RealTimeClient = {
 };
 
 export const createRealTimeClient = (opts: RealTimeClientOptions) => {
-  const { baseUrl, apiKey, integration } = opts;
+  const { baseUrl, apiKey, integration, queryParams } = opts;
 
   const connect = async (
     stream: MediaStream | null,
@@ -141,8 +143,14 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         : undefined;
 
     const url = `${baseUrl}${options.model.urlPath}`;
+    // Build query string with api_key, model, and any additional query params
+    const urlParams = new URLSearchParams({
+      api_key: apiKey,
+      model: options.model.name,
+      ...(queryParams || {}),
+    });
     const webrtcManager = new WebRTCManager({
-      webrtcUrl: `${url}?api_key=${apiKey}&model=${options.model.name}`,
+      webrtcUrl: `${url}?${urlParams.toString()}`,
       apiKey,
       sessionId,
       fps: options.model.fps,


### PR DESCRIPTION
This is required to support priority queue for @naed90 and other "demos" [PR409](https://github.com/DecartAI/api/pull/409)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `queryParams` option that alters the realtime WebRTC/WebSocket connection URL, which could affect connectivity if parameters are malformed or unexpected. Scope is limited to SDK option plumbing and URL construction.
> 
> **Overview**
> Adds support for passing arbitrary `queryParams` through `createDecartClient` into the realtime client.
> 
> Realtime connection URL generation now builds the WebRTC/WebSocket query string via `URLSearchParams`, always including `api_key` and `model` and appending any provided `queryParams`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f77f55a4a6e221807b4582b20c852cd34fab1fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->