### PR TITLE
feat: add 20MB file size limit for uploads

### DIFF
--- a/packages/sdk/src/process/client.ts
+++ b/packages/sdk/src/process/client.ts
@@ -30,7 +30,7 @@ export const createProcessClient = (opts: ProcessClientOptions): ProcessClient =
     const processedInputs: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(parsedInputs.data as Record<string, unknown>)) {
       if (key === "data" || key === "start" || key === "end") {
-        processedInputs[key] = await fileInputToBlob(value as FileInput, key);
+        processedInputs[key] = await fileInputToBlob(value as FileInput, key, model.maxFileSize);
       } else {
         processedInputs[key] = value;
       }

--- a/packages/sdk/src/process/client.ts
+++ b/packages/sdk/src/process/client.ts
@@ -30,7 +30,7 @@ export const createProcessClient = (opts: ProcessClientOptions): ProcessClient =
     const processedInputs: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(parsedInputs.data as Record<string, unknown>)) {
       if (key === "data" || key === "start" || key === "end") {
-        processedInputs[key] = await fileInputToBlob(value as FileInput);
+        processedInputs[key] = await fileInputToBlob(value as FileInput, key);
       } else {
         processedInputs[key] = value;
       }

--- a/packages/sdk/src/queue/client.ts
+++ b/packages/sdk/src/queue/client.ts
@@ -101,7 +101,7 @@ export const createQueueClient = (opts: QueueClientOptions): QueueClient => {
     const processedInputs: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(parsedInputs.data as Record<string, unknown>)) {
       if (key === "data" || key === "start" || key === "end" || key === "reference_image") {
-        processedInputs[key] = await fileInputToBlob(value as FileInput);
+        processedInputs[key] = await fileInputToBlob(value as FileInput, key);
       } else {
         processedInputs[key] = value;
       }

--- a/packages/sdk/src/queue/client.ts
+++ b/packages/sdk/src/queue/client.ts
@@ -101,7 +101,7 @@ export const createQueueClient = (opts: QueueClientOptions): QueueClient => {
     const processedInputs: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(parsedInputs.data as Record<string, unknown>)) {
       if (key === "data" || key === "start" || key === "end" || key === "reference_image") {
-        processedInputs[key] = await fileInputToBlob(value as FileInput, key);
+        processedInputs[key] = await fileInputToBlob(value as FileInput, key, model.maxFileSize);
       } else {
         processedInputs[key] = value;
       }

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -205,6 +205,11 @@ export type ModelDefinition<T extends Model = Model> = {
   fps: number;
   width: number;
   height: number;
+  /**
+   * Optional per-model file size limit in bytes.
+   * Falls back to the global MAX_FILE_SIZE (20MB) if not set.
+   */
+  maxFileSize?: number;
   inputSchema: T extends keyof ModelInputSchemas ? ModelInputSchemas[T] : z.ZodTypeAny;
 };
 
@@ -227,6 +232,7 @@ export const modelDefinitionSchema = z.object({
   fps: z.number().min(1),
   width: z.number().min(1),
   height: z.number().min(1),
+  maxFileSize: z.number().min(1).optional(),
   inputSchema: z.any(),
 });
 
@@ -364,6 +370,7 @@ const _models = {
       fps: 22,
       width: 1280,
       height: 704,
+      maxFileSize: 100 * 1024 * 1024,
       inputSchema: modelInputSchemas["lucy-restyle-v2v"],
     },
   },

--- a/packages/sdk/src/shared/request.ts
+++ b/packages/sdk/src/shared/request.ts
@@ -24,7 +24,11 @@ function isReactNativeFile(value: unknown): value is ReactNativeFile {
  * Convert various file input types to a Blob or React Native file object.
  * React Native file objects are passed through as-is for proper FormData handling.
  */
-export async function fileInputToBlob(input: FileInput, fieldName?: string): Promise<Blob | ReactNativeFile> {
+export async function fileInputToBlob(
+  input: FileInput,
+  fieldName?: string,
+  maxFileSize?: number,
+): Promise<Blob | ReactNativeFile> {
   // React Native file object - pass through as-is (cannot check size)
   if (isReactNativeFile(input)) {
     return input;
@@ -54,8 +58,9 @@ export async function fileInputToBlob(input: FileInput, fieldName?: string): Pro
   }
 
   // Validate file size
-  if (blob.size > MAX_FILE_SIZE) {
-    throw createFileTooLargeError(blob.size, MAX_FILE_SIZE, fieldName);
+  const limit = maxFileSize ?? MAX_FILE_SIZE;
+  if (blob.size > limit) {
+    throw createFileTooLargeError(blob.size, limit, fieldName);
   }
 
   return blob;

--- a/packages/sdk/src/utils/errors.ts
+++ b/packages/sdk/src/utils/errors.ts
@@ -18,6 +18,7 @@ export const ERROR_CODES = {
   QUEUE_RESULT_ERROR: "QUEUE_RESULT_ERROR",
   JOB_NOT_COMPLETED: "JOB_NOT_COMPLETED",
   TOKEN_CREATE_ERROR: "TOKEN_CREATE_ERROR",
+  FILE_TOO_LARGE: "FILE_TOO_LARGE",
 } as const;
 
 export function createSDKError(
@@ -71,5 +72,16 @@ export function createJobNotCompletedError(jobId: string, currentStatus: string)
     ERROR_CODES.JOB_NOT_COMPLETED,
     `Cannot get content for job ${jobId} with status "${currentStatus}"`,
     { jobId, currentStatus },
+  );
+}
+
+export function createFileTooLargeError(fileSize: number, maxSize: number, fieldName?: string): DecartSDKError {
+  const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(1);
+  const maxSizeMB = (maxSize / (1024 * 1024)).toFixed(0);
+  const field = fieldName ? ` for field '${fieldName}'` : "";
+  return createSDKError(
+    ERROR_CODES.FILE_TOO_LARGE,
+    `File size${field} (${fileSizeMB}MB) exceeds the maximum allowed size of ${maxSizeMB}MB. Please reduce the file size or resolution before uploading.`,
+    { fileSize, maxSize, fieldName },
   );
 }

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -233,6 +233,48 @@ describe("Decart SDK", () => {
       });
     });
 
+    describe("File Size Validation", () => {
+      it("rejects file exceeding 20MB limit for process API", async () => {
+        const largeBlob = new Blob([new Uint8Array(21 * 1024 * 1024)], { type: "image/png" });
+
+        await expect(
+          decart.process({
+            model: models.image("lucy-pro-i2i"),
+            prompt: "test",
+            data: largeBlob,
+          }),
+        ).rejects.toThrow("exceeds the maximum allowed size of 20MB");
+      });
+
+      it("accepts file at exactly 20MB limit", async () => {
+        server.use(createMockHandler("/v1/generate/lucy-pro-i2i"));
+
+        const exactBlob = new Blob([new Uint8Array(20 * 1024 * 1024)], { type: "image/png" });
+
+        const result = await decart.process({
+          model: models.image("lucy-pro-i2i"),
+          prompt: "test",
+          data: exactBlob,
+        });
+
+        expect(result).toBeInstanceOf(Blob);
+      });
+
+      it("accepts file under 20MB limit", async () => {
+        server.use(createMockHandler("/v1/generate/lucy-pro-i2i"));
+
+        const smallBlob = new Blob([new Uint8Array(1024)], { type: "image/png" });
+
+        const result = await decart.process({
+          model: models.image("lucy-pro-i2i"),
+          prompt: "test",
+          data: smallBlob,
+        });
+
+        expect(result).toBeInstanceOf(Blob);
+      });
+    });
+
     describe("Error Handling", () => {
       it("handles API errors", async () => {
         server.use(
@@ -617,6 +659,18 @@ describe("Queue API", () => {
           prompt: "test",
         }),
       ).rejects.toThrow("Failed to submit job");
+    });
+
+    it("rejects file exceeding 20MB limit for queue API", async () => {
+      const largeBlob = new Blob([new Uint8Array(21 * 1024 * 1024)], { type: "video/mp4" });
+
+      await expect(
+        decart.queue.submit({
+          model: models.video("lucy-pro-v2v"),
+          prompt: "test",
+          data: largeBlob,
+        }),
+      ).rejects.toThrow("exceeds the maximum allowed size of 20MB");
     });
   });
 


### PR DESCRIPTION
## Summary
- Add client-side validation to reject files exceeding 20MB before sending to the API, preventing GPU timeouts from oversized video uploads (Lucy Edit Pro v2v supports up to 5s input)
- Add `FILE_TOO_LARGE` error code and `createFileTooLargeError()` factory function
- Validate file size after blob conversion in both process and queue APIs (skips React Native files lacking `.size`)

## Changes
- `src/utils/errors.ts` — New error code + factory
- `src/shared/request.ts` — `MAX_FILE_SIZE` constant, size validation in `fileInputToBlob()`
- `src/process/client.ts` — Pass field name to `fileInputToBlob()` for error messages
- `src/queue/client.ts` — Pass field name to `fileInputToBlob()` for error messages
- `tests/unit.test.ts` — 4 new tests (over/at/under limit for process + queue)

## Testing
- 91 tests passing
- Typecheck clean
- Biome format clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes input processing for both `process` and `queue` APIs by adding size checks that can cause previously-accepted requests to fail before hitting the server; React Native uploads bypass size validation.
> 
> **Overview**
> Adds client-side upload size validation in the SDK by enforcing a **default 20MB limit** on all file-like inputs after conversion to a `Blob` in `fileInputToBlob`, raising a new `FILE_TOO_LARGE` `DecartSDKError` with field-specific messaging.
> 
> Introduces an optional per-model `maxFileSize` override (wired through both `process` and `queue` clients) and sets `lucy-restyle-v2v` to **100MB**. Unit tests are expanded to cover reject/accept behavior at the boundary for both APIs and the per-model override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ac803020f07c5712290c7b9fd43192323177aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->