### PR TITLE
feat(realtime): expose queue status and position events

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decartai/sdk",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "Decart's JavaScript SDK",
   "type": "module",
   "license": "MIT",

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -79,6 +79,8 @@ export type RealTimeClientOptions = {
 
 const realTimeClientInitialStateSchema = modelStateSchema;
 type OnRemoteStreamFn = (stream: MediaStream) => void;
+type OnStatusFn = (status: string) => void;
+type OnQueuePositionFn = (data: { position: number; queueSize: number }) => void;
 export type RealTimeClientInitialState = z.infer<typeof realTimeClientInitialStateSchema>;
 
 // ugly workaround to add an optional function to the schema
@@ -93,6 +95,16 @@ const realTimeClientConnectOptionsSchema = z.object({
   }),
   initialState: realTimeClientInitialStateSchema.optional(),
   customizeOffer: createAsyncFunctionSchema(z.function()).optional(),
+  onStatus: z
+    .custom<OnStatusFn>((val) => typeof val === "function", {
+      message: "onStatus must be a function",
+    })
+    .optional(),
+  onQueuePosition: z
+    .custom<OnQueuePositionFn>((val) => typeof val === "function", {
+      message: "onQueuePosition must be a function",
+    })
+    .optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -102,6 +114,8 @@ export type Events = {
   connectionChange: ConnectionState;
   error: DecartSDKError;
   generationTick: { seconds: number };
+  status: string;
+  queuePosition: { position: number; queueSize: number };
   diagnostic: DiagnosticEvent;
   stats: WebRTCStats;
 };
@@ -137,7 +151,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
 
     const isAvatarLive = options.model.name === "live_avatar" || options.model.name === "live-avatar";
 
-    const { onRemoteStream, initialState } = parsedOptions.data;
+    const { onRemoteStream, initialState, onStatus, onQueuePosition } = parsedOptions.data;
 
     // For live_avatar without user-provided stream: create AudioStreamManager for continuous silent stream with audio injection
     // If user provides their own stream (e.g., mic input), use it directly
@@ -257,6 +271,17 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         emitOrBuffer("generationTick", { seconds: msg.seconds });
       };
       manager.getWebsocketMessageEmitter().on("generationTick", tickListener);
+
+      const wsEmitter = manager.getWebsocketMessageEmitter();
+      wsEmitter.on("status", (msg) => {
+        emitOrBuffer("status", msg.status);
+        onStatus?.(msg.status);
+      });
+      wsEmitter.on("queuePosition", (msg) => {
+        const data = { position: msg.position, queueSize: msg.queue_size };
+        emitOrBuffer("queuePosition", data);
+        onQueuePosition?.(data);
+      });
 
       await manager.connect(inputStream);
 

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -49,6 +49,17 @@ export type SetImageAckMessage = {
   error: null | string;
 };
 
+export type StatusMessage = {
+  type: "status";
+  status: string;
+};
+
+export type QueuePositionMessage = {
+  type: "queue_position";
+  position: number;
+  queue_size: number;
+};
+
 export type GenerationStartedMessage = {
   type: "generation_started";
 };
@@ -85,7 +96,9 @@ export type IncomingWebRTCMessage =
   | GenerationStartedMessage
   | GenerationTickMessage
   | GenerationEndedMessage
-  | SessionIdMessage;
+  | SessionIdMessage
+  | StatusMessage
+  | QueuePositionMessage;
 
 // Outgoing message types (to server)
 export type OutgoingWebRTCMessage =

--- a/packages/sdk/src/realtime/webrtc-connection.ts
+++ b/packages/sdk/src/realtime/webrtc-connection.ts
@@ -9,8 +9,10 @@ import type {
   IncomingWebRTCMessage,
   OutgoingWebRTCMessage,
   PromptAckMessage,
+  QueuePositionMessage,
   SessionIdMessage,
   SetImageAckMessage,
+  StatusMessage,
 } from "./types";
 
 const ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
@@ -35,6 +37,8 @@ type WsMessageEvents = {
   setImageAck: SetImageAckMessage;
   sessionId: SessionIdMessage;
   generationTick: GenerationTickMessage;
+  status: StatusMessage;
+  queuePosition: QueuePositionMessage;
 };
 
 const noopDiagnostic: DiagnosticEmitter = () => {};
@@ -251,6 +255,16 @@ export class WebRTCConnection {
 
       if (msg.type === "session_id") {
         this.websocketMessagesEmitter.emit("sessionId", msg);
+        return;
+      }
+
+      if (msg.type === "status") {
+        this.websocketMessagesEmitter.emit("status", msg);
+        return;
+      }
+
+      if (msg.type === "queue_position") {
+        this.websocketMessagesEmitter.emit("queuePosition", msg);
         return;
       }
 

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1752,6 +1752,167 @@ describe("Subscribe Client", () => {
     }
   });
 
+  it("exposes status and queue_position websocket messages as realtime client events", async () => {
+    const { createRealTimeClient } = await import("../src/realtime/client.js");
+    const { WebRTCManager } = await import("../src/realtime/webrtc-manager.js");
+
+    const statusListeners = new Set<
+      (
+        msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+      ) => void
+    >();
+    const queuePositionListeners = new Set<
+      (
+        msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+      ) => void
+    >();
+    const websocketEmitter = {
+      on: (
+        event: string,
+        listener: (
+          msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+        ) => void,
+      ) => {
+        if (event === "status") statusListeners.add(listener);
+        if (event === "queuePosition") queuePositionListeners.add(listener);
+      },
+      off: (
+        event: string,
+        listener: (
+          msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+        ) => void,
+      ) => {
+        if (event === "status") statusListeners.delete(listener);
+        if (event === "queuePosition") queuePositionListeners.delete(listener);
+      },
+    };
+
+    const connectSpy = vi.spyOn(WebRTCManager.prototype, "connect").mockImplementation(async function () {
+      const mgr = this as unknown as {
+        config: { onConnectionStateChange?: (state: import("../src/realtime/types").ConnectionState) => void };
+        managerState: import("../src/realtime/types").ConnectionState;
+      };
+      mgr.managerState = "connected";
+      mgr.config.onConnectionStateChange?.("connected");
+      return true;
+    });
+    const stateSpy = vi.spyOn(WebRTCManager.prototype, "getConnectionState").mockReturnValue("connected");
+    const emitterSpy = vi
+      .spyOn(WebRTCManager.prototype, "getWebsocketMessageEmitter")
+      .mockReturnValue(websocketEmitter as never);
+    const cleanupSpy = vi.spyOn(WebRTCManager.prototype, "cleanup").mockImplementation(() => {});
+
+    try {
+      const realtime = createRealTimeClient({ baseUrl: "wss://api3.decart.ai", apiKey: "test-key" });
+      const client = await realtime.connect({} as MediaStream, {
+        model: models.realtime("mirage_v2"),
+        onRemoteStream: vi.fn(),
+      });
+
+      const statusEvents: string[] = [];
+      const queueEvents: Array<{ position: number; queueSize: number }> = [];
+
+      client.on("status", (status) => statusEvents.push(status));
+      client.on("queuePosition", (data) => queueEvents.push(data));
+
+      for (const listener of statusListeners) {
+        listener({ type: "status", status: "queued" });
+      }
+      for (const listener of queuePositionListeners) {
+        listener({ type: "queue_position", position: 2, queue_size: 11 });
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(statusEvents).toEqual(["queued"]);
+      expect(queueEvents).toEqual([{ position: 2, queueSize: 11 }]);
+    } finally {
+      connectSpy.mockRestore();
+      stateSpy.mockRestore();
+      emitterSpy.mockRestore();
+      cleanupSpy.mockRestore();
+    }
+  });
+
+  it("calls onStatus and onQueuePosition callbacks when websocket updates arrive", async () => {
+    const { createRealTimeClient } = await import("../src/realtime/client.js");
+    const { WebRTCManager } = await import("../src/realtime/webrtc-manager.js");
+
+    const statusListeners = new Set<
+      (
+        msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+      ) => void
+    >();
+    const queuePositionListeners = new Set<
+      (
+        msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+      ) => void
+    >();
+    const websocketEmitter = {
+      on: (
+        event: string,
+        listener: (
+          msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+        ) => void,
+      ) => {
+        if (event === "status") statusListeners.add(listener);
+        if (event === "queuePosition") queuePositionListeners.add(listener);
+      },
+      off: (
+        event: string,
+        listener: (
+          msg: { type: "status"; status: string } | { type: "queue_position"; position: number; queue_size: number },
+        ) => void,
+      ) => {
+        if (event === "status") statusListeners.delete(listener);
+        if (event === "queuePosition") queuePositionListeners.delete(listener);
+      },
+    };
+
+    const connectSpy = vi.spyOn(WebRTCManager.prototype, "connect").mockImplementation(async function () {
+      const mgr = this as unknown as {
+        config: { onConnectionStateChange?: (state: import("../src/realtime/types").ConnectionState) => void };
+        managerState: import("../src/realtime/types").ConnectionState;
+      };
+      mgr.managerState = "connected";
+      mgr.config.onConnectionStateChange?.("connected");
+      return true;
+    });
+    const stateSpy = vi.spyOn(WebRTCManager.prototype, "getConnectionState").mockReturnValue("connected");
+    const emitterSpy = vi
+      .spyOn(WebRTCManager.prototype, "getWebsocketMessageEmitter")
+      .mockReturnValue(websocketEmitter as never);
+    const cleanupSpy = vi.spyOn(WebRTCManager.prototype, "cleanup").mockImplementation(() => {});
+
+    try {
+      const onStatus = vi.fn();
+      const onQueuePosition = vi.fn();
+
+      const realtime = createRealTimeClient({ baseUrl: "wss://api3.decart.ai", apiKey: "test-key" });
+      await realtime.connect({} as MediaStream, {
+        model: models.realtime("mirage_v2"),
+        onRemoteStream: vi.fn(),
+        onStatus,
+        onQueuePosition,
+      });
+
+      for (const listener of statusListeners) {
+        listener({ type: "status", status: "initializing" });
+      }
+      for (const listener of queuePositionListeners) {
+        listener({ type: "queue_position", position: 4, queue_size: 19 });
+      }
+
+      expect(onStatus).toHaveBeenCalledWith("initializing");
+      expect(onQueuePosition).toHaveBeenCalledWith({ position: 4, queueSize: 19 });
+    } finally {
+      connectSpy.mockRestore();
+      stateSpy.mockRestore();
+      emitterSpy.mockRestore();
+      cleanupSpy.mockRestore();
+    }
+  });
+
   it("buffers pre-session telemetry diagnostics and flushes them after session_id", async () => {
     const { createRealTimeClient } = await import("../src/realtime/client.js");
     const { WebRTCManager } = await import("../src/realtime/webrtc-manager.js");


### PR DESCRIPTION
## Summary
- Reapply queue-status support from PR #71 on top of current `main` realtime architecture.
- Add websocket `status` and `queue_position` message handling through WebRTC connection and realtime client events.
- Expose optional `onStatus` and `onQueuePosition` connect callbacks, and add unit tests covering both event and callback flows.

## Validation
- `pnpm format`
- `pnpm test tests/unit.test.ts`
- `pnpm typecheck`
- `pnpm build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive event/callback plumbing and type updates with unit coverage; low risk aside from potential minor compatibility impact for consumers relying on strict event typings.
> 
> **Overview**
> Surfaces server queue updates end-to-end in realtime mode by adding websocket message types for `status` and `queue_position`, wiring them through `WebRTCConnection`’s emitter, and exposing them from `RealTimeClient` as new `status` and `queuePosition` events.
> 
> `connect()` now accepts optional `onStatus` and `onQueuePosition` callbacks (validated via zod) that fire alongside event emission, and unit tests were added to cover both the event-based and callback-based flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7af30d773671806d349bb1d4f433d551a77a2628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->