### PR TITLE
fix(realtime): prevent telemetry 401s on reconnection

### DIFF
--- a/packages/sdk/src/realtime/telemetry-reporter.ts
+++ b/packages/sdk/src/realtime/telemetry-reporter.ts
@@ -97,13 +97,14 @@ export class TelemetryReporter implements ITelemetryReporter {
     this.sendReport(false);
   }
 
-  /** Stop the reporter and send a final report with keepalive. */
+  /** Stop the reporter and discard any buffered data. */
   stop(): void {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
-    this.sendReport(true);
+    this.statsBuffer = [];
+    this.diagnosticsBuffer = [];
   }
 
   /**

--- a/packages/sdk/src/realtime/telemetry-reporter.ts
+++ b/packages/sdk/src/realtime/telemetry-reporter.ts
@@ -94,7 +94,7 @@ export class TelemetryReporter implements ITelemetryReporter {
 
   /** Flush buffered data immediately. */
   flush(): void {
-    this.sendReport(false);
+    this.sendReport();
   }
 
   /** Stop the reporter and discard any buffered data. */
@@ -134,7 +134,7 @@ export class TelemetryReporter implements ITelemetryReporter {
     };
   }
 
-  private sendReport(keepalive: boolean): void {
+  private sendReport(): void {
     if (this.statsBuffer.length === 0 && this.diagnosticsBuffer.length === 0) {
       return;
     }
@@ -149,14 +149,10 @@ export class TelemetryReporter implements ITelemetryReporter {
       // Send as many chunks as needed to drain both buffers.
       let chunk = this.createReportChunk();
       while (chunk !== null) {
-        const isLast = this.statsBuffer.length === 0 && this.diagnosticsBuffer.length === 0;
-
         fetch(TELEMETRY_URL, {
           method: "POST",
           headers: commonHeaders,
           body: JSON.stringify(chunk),
-          // Only set keepalive on the very last chunk (if the caller requested it).
-          keepalive: keepalive && isLast,
         })
           .then((response) => {
             if (!response.ok) {

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2300,7 +2300,6 @@ describe("TelemetryReporter", () => {
       const [url, options] = fetchMock.mock.calls[0];
       expect(url).toBe("https://platform.decart.ai/api/v1/telemetry");
       expect(options.method).toBe("POST");
-      expect(options.keepalive).toBe(false);
 
       const body = JSON.parse(options.body);
       expect(body.sessionId).toBe("sess-1");

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1618,7 +1618,7 @@ describe("Subscribe Client", () => {
     }
   });
 
-  it("buffers pre-session telemetry diagnostics and flushes them after session_id", async () => {
+  it("buffers pre-session telemetry diagnostics and discards them on disconnect", async () => {
     const { createRealTimeClient } = await import("../src/realtime/client.js");
     const { WebRTCManager } = await import("../src/realtime/webrtc-manager.js");
 
@@ -1683,17 +1683,11 @@ describe("Subscribe Client", () => {
         });
       }
 
+      // disconnect() calls stop() which discards buffered data instead of sending it.
+      // This avoids 401s when the API key has been invalidated on reconnect.
       client.disconnect();
 
-      await vi.waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-      });
-
-      const [, options] = fetchMock.mock.calls[0];
-      const body = JSON.parse(options.body);
-      expect(body.diagnostics).toHaveLength(1);
-      expect(body.diagnostics[0].name).toBe("phaseTiming");
-      expect(body.diagnostics[0].data.phase).toBe("websocket");
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       connectSpy.mockRestore();
       stateSpy.mockRestore();
@@ -2351,7 +2345,7 @@ describe("TelemetryReporter", () => {
     }
   });
 
-  it("stop sends final report with keepalive", async () => {
+  it("stop discards buffered data without sending a request", async () => {
     const { TelemetryReporter } = await import("../src/realtime/telemetry-reporter.js");
 
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
@@ -2375,9 +2369,12 @@ describe("TelemetryReporter", () => {
 
       reporter.stop();
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [, options] = fetchMock.mock.calls[0];
-      expect(options.keepalive).toBe(true);
+      // stop() should NOT send any network request
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      // flush() after stop() should be a no-op (buffers were cleared)
+      reporter.flush();
+      expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }


### PR DESCRIPTION
## Summary

- `TelemetryReporter.stop()` now discards buffered data instead of sending a final `keepalive` report
- Prevents `401 Unauthorized` errors on `POST /api/v1/telemetry` when reconnecting with a fresh API key while the old reporter's final fetch fires with a stale key

## Changes

| File | Change |
|------|--------|
| `telemetry-reporter.ts` | `stop()` clears buffers instead of calling `sendReport(true)` |
| `unit.test.ts` | Updated 2 tests to assert `stop()` does not make network requests |

## Design Decision

Telemetry is non-critical — losing one final batch (up to 10s) on disconnect is acceptable. The three `stop()` call sites in `client.ts` remain unchanged; the new contract is strictly simpler (never makes a network call).

## Test plan

- [x] All 129 unit tests pass (`pnpm test`)
- [ ] Manual: connect → disconnect → reconnect with new key → no 401s in DevTools Network tab

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to realtime telemetry shutdown behavior and related tests, trading a small amount of final telemetry for avoiding unwanted requests during disconnect/reconnect flows.
> 
> **Overview**
> Prevents stale API keys from triggering `401 Unauthorized` telemetry posts during disconnect/reconnect by changing `TelemetryReporter.stop()` to **never send a final report** and instead clear buffered stats/diagnostics.
> 
> Simplifies the reporter send path by removing `keepalive` handling (including from `flush()` calls), and updates unit tests to assert that disconnect/`stop()` discards pre-session and buffered telemetry without making any network requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a2877c61337a5a0087bbae27f73df1317adad4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->