### PR TITLE
feat: add lucy-2.1-vton batch/queue API support

### DIFF
--- a/examples/sdk-core/video/virtual-try-on.ts
+++ b/examples/sdk-core/video/virtual-try-on.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import { createDecartClient, models } from "@decartai/sdk";
+import { run } from "../lib/run";
+
+run(async () => {
+  const apiKey = process.env.DECART_API_KEY;
+  if (!apiKey) {
+    throw new Error("DECART_API_KEY environment variable is required");
+  }
+
+  const client = createDecartClient({
+    apiKey,
+  });
+
+  console.log("Processing virtual try-on with lucy-2.1-vton...");
+
+  const inputVideo = fs.readFileSync("input.mp4");
+
+  const result = await client.queue.submitAndPoll({
+    model: models.video("lucy-2.1-vton"),
+    prompt: "Wearing a red leather jacket",
+    data: new Blob([inputVideo]),
+    onStatusChange: (job) => {
+      console.log(`Job ${job.job_id}: ${job.status}`);
+    },
+  });
+
+  if (result.status === "completed") {
+    const output = Buffer.from(await result.data.arrayBuffer());
+    fs.writeFileSync("output.mp4", output);
+    console.log("Video saved to output.mp4");
+  } else {
+    console.log("Job failed:", result.error);
+  }
+});

--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -163,7 +163,7 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
   ? ImageEditingInputs
   : T["name"] extends "lucy-restyle-v2v" | "lucy-restyle-2"
     ? VideoRestyleInputs
-    : T["name"] extends "lucy-2-v2v" | "lucy-2" | "lucy-2.1"
+    : T["name"] extends "lucy-2-v2v" | "lucy-2" | "lucy-2.1" | "lucy-2.1-vton"
       ? VideoEdit2Inputs
       : T["name"] extends "lucy-pro-v2v" | "lucy-clip"
         ? VideoEditInputs

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -59,10 +59,12 @@ export const videoModels = z.union([
   z.literal("lucy-clip"),
   z.literal("lucy-2"),
   z.literal("lucy-2.1"),
+  z.literal("lucy-2.1-vton"),
   z.literal("lucy-restyle-2"),
   z.literal("lucy-motion"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
+  z.literal("lucy-vton-latest"),
   z.literal("lucy-restyle-latest"),
   z.literal("lucy-clip-latest"),
   z.literal("lucy-motion-latest"),
@@ -209,6 +211,7 @@ export const modelInputSchemas = {
   "lucy-restyle-2": restyleSchema,
   "lucy-2": videoEdit2Schema,
   "lucy-2.1": videoEdit2Schema,
+  "lucy-2.1-vton": videoEdit2Schema,
   "lucy-motion": z.object({
     data: fileInputSchema.describe(
       "The image data to use for generation (File, Blob, ReadableStream, URL, or string URL). Output video is limited to 5 seconds.",
@@ -229,6 +232,7 @@ export const modelInputSchemas = {
   }),
   // Latest aliases (server-side resolution)
   "lucy-latest": videoEdit2Schema,
+  "lucy-vton-latest": videoEdit2Schema,
   "lucy-restyle-latest": restyleSchema,
   "lucy-clip-latest": videoEditSchema,
   "lucy-motion-latest": z.object({
@@ -489,6 +493,15 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-2.1"],
     },
+    "lucy-2.1-vton": {
+      urlPath: "/v1/generate/lucy-2.1-vton",
+      queueUrlPath: "/v1/jobs/lucy-2.1-vton",
+      name: "lucy-2.1-vton" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-2.1-vton"],
+    },
     "lucy-restyle-2": {
       urlPath: "/v1/generate/lucy-restyle-2",
       queueUrlPath: "/v1/jobs/lucy-restyle-2",
@@ -516,6 +529,15 @@ const _models = {
       width: 1088,
       height: 624,
       inputSchema: modelInputSchemas["lucy-latest"],
+    },
+    "lucy-vton-latest": {
+      urlPath: "/v1/generate/lucy-vton-latest",
+      queueUrlPath: "/v1/jobs/lucy-vton-latest",
+      name: "lucy-vton-latest" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-vton-latest"],
     },
     "lucy-restyle-latest": {
       urlPath: "/v1/generate/lucy-restyle-latest",
@@ -603,6 +625,7 @@ export const models = {
    *   - `"lucy-clip"` - Video-to-video editing
    *   - `"lucy-2"` - Long-form video editing (720p)
    *   - `"lucy-2.1"` - Long-form video editing (Lucy 2.1)
+   *   - `"lucy-2.1-vton"` - Virtual try-on video editing
    *   - `"lucy-restyle-2"` - Video restyling
    *   - `"lucy-motion"` - Motion generation
    */

--- a/packages/sdk/tests/e2e.test.ts
+++ b/packages/sdk/tests/e2e.test.ts
@@ -212,6 +212,29 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
       await expectResult(result, "lucy-2.1-reference_image", ".mp4");
     });
 
+    it("lucy-2.1-vton: virtual try-on (prompt)", async () => {
+      const result = await client.queue.submitAndPoll({
+        model: models.video("lucy-2.1-vton"),
+        prompt: "Wearing a red leather jacket",
+        data: videoBlob,
+        seed: 42,
+      });
+
+      await expectResult(result, "lucy-2.1-vton-prompt", ".mp4");
+    });
+
+    it("lucy-2.1-vton: virtual try-on (reference_image)", async () => {
+      const result = await client.queue.submitAndPoll({
+        model: models.video("lucy-2.1-vton"),
+        prompt: "",
+        reference_image: imageBlob,
+        data: videoBlob,
+        seed: 42,
+      });
+
+      await expectResult(result, "lucy-2.1-vton-reference_image", ".mp4");
+    });
+
     // Deprecated video model names (aliases)
     it("lucy-pro-v2v (deprecated): video-to-video", async () => {
       const result = await client.queue.submitAndPoll({

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -3487,6 +3487,13 @@ describe("Canonical Model Names", () => {
       expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.1");
     });
 
+    it("lucy-2.1-vton as video model works", () => {
+      const model = models.video("lucy-2.1-vton");
+      expect(model.name).toBe("lucy-2.1-vton");
+      expect(model.urlPath).toBe("/v1/generate/lucy-2.1-vton");
+      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.1-vton");
+    });
+
     it("lucy-restyle-2 as video model works", () => {
       const model = models.video("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -3542,6 +3549,16 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
+    it("lucy-vton-latest works as video model", () => {
+      const model = models.video("lucy-vton-latest");
+      expect(model.name).toBe("lucy-vton-latest");
+      expect(model.urlPath).toBe("/v1/generate/lucy-vton-latest");
+      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-vton-latest");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
+    });
+
     it("lucy-restyle-latest works as video model", () => {
       const model = models.video("lucy-restyle-latest");
       expect(model.name).toBe("lucy-restyle-latest");
@@ -3578,6 +3595,11 @@ describe("Canonical Model Names", () => {
       expect(isVideoModel("lucy-latest")).toBe(true);
     });
 
+    it("lucy-vton-latest is both a realtime and video model", () => {
+      expect(isRealtimeModel("lucy-vton-latest")).toBe(true);
+      expect(isVideoModel("lucy-vton-latest")).toBe(true);
+    });
+
     it("lucy-restyle-latest is both a realtime and video model", () => {
       expect(isRealtimeModel("lucy-restyle-latest")).toBe(true);
       expect(isVideoModel("lucy-restyle-latest")).toBe(true);
@@ -3591,6 +3613,7 @@ describe("Canonical Model Names", () => {
       models.realtime("lucy-vton-latest");
       models.realtime("lucy-restyle-latest");
       models.video("lucy-latest");
+      models.video("lucy-vton-latest");
       models.video("lucy-restyle-latest");
       models.video("lucy-clip-latest");
       models.video("lucy-motion-latest");
@@ -3610,6 +3633,11 @@ describe("Canonical Model Names", () => {
     it("lucy-2.1 is both a realtime and video model", () => {
       expect(isRealtimeModel("lucy-2.1")).toBe(true);
       expect(isVideoModel("lucy-2.1")).toBe(true);
+    });
+
+    it("lucy-2.1-vton is both a realtime and video model", () => {
+      expect(isRealtimeModel("lucy-2.1-vton")).toBe(true);
+      expect(isVideoModel("lucy-2.1-vton")).toBe(true);
     });
 
     it("lucy-restyle-2 is both a realtime and video model", () => {


### PR DESCRIPTION
## Summary

`lucy-2.1-vton` (virtual try-on) is now available as a batch/queue model in addition to realtime. Users can submit async video processing jobs for virtual try-on using the queue API.

Also adds `lucy-vton-latest` as a video model alias for server-side resolution.

## Usage

```ts
import { createDecartClient, models } from "@decartai/sdk";

const client = createDecartClient({ apiKey: "..." });

const result = await client.queue.submitAndPoll({
  model: models.video("lucy-2.1-vton"),
  prompt: "Wearing a red leather jacket",
  data: videoBlob,
});
```

## Test plan

- [x] Unit tests pass (179/179)
- [x] Build succeeds
- [x] E2E tests for lucy-2.1-vton prompt and reference_image variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this primarily extends the SDK’s model registry/types with a new video model and alias, plus adds example and test coverage; no core request/queue logic is refactored.
> 
> **Overview**
> Adds `lucy-2.1-vton` as a first-class **queue/batch video model** in the SDK (model enums, input schema mapping, and model definitions with `/v1/generate/*` + `/v1/jobs/*` paths), and introduces `lucy-vton-latest` as a **video-model alias** for server-side resolution.
> 
> Updates type-level input documentation selection so `lucy-2.1-vton` uses the `VideoEdit2Inputs` shape, adds an example script for async virtual try-on processing, and extends unit + E2E tests to cover the new model/alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7174ebec0e5b6bfc9b2e7159d2cda71165a1858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->