### PR TITLE
fix: `lucy-2` realtime video dimensions

### DIFF
--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -321,8 +321,8 @@ const _models = {
       urlPath: "/v1/stream",
       name: "lucy-2" as const,
       fps: 20,
-      width: 1280,
-      height: 720,
+      width: 1088,
+      height: 624,
       inputSchema: z.object({}),
     },
     "lucy-2.1": {
@@ -419,8 +419,8 @@ const _models = {
       urlPath: "/v1/stream",
       name: "lucy_2_rt" as const,
       fps: 20,
-      width: 1280,
-      height: 720,
+      width: 1088,
+      height: 624,
       inputSchema: z.object({}),
     },
     live_avatar: {

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1140,8 +1140,8 @@ describe("Lucy 2 realtime", () => {
 
     it("has expected dimensions", () => {
       const lucyModel = models.realtime("lucy_2_rt");
-      expect(lucyModel.width).toBe(1280);
-      expect(lucyModel.height).toBe(720);
+      expect(lucyModel.width).toBe(1088);
+      expect(lucyModel.height).toBe(624);
     });
 
     it("has correct fps", () => {
@@ -3420,8 +3420,8 @@ describe("Canonical Model Names", () => {
       expect(model.name).toBe("lucy-2");
       expect(model.urlPath).toBe("/v1/stream");
       expect(model.fps).toBe(20);
-      expect(model.width).toBe(1280);
-      expect(model.height).toBe(720);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
     });
 
     it("lucy-2.1 canonical name works", () => {


### PR DESCRIPTION
Should be 624x1088 instead of 720x1280

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates realtime model metadata (width/height) and adjusts unit tests accordingly, with no changes to request flow or validation logic.
> 
> **Overview**
> Fixes the `lucy-2` realtime model definitions (`lucy-2` and deprecated `lucy_2_rt`) to report dimensions as **1088x624** instead of **1280x720**.
> 
> Updates unit tests to assert the new realtime dimensions for both the canonical and deprecated model names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd544bae7de5c19da6ae659a41b955815387606e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->