### PR TITLE
Pin @types/bun to ^1.3.12 in bun-cli example

### DIFF
--- a/examples/bun-cli/package.json
+++ b/examples/bun-cli/package.json
@@ -13,6 +13,6 @@
     "@decartai/sdk": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "latest"
+    "@types/bun": "^1.3.12"
   }
 }


### PR DESCRIPTION
## Summary
- Replaces `"@types/bun": "latest"` with `^1.3.12` in `examples/bun-cli/package.json`
- Part of the org-wide audit to remove `latest` version specifiers

## Test plan
- [ ] `bun install` in `examples/bun-cli` resolves cleanly
- [ ] `bun run build` still produces `decart-cli`

## Platform team
Linear: https://linear.app/decart/issue/PLA-202/pin-typesbun-in-sdk-bun-cli-example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only pins a dev dependency version in an example project, with no runtime or production code changes.
> 
> **Overview**
> Pins the `examples/bun-cli` dev dependency `@types/bun` from `latest` to `^1.3.12` to avoid floating type definitions and make installs reproducible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1cf33ea94da0f0be9f7e66cc591249a39c0a44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->