### PR TITLE
feat: scope client tokens to specific browser origins

### DIFF
--- a/examples/sdk-core/tokens/create-client-token.ts
+++ b/examples/sdk-core/tokens/create-client-token.ts
@@ -9,11 +9,14 @@ run(async () => {
 
   console.log("Creating client token...");
 
-  const token = await serverClient.tokens.create();
+  const token = await serverClient.tokens.create({
+    allowedOrigins: ["https://example.com"],
+  });
 
   console.log("Token created successfully:");
   console.log(`  API Key: ${token.apiKey.slice(0, 10)}...`);
   console.log(`  Expires At: ${token.expiresAt}`);
+  console.log(`  Allowed Origins: ${token.permissions?.origins?.join(", ") ?? "(any)"}`);
 
   // Client-side: Use the client token
   // In a real app, you would send token.apiKey to the frontend

--- a/packages/sdk/src/tokens/client.ts
+++ b/packages/sdk/src/tokens/client.ts
@@ -15,6 +15,13 @@ export type CreateTokenOptions = {
   expiresIn?: number;
   /** Restrict which models this token can access (max 20 items). */
   allowedModels?: (Model | (string & {}))[];
+  /**
+   * Restrict which web origins this token can be used from (max 20 items).
+   * Each entry must be a full origin including scheme, e.g. `https://example.com`.
+   * Enforced on realtime sessions by matching the WebSocket `Origin` header
+   * verbatim. Defense-in-depth — only effective for browser-based clients.
+   */
+  allowedOrigins?: string[];
   /** Operational limits for the token. */
   constraints?: { realtime?: { maxSessionDuration?: number } };
 };
@@ -22,8 +29,11 @@ export type CreateTokenOptions = {
 export type CreateTokenResponse = {
   apiKey: string;
   expiresAt: string;
-  /** Present when `allowedModels` was set on the request. */
-  permissions?: { models: (Model | (string & {}))[] } | null;
+  /** Present when `allowedModels` and/or `allowedOrigins` were set on the request. */
+  permissions?: {
+    models?: (Model | (string & {}))[];
+    origins?: string[];
+  } | null;
   /** Present when `constraints` was set on the request. */
   constraints?: { realtime?: { maxSessionDuration?: number } } | null;
 };
@@ -43,10 +53,11 @@ export type TokensClient = {
    * // With metadata:
    * const token = await client.tokens.create({ metadata: { role: "viewer" } });
    *
-   * // With expiry, model restrictions, and constraints:
+   * // With expiry, model restrictions, origin restrictions, and constraints:
    * const token = await client.tokens.create({
    *   expiresIn: 300,
    *   allowedModels: ["lucy-pro-v2v", "lucy-restyle-v2v"],
+   *   allowedOrigins: ["https://example.com"],
    *   constraints: { realtime: { maxSessionDuration: 120 } },
    * });
    * ```

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1074,6 +1074,23 @@ describe("Tokens API", () => {
       expect(body).toEqual({ constraints: { realtime: { maxSessionDuration: 120 } } });
     });
 
+    it("sends allowedOrigins in request body", async () => {
+      server.use(
+        http.post("http://localhost/v1/client/tokens", async ({ request }) => {
+          lastRequest = request;
+          return HttpResponse.json({
+            apiKey: "ek_test123",
+            expiresAt: "2024-12-15T12:10:00Z",
+          });
+        }),
+      );
+
+      await decart.tokens.create({ allowedOrigins: ["https://example.com", "https://app.example.com"] });
+
+      const body = await lastRequest?.json();
+      expect(body).toEqual({ allowedOrigins: ["https://example.com", "https://app.example.com"] });
+    });
+
     it("sends all options together", async () => {
       server.use(
         http.post("http://localhost/v1/client/tokens", async ({ request }) => {
@@ -1089,6 +1106,7 @@ describe("Tokens API", () => {
         metadata: { role: "viewer" },
         expiresIn: 300,
         allowedModels: ["lucy-pro-v2v"],
+        allowedOrigins: ["https://example.com"],
         constraints: { realtime: { maxSessionDuration: 60 } },
       });
 
@@ -1097,6 +1115,7 @@ describe("Tokens API", () => {
         metadata: { role: "viewer" },
         expiresIn: 300,
         allowedModels: ["lucy-pro-v2v"],
+        allowedOrigins: ["https://example.com"],
         constraints: { realtime: { maxSessionDuration: 60 } },
       });
     });
@@ -1108,7 +1127,10 @@ describe("Tokens API", () => {
           return HttpResponse.json({
             apiKey: "ek_test123",
             expiresAt: "2024-12-15T12:15:00Z",
-            permissions: { models: ["lucy-pro-v2v", "lucy-restyle-v2v"] },
+            permissions: {
+              models: ["lucy-pro-v2v", "lucy-restyle-v2v"],
+              origins: ["https://example.com"],
+            },
             constraints: { realtime: { maxSessionDuration: 120 } },
           });
         }),
@@ -1116,11 +1138,15 @@ describe("Tokens API", () => {
 
       const result = await decart.tokens.create({
         allowedModels: ["lucy-pro-v2v", "lucy-restyle-v2v"],
+        allowedOrigins: ["https://example.com"],
         constraints: { realtime: { maxSessionDuration: 120 } },
       });
 
       expect(result.apiKey).toBe("ek_test123");
-      expect(result.permissions).toEqual({ models: ["lucy-pro-v2v", "lucy-restyle-v2v"] });
+      expect(result.permissions).toEqual({
+        models: ["lucy-pro-v2v", "lucy-restyle-v2v"],
+        origins: ["https://example.com"],
+      });
       expect(result.constraints).toEqual({ realtime: { maxSessionDuration: 120 } });
     });
   });


### PR DESCRIPTION
## Summary

Adds an `allowedOrigins` option to `client.tokens.create()` that scopes a short-lived client token to a specific list of web origins. When the token is later used to open a realtime session, the connection is accepted only if the browser-issued WebSocket `Origin` header matches one of the listed origins.

This complements `allowedModels` to give server-side issuers tighter control over how a frontend-bound token can be used.

## Usage

```ts
import { createDecartClient } from "@decartai/sdk";

const server = createDecartClient({ apiKey: process.env.DECART_API_KEY });

// Token usable only from https://app.example.com
const token = await server.tokens.create({
  allowedOrigins: ["https://app.example.com"],
  expiresIn: 60,
});
```

Combine with the existing options:

```ts
const token = await server.tokens.create({
  allowedModels: ["lucy-pro-v2v"],
  allowedOrigins: ["https://app.example.com"],
  constraints: { realtime: { maxSessionDuration: 120 } },
});
```

When the token is used from a non-allowed origin, the realtime WebSocket is closed with `{"type":"error","error":"Origin not allowed"}`. When `allowedOrigins` is omitted, no origin restriction is applied.

## Notes

- Each entry must be a canonical origin: `scheme://host[:port]` — lowercase, no trailing slash, path, query, fragment, credentials, or default port. Up to 20 entries, max 253 characters each.
- This is a defense-in-depth control: it is enforced via the browser-set `Origin` header, so it materially raises the cost of stolen-token abuse from a different web origin, but does not protect against attackers controlling a non-browser HTTP client.

## Test plan

- [x] Unit tests cover request-body forwarding, all-options-together, and response round-trip.
- [x] \`pnpm --filter @decartai/sdk test\` — 176/176 pass.
- [x] \`examples/sdk-core/tokens/create-client-token.ts\` updated to demonstrate the new field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive SDK surface-area and type-shape changes, but consumers relying on the old `permissions` structure may need to adjust to the updated optional fields.
> 
> **Overview**
> Adds a new `allowedOrigins` option to `client.tokens.create()` to request client tokens restricted to specific browser origins.
> 
> Updates the SDK response typing to return `permissions.origins` (alongside existing model permissions), expands unit tests to cover request forwarding and response round-tripping, and updates the token creation example to demonstrate origin scoping and printing the resulting allowed origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78da2d01d7ff6d32b2a1f117e1cc4f2587529ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->