### PR TITLE
feat: list all realtime models in demo dropdown

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -235,10 +235,24 @@
         <div class="control-group">
             <label for="model-select">Model:</label>
             <select id="model-select">
-                <option value="mirage">Mirage</option>
-                <option value="mirage_v2" selected>Mirage v2</option>
-                <option value="lucy_v2v_720p_rt">Lucy v2v 720p RT</option>
-                <option value="lucy-2.1">Lucy 2.1 RT</option>
+                <optgroup label="Latest (server-resolved)">
+                    <option value="lucy-latest">Lucy (latest)</option>
+                    <option value="lucy-vton-latest">Lucy VTON (latest)</option>
+                    <option value="lucy-restyle-latest">Lucy Restyle (latest)</option>
+                </optgroup>
+                <optgroup label="Canonical">
+                    <option value="lucy">Lucy</option>
+                    <option value="lucy-2.1" selected>Lucy 2.1</option>
+                    <option value="lucy-2.1-vton">Lucy 2.1 VTON</option>
+                    <option value="lucy-restyle">Lucy Restyle</option>
+                    <option value="lucy-restyle-2">Lucy Restyle 2</option>
+                    <option value="live-avatar">Live Avatar</option>
+                </optgroup>
+                <optgroup label="Deprecated aliases">
+                    <option value="mirage">Mirage</option>
+                    <option value="mirage_v2">Mirage v2</option>
+                    <option value="lucy_v2v_720p_rt">Lucy v2v 720p RT</option>
+                </optgroup>
             </select>
         </div>
         <div class="control-group">

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -385,7 +385,7 @@
         let isConnected = false;
         let processedVideoUrl = null;
         let currentSessionId = null;
-        let model = models.realtime("mirage_v2");
+        let model = models.realtime("lucy-2.1");
         
         // DOM elements
         const elements = {


### PR DESCRIPTION
## Summary
- The Realtime model selector in `packages/sdk/index.html` only listed 4 models. Adds all canonical realtime models from `src/shared/model.ts` plus the `*-latest` aliases.
- Options grouped via `<optgroup>` into **Latest (server-resolved)**, **Canonical**, and **Deprecated aliases** — old names kept since they still resolve through the SDK's alias map.
- Default selection updated from the deprecated `mirage_v2` to canonical `lucy-2.1`.

## Linear
Platform: https://linear.app/decart/issue/PLA-227/demo-list-all-realtime-models-in-sdk-demo-dropdown

## Test plan
- [ ] Open `packages/sdk/index.html` in Chrome and confirm the dropdown shows all three groups
- [ ] Pick a canonical model (e.g. `lucy-2.1-vton`) and verify camera + connect flow still works
- [ ] Pick a deprecated alias (e.g. `mirage`) and verify it still connects (deprecation warning expected in console)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only UI/configuration changes; no SDK runtime logic or security-sensitive behavior is modified.
> 
> **Overview**
> Updates the SDK demo (`packages/sdk/index.html`) realtime model selector to list **all supported realtime models**, grouped into *Latest (server-resolved)*, *Canonical*, and *Deprecated aliases*.
> 
> Changes the demo’s default model from deprecated `mirage_v2` to canonical `lucy-2.1`, while keeping legacy aliases available for compatibility testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5550974f1fb56401e135858847b15b30184ac71f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->