### PR TITLE
fix: custom realtime models broken under zod 4.4+

### DIFF
--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -295,7 +295,7 @@ export const modelDefinitionSchema = z.object({
   fps: z.number().min(1),
   width: z.number().min(1),
   height: z.number().min(1),
-  inputSchema: z.any(),
+  inputSchema: z.any().optional(),
 });
 
 const _models = {


### PR DESCRIPTION
## Summary

A fresh install of `@decartai/sdk` started failing realtime connect for users who pass a custom model definition without an `inputSchema`. The error surfaces as:

```
[ { code: "invalid_type", expected: "nonoptional",
    path: ["model","inputSchema"],
    message: "Invalid input: expected nonoptional, received undefined" } ]
```

This regression is triggered by zod 4.4, which stopped treating `z.any()` as implicitly optional inside object schemas. Built-in models (`models.realtime("lucy-2.1")`, etc.) were unaffected because they always set `inputSchema`. Users following our own `examples/sdk-core/realtime/custom-model.ts` pattern were broken.

The fix aligns the runtime schema with the existing TypeScript type (`CustomModelDefinition.inputSchema?`) and works under zod 4.0–4.4+.

## Usage (unchanged, now actually works on zod 4.4+)

```ts
const customModel: CustomModelDefinition = {
  name: "my-preview-model",
  urlPath: "/v1/stream",
  fps: 20,
  width: 1280,
  height: 720,
};

await client.realtime.connect(stream, { model: customModel, onRemoteStream });
```

## Test plan

- [x] Reproduce the user error against zod@4.4.1 with the old schema (matches reported error verbatim)
- [x] Verify fixed schema accepts custom models with and without `inputSchema` under zod@4.4.1
- [x] Verify built-in models still validate
- [x] Verify the schema still rejects truly-invalid model definitions (missing `fps`, etc.)
- [x] `pnpm --filter @decartai/sdk typecheck`
- [x] `pnpm --filter @decartai/sdk test` (175/175 pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-field validation change that relaxes runtime model definition parsing to match existing TS types; main impact is allowing previously-rejected custom realtime model configs under newer Zod versions.
> 
> **Overview**
> Fixes a regression in `@decartai/sdk` model validation by making `modelDefinitionSchema.inputSchema` optional, aligning runtime Zod validation with `CustomModelDefinition.inputSchema?`.
> 
> This restores compatibility for custom model definitions (notably realtime `connect`) that omit `inputSchema`, which started failing validation under Zod 4.4+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d52ebf68753418b3c1ddc5ddb374bae3a78b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->