### PR TITLE
[codex] Add SDK image deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.vscode
+node_modules
+**/node_modules
+packages/*/dist
+.DS_Store
+test-lucy2-api.html

--- a/.github/workflows/deploy-sdk.yaml
+++ b/.github/workflows/deploy-sdk.yaml
@@ -1,0 +1,177 @@
+name: Deploy SDK
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/deploy-sdk.yaml
+      - biome.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - examples/**
+      - packages/**
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      api_domain:
+        description: "API domain baked into the SDK example realtime default"
+        required: false
+        default: "api.stage-decart.com"
+        type: string
+      image_tag:
+        description: "Optional image tag override. Defaults to the source commit SHA."
+        required: false
+        type: string
+      deploy_to_gitops:
+        description: "Dispatch DecartAI/api GitOps deployment after pushing the image"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  API_REPOSITORY: DecartAI/api
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: sdk
+
+jobs:
+  build-check:
+    name: Docker build check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          build-args: |
+            API_DOMAIN=api.stage-decart.com
+          cache-from: type=gha,scope=sdk
+
+  deploy:
+    name: Build, push, and deploy
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve build inputs
+        id: vars
+        env:
+          DISPATCH_API_DOMAIN: ${{ github.event.inputs.api_domain }}
+          DISPATCH_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          source_sha="${WORKFLOW_RUN_SHA:-$GITHUB_SHA}"
+          api_domain="${DISPATCH_API_DOMAIN:-api.stage-decart.com}"
+          image_tag="${DISPATCH_IMAGE_TAG:-$source_sha}"
+
+          if ! [[ "$image_tag" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::image_tag contains disallowed characters (allowed: [A-Za-z0-9._-])"
+            exit 1
+          fi
+          if [[ ${#image_tag} -gt 128 ]]; then
+            echo "::error::image_tag too long (max 128)"
+            exit 1
+          fi
+          if ! [[ "$api_domain" =~ ^[A-Za-z0-9.-]+$ ]]; then
+            echo "::error::api_domain must be a hostname without scheme or path"
+            exit 1
+          fi
+
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "api_domain=$api_domain" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.vars.outputs.source_sha }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_STAGING }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Ensure ECR repository
+        run: |
+          aws ecr describe-repositories --repository-names "${ECR_REPOSITORY}" >/dev/null 2>&1 \
+            || aws ecr create-repository --repository-name "${ECR_REPOSITORY}" >/dev/null
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          build-args: |
+            API_DOMAIN=${{ steps.vars.outputs.api_domain }}
+          tags: |
+            ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.vars.outputs.source_sha }}
+          cache-from: type=gha,scope=sdk
+          cache-to: type=gha,scope=sdk,mode=max
+
+      - name: Build summary
+        run: |
+          echo "### SDK image" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image:** \`${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.vars.outputs.image_tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Source:** \`${{ github.repository }}@${{ steps.vars.outputs.source_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **API domain:** \`${{ steps.vars.outputs.api_domain }}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Get GitOps app token
+        if: github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops
+        id: app-token
+        uses: peter-murray/workflow-application-token-action@baa1ef2638c3d9e5967b7c8b86219f8fc919e1bb # v3.0.0
+        with:
+          application_id: ${{ secrets.GITOPS_APP_ID }}
+          application_private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+
+      - name: Construct GitOps payload
+        if: github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops
+        id: payload
+        run: |
+          payload="$(jq -nc \
+            --arg service_name "sdk" \
+            --arg image_tag "${{ steps.vars.outputs.image_tag }}" \
+            --arg source_repo "${{ github.repository }}" \
+            --arg source_sha "${{ steps.vars.outputs.source_sha }}" \
+            '{service_name: $service_name, image_tag: $image_tag, source_repo: $source_repo, source_sha: $source_sha}')"
+          echo "payload=$payload" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger API GitOps deploy
+        if: github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ env.API_REPOSITORY }}
+          event-type: gitops-deploy
+          client-payload: ${{ steps.payload.outputs.payload }}

--- a/.github/workflows/deploy-sdk.yaml
+++ b/.github/workflows/deploy-sdk.yaml
@@ -155,8 +155,28 @@ jobs:
           application_id: ${{ secrets.GITOPS_APP_ID }}
           application_private_key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
 
-      - name: Construct GitOps payload
+      - name: Check API GitOps support
         if: github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops
+        id: api-support
+        env:
+          GITOPS_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          status="$(curl -sS -o /tmp/api-sdk-support.json -w "%{http_code}" \
+            -H "Authorization: Bearer ${GITOPS_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${API_REPOSITORY}/contents/dev-env/SDK_DEPLOYMENT.md?ref=main")"
+
+          if [[ "$status" == "200" ]]; then
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Skipping GitOps dispatch because ${API_REPOSITORY}@main does not have SDK deploy support yet (HTTP ${status})"
+            echo "supported=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Construct GitOps payload
+        if: (github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops) && steps.api-support.outputs.supported == 'true'
         id: payload
         run: |
           payload="$(jq -nc \
@@ -168,7 +188,7 @@ jobs:
           echo "payload=$payload" >> "$GITHUB_OUTPUT"
 
       - name: Trigger API GitOps deploy
-        if: github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops
+        if: (github.event_name != 'workflow_dispatch' || inputs.deploy_to_gitops) && steps.api-support.outputs.supported == 'true'
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:20-alpine
+
+# Deployment image for sdk.stage-decart.com.
+#
+# The API repo keeps a separate local-dev Dockerfile that clones SDK branches for
+# `just build sdk`. This Dockerfile is intentionally built from the checked-out
+# SDK repo so the image tag maps directly to an SDK commit.
+
+RUN npm install -g pnpm@10.7.1
+
+WORKDIR /app
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages ./packages
+COPY examples ./examples
+
+# SDK example target API domain. Keep the replacement scheme-free because the
+# SDK source already includes the protocol in the default realtime URL.
+ARG API_DOMAIN=api.stage-decart.com
+RUN sed -i "s|api3.decart.ai|${API_DOMAIN}|g" packages/sdk/src/index.ts
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile
+
+WORKDIR /app/packages/sdk
+RUN pnpm build
+
+RUN echo 'import { defineConfig } from "vite"; \
+export default defineConfig({ \
+  server: { \
+    allowedHosts: ["sdk.decart.local", "sdk.stage-decart.com"], \
+  }, \
+});' > vite.config.ts
+
+EXPOSE 3000
+
+CMD ["pnpm", "dev:example", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- add a root SDK Dockerfile that builds from the checked-out SDK commit instead of cloning another repo during image build
- add `.dockerignore` for lean, deterministic Docker contexts
- add `Deploy SDK` workflow: PR Docker build check, then after the existing `CI` workflow succeeds on `main`, build/push `sdk:<sdk-sha>` to staging ECR and dispatch `DecartAI/api` `gitops-deploy` with `service_name: sdk`
- guard the GitOps dispatch until `DecartAI/api@main` has SDK deploy support, so merging this before the API PR only builds/pushes and does not update old GitOps paths

## Operational notes
- workflow expects `AWS_ROLE_TO_ASSUME_STAGING` as a repo/org variable
- workflow expects `GITOPS_APP_ID` and `GITOPS_APP_PRIVATE_KEY` secrets with access to dispatch `DecartAI/api`
- manual dispatch can override `api_domain`, `image_tag`, or skip the GitOps dispatch

## Validation
- `git diff --check`
- `yq eval '.' .github/workflows/deploy-sdk.yaml`
- `docker build -t sdk:codex-deploy-test --build-arg API_DOMAIN=api.stage-decart.com .`

Paired API repo PR: https://github.com/DecartAI/api/pull/1302

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new staging deployment automation (ECR push + cross-repo GitOps dispatch), so misconfiguration could impact release cadence or deploy the wrong image/tag, though it doesn’t change runtime SDK logic.
> 
> **Overview**
> Adds a root `Dockerfile` and `.dockerignore` to build a deterministic SDK deployment image from the checked-out commit, including a build arg to bake in the target API hostname and a Vite `allowedHosts` config for the hosted example.
> 
> Introduces a new `Deploy SDK` GitHub Actions workflow that (1) validates the Docker build on PRs and (2) after `CI` succeeds on `main` (or via manual dispatch) builds and pushes `sdk:<sha>` to staging ECR, optionally dispatching a `gitops-deploy` event to `DecartAI/api` after first checking that the target repo supports SDK deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a7ad859edfa6d482fd8de8eb0964e49d5a6422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->