### PR TITLE
test: retire inactive model e2e coverage

### DIFF
--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -11,16 +11,11 @@ function createSyntheticStream(fps: number, width: number, height: number): Medi
 }
 
 const REALTIME_MODELS: RealTimeModels[] = [
-  // Canonical names
-  "lucy-restyle",
+  // Actively served realtime video models and supported aliases.
   "lucy-restyle-2",
-  "lucy",
   "lucy-2.1",
   "lucy-2.1-vton",
-  // Deprecated names
-  "mirage",
   "mirage_v2",
-  "lucy_v2v_720p_rt",
 ];
 
 const TIMEOUT = 1 * 60 * 1000; // 1 minute

--- a/packages/sdk/tests/e2e.test.ts
+++ b/packages/sdk/tests/e2e.test.ts
@@ -120,18 +120,6 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
   });
 
   describe("Queue API - Video Models", () => {
-    it("lucy-clip: video-to-video", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-clip"),
-        prompt: "Lego World animated style",
-        data: videoBlob,
-        seed: 999,
-        enhance_prompt: true,
-      });
-
-      await expectResult(result, "lucy-clip", ".mp4");
-    });
-
     it("lucy-restyle-2: video restyling (prompt)", async () => {
       const result = await client.queue.submitAndPoll({
         model: models.video("lucy-restyle-2"),
@@ -201,18 +189,6 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
     });
 
     // Deprecated video model names (aliases)
-    it("lucy-pro-v2v (deprecated): video-to-video", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-pro-v2v"),
-        prompt: "Lego World animated style",
-        data: videoBlob,
-        seed: 999,
-        enhance_prompt: true,
-      });
-
-      await expectResult(result, "lucy-pro-v2v", ".mp4");
-    });
-
     it("lucy-restyle-v2v (deprecated): video restyling", async () => {
       const result = await client.queue.submitAndPoll({
         model: models.video("lucy-restyle-v2v"),
@@ -257,36 +233,6 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
       });
 
       await expectResult(result, "lucy-clip-latest", ".mp4");
-    });
-
-    it("lucy-motion-latest: motion-guided image-to-video", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-motion-latest"),
-        data: imageBlob,
-        trajectory: [
-          { frame: 0, x: 0, y: 0 },
-          { frame: 1, x: 0.1, y: 0.2 },
-          { frame: 2, x: 0.2, y: 0.4 },
-        ],
-        seed: 555,
-      });
-
-      await expectResult(result, "lucy-motion-latest", ".mp4");
-    });
-
-    it("lucy-motion: motion-guided image-to-video", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-motion"),
-        data: imageBlob,
-        trajectory: [
-          { frame: 0, x: 0, y: 0 },
-          { frame: 1, x: 0.1, y: 0.2 },
-          { frame: 2, x: 0.2, y: 0.4 },
-        ],
-        seed: 555,
-      });
-
-      await expectResult(result, "lucy-motion", ".mp4");
     });
   });
 });


### PR DESCRIPTION
## Summary
- remove realtime E2E coverage for retired realtime model names (`lucy-restyle`, `lucy`, `mirage`, `lucy_v2v_720p_rt`)
- remove Queue API E2E coverage for retired/failing video models/aliases (`lucy-clip`, `lucy-pro-v2v`, `lucy-motion-latest`, `lucy-motion`)
- keep E2E coverage for currently served realtime/video models and aliases, including `lucy-clip-latest`

## Validation
- `pnpm typecheck`
- `pnpm exec biome check tests/e2e.test.ts tests/e2e-realtime.test.ts`
- `git diff --check`
- independent Claude Code diff review: no blockers; only assumption is that `lucy-clip-latest` remains live, which matched the scheduled E2E alert (15/18 passed; only the removed non-latest/retired video tests failed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes only delete/trim E2E tests and model lists, with no SDK runtime or API behavior changes.
> 
> **Overview**
> Prunes SDK E2E coverage to match currently served models.
> 
> Realtime E2E tests narrow `REALTIME_MODELS` to active model names/aliases and drop older canonical/deprecated entries.
> 
> Queue API video E2E tests remove cases for retired/failing models/aliases (`lucy-clip`, `lucy-pro-v2v`, `lucy-motion(-latest)`), while keeping coverage for active models including `lucy-clip-latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d0660f50c4f8fda9cd05b74b4bee3b30a2010d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->