### PR TITLE
feat: rename Lucy VTON public model ids

### DIFF
--- a/examples/nextjs-realtime/README.md
+++ b/examples/nextjs-realtime/README.md
@@ -47,3 +47,4 @@ This example uses `lucy-restyle-2` for style transformation. You can also use:
 
 - `lucy-2.1` - Lucy 2.1 for video editing with reference image support
 - `lucy-2.1-vton` - Lucy 2.1 virtual try-on
+- `lucy-vton-2` - Lucy VTON 2

--- a/examples/react-vite/README.md
+++ b/examples/react-vite/README.md
@@ -45,3 +45,4 @@ This example uses `lucy-restyle-2` for style transformation. You can also use:
 
 - `lucy-2.1` - Lucy 2.1 for video editing with reference image support
 - `lucy-2.1-vton` - Lucy 2.1 virtual try-on
+- `lucy-vton-2` - Lucy VTON 2

--- a/examples/sdk-core/README.md
+++ b/examples/sdk-core/README.md
@@ -50,6 +50,7 @@ See `examples/nextjs-realtime` or `examples/react-vite` for runnable demos.
 - `realtime/mirage-v2-basic.ts` - Realtime style transformation with `lucy-restyle-2`
 - `realtime/lucy-2.1.ts` - Lucy 2.1 realtime video editing with reference image support
 - `realtime/lucy-2.1-vton.ts` - Lucy 2.1 virtual try-on
+- `realtime/lucy-vton-2.ts` - Lucy VTON 2
 - `realtime/connection-events.ts` - Handling connection state and errors
 - `realtime/prompt-update.ts` - Updating prompt dynamically
 - `realtime/custom-model.ts` - Using a custom model definition (e.g., preview/experimental models)

--- a/examples/sdk-core/realtime/lucy-vton-2.ts
+++ b/examples/sdk-core/realtime/lucy-vton-2.ts
@@ -1,0 +1,48 @@
+/**
+ * Browser-only example - requires WebRTC APIs
+ * Lucy VTON 2 (Virtual Try-On) for realtime garment/outfit transfer
+ * See examples/nextjs-realtime or examples/react-vite for runnable demos
+ */
+
+import { createDecartClient, models } from "@decartai/sdk";
+
+async function main() {
+  const model = models.realtime("lucy-vton-2");
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: true,
+    video: {
+      frameRate: model.fps,
+      width: model.width,
+      height: model.height,
+    },
+  });
+
+  const client = createDecartClient({
+    apiKey: process.env.DECART_API_KEY!,
+  });
+
+  const realtimeClient = await client.realtime.connect(stream, {
+    model,
+    onRemoteStream: (editedStream) => {
+      const video = document.getElementById("output") as HTMLVideoElement;
+      video.srcObject = editedStream;
+    },
+    initialState: {
+      prompt: {
+        text: "Wearing a red leather jacket",
+        enhance: true,
+      },
+    },
+  });
+
+  // Use a reference image of a garment to try on
+  await realtimeClient.set({
+    prompt: "Wearing the outfit from the reference image",
+    image: "https://example.com/outfit-reference.png",
+  });
+
+  console.log("Session ID:", realtimeClient.sessionId);
+}
+
+main();

--- a/examples/tanstack-streamer/README.md
+++ b/examples/tanstack-streamer/README.md
@@ -55,3 +55,4 @@ This example uses `lucy-2.1` for video editing with reference image support. You
 
 - `lucy-restyle-2` - MirageLSD v2 for style transformation
 - `lucy-2.1-vton` - Lucy 2.1 virtual try-on
+- `lucy-vton-2` - Lucy VTON 2

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -65,15 +65,19 @@
 ### Realtime Models (WebRTC)
 - `lucy-2.1` - Real-time video editing (supports reference image)
 - `lucy-2.1-vton` - Real-time virtual try-on
+- `lucy-vton-2` - Real-time virtual try-on 2
 - `lucy-restyle-2` - Real-time video restyling
 - `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest` - Server-resolved aliases for the latest stable version
+- Deprecated: `lucy-vton` → `lucy-2.1-vton`, `lucy-2.1-vton-2` → `lucy-vton-2`
 
 ### Video Models (Queue API)
 - `lucy-clip` - video-to-video editing
 - `lucy-2.1` - long-form video editing (720p)
 - `lucy-2.1-vton` - virtual try-on video editing
+- `lucy-vton-2` - virtual try-on 2 video editing
 - `lucy-restyle-2` - video restyling
 - `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest`, `lucy-clip-latest` - Server-resolved aliases
+- Deprecated: `lucy-vton` → `lucy-2.1-vton`, `lucy-2.1-vton-2` → `lucy-vton-2`
 
 ### Image Models (Process API)
 - `lucy-image-2` - image-to-image editing

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -243,10 +243,13 @@
                 <optgroup label="Canonical">
                     <option value="lucy-2.1" selected>Lucy 2.1</option>
                     <option value="lucy-2.1-vton">Lucy 2.1 VTON</option>
+                    <option value="lucy-vton-2">Lucy VTON 2</option>
                     <option value="lucy-restyle-2">Lucy Restyle 2</option>
                 </optgroup>
                 <optgroup label="Deprecated aliases">
                     <option value="mirage_v2">Mirage v2</option>
+                    <option value="lucy-vton">Lucy VTON (alias for Lucy 2.1 VTON)</option>
+                    <option value="lucy-2.1-vton-2">Lucy 2.1 VTON 2 (alias for Lucy VTON 2)</option>
                 </optgroup>
             </select>
         </div>

--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -163,7 +163,13 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
   ? ImageEditingInputs
   : T["name"] extends "lucy-restyle-v2v" | "lucy-restyle-2"
     ? VideoRestyleInputs
-    : T["name"] extends "lucy-2.1" | "lucy-2.1-vton" | "lucy-vton-2" | "lucy-vton" | "lucy-2.1-vton-2" | "lucy-vton-latest"
+    : T["name"] extends
+          | "lucy-2.1"
+          | "lucy-2.1-vton"
+          | "lucy-vton-2"
+          | "lucy-vton"
+          | "lucy-2.1-vton-2"
+          | "lucy-vton-latest"
       ? VideoEdit2Inputs
       : T["name"] extends "lucy-pro-v2v" | "lucy-clip"
         ? VideoEditInputs

--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -163,7 +163,7 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
   ? ImageEditingInputs
   : T["name"] extends "lucy-restyle-v2v" | "lucy-restyle-2"
     ? VideoRestyleInputs
-    : T["name"] extends "lucy-2.1" | "lucy-2.1-vton"
+    : T["name"] extends "lucy-2.1" | "lucy-2.1-vton" | "lucy-vton-2" | "lucy-vton" | "lucy-2.1-vton-2" | "lucy-vton-latest"
       ? VideoEdit2Inputs
       : T["name"] extends "lucy-pro-v2v" | "lucy-clip"
         ? VideoEditInputs

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -7,6 +7,8 @@ import { createModelNotFoundError } from "../utils/errors";
  */
 const MODEL_ALIASES: Record<string, string> = {
   mirage_v2: "lucy-restyle-2",
+  "lucy-vton": "lucy-2.1-vton",
+  "lucy-2.1-vton-2": "lucy-vton-2",
   "lucy-pro-v2v": "lucy-clip",
   "lucy-restyle-v2v": "lucy-restyle-2",
   "lucy-pro-i2i": "lucy-image-2",
@@ -33,6 +35,7 @@ export const realtimeModels = z.union([
   // Canonical names
   z.literal("lucy-2.1"),
   z.literal("lucy-2.1-vton"),
+  z.literal("lucy-vton-2"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -40,12 +43,15 @@ export const realtimeModels = z.union([
   z.literal("lucy-restyle-latest"),
   // Deprecated names (use canonical names above instead)
   z.literal("mirage_v2"),
+  z.literal("lucy-vton"),
+  z.literal("lucy-2.1-vton-2"),
 ]);
 export const videoModels = z.union([
   // Canonical names
   z.literal("lucy-clip"),
   z.literal("lucy-2.1"),
   z.literal("lucy-2.1-vton"),
+  z.literal("lucy-vton-2"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -53,6 +59,8 @@ export const videoModels = z.union([
   z.literal("lucy-restyle-latest"),
   z.literal("lucy-clip-latest"),
   // Deprecated names (use canonical names above instead)
+  z.literal("lucy-vton"),
+  z.literal("lucy-2.1-vton-2"),
   z.literal("lucy-pro-v2v"),
   z.literal("lucy-restyle-v2v"),
 ]);
@@ -185,6 +193,7 @@ export const modelInputSchemas = {
   "lucy-restyle-2": restyleSchema,
   "lucy-2.1": videoEdit2Schema,
   "lucy-2.1-vton": videoEdit2Schema,
+  "lucy-vton-2": videoEdit2Schema,
   // Latest aliases (server-side resolution)
   "lucy-latest": videoEdit2Schema,
   "lucy-vton-latest": videoEdit2Schema,
@@ -192,6 +201,8 @@ export const modelInputSchemas = {
   "lucy-clip-latest": videoEditSchema,
   "lucy-image-latest": imageEditSchema,
   // Deprecated names (kept for backward compatibility)
+  "lucy-vton": videoEdit2Schema,
+  "lucy-2.1-vton-2": videoEdit2Schema,
   "lucy-pro-v2v": videoEditSchema,
   "lucy-pro-i2i": imageEditSchema,
   "lucy-restyle-v2v": restyleSchema,
@@ -261,6 +272,14 @@ const _models = {
       height: 624,
       inputSchema: z.object({}),
     },
+    "lucy-vton-2": {
+      urlPath: "/v1/stream",
+      name: "lucy-vton-2" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: z.object({}),
+    },
     "lucy-restyle-2": {
       urlPath: "/v1/stream",
       name: "lucy-restyle-2" as const,
@@ -278,6 +297,7 @@ const _models = {
       height: 624,
       inputSchema: z.object({}),
     },
+    // Server-side alias currently resolves to lucy-vton-2.
     "lucy-vton-latest": {
       urlPath: "/v1/stream",
       name: "lucy-vton-latest" as const,
@@ -301,6 +321,22 @@ const _models = {
       fps: 22,
       width: 1280,
       height: 704,
+      inputSchema: z.object({}),
+    },
+    "lucy-vton": {
+      urlPath: "/v1/stream",
+      name: "lucy-vton" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: z.object({}),
+    },
+    "lucy-2.1-vton-2": {
+      urlPath: "/v1/stream",
+      name: "lucy-2.1-vton-2" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
       inputSchema: z.object({}),
     },
   },
@@ -365,6 +401,15 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-2.1-vton"],
     },
+    "lucy-vton-2": {
+      urlPath: "/v1/generate/lucy-vton-2",
+      queueUrlPath: "/v1/jobs/lucy-vton-2",
+      name: "lucy-vton-2" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-vton-2"],
+    },
     "lucy-restyle-2": {
       urlPath: "/v1/generate/lucy-restyle-2",
       queueUrlPath: "/v1/jobs/lucy-restyle-2",
@@ -384,6 +429,7 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-latest"],
     },
+    // Server-side alias currently resolves to lucy-vton-2.
     "lucy-vton-latest": {
       urlPath: "/v1/generate/lucy-vton-latest",
       queueUrlPath: "/v1/jobs/lucy-vton-latest",
@@ -412,6 +458,24 @@ const _models = {
       inputSchema: modelInputSchemas["lucy-clip-latest"],
     },
     // Deprecated names (use canonical names above instead)
+    "lucy-vton": {
+      urlPath: "/v1/generate/lucy-vton",
+      queueUrlPath: "/v1/jobs/lucy-vton",
+      name: "lucy-vton" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-vton"],
+    },
+    "lucy-2.1-vton-2": {
+      urlPath: "/v1/generate/lucy-2.1-vton-2",
+      queueUrlPath: "/v1/jobs/lucy-2.1-vton-2",
+      name: "lucy-2.1-vton-2" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-2.1-vton-2"],
+    },
     "lucy-pro-v2v": {
       urlPath: "/v1/generate/lucy-pro-v2v",
       queueUrlPath: "/v1/jobs/lucy-pro-v2v",
@@ -440,6 +504,7 @@ export const models = {
    * Available options:
    *   - `"lucy-2.1"` - Lucy 2.1 realtime video editing
    *   - `"lucy-2.1-vton"` - Lucy 2.1 virtual try-on
+   *   - `"lucy-vton-2"` - Lucy virtual try-on 2
    *   - `"lucy-restyle-2"` - Realtime video restyling
    */
   realtime: <T extends RealTimeModels>(model: T): ModelDefinition<T> => {
@@ -457,6 +522,7 @@ export const models = {
    *   - `"lucy-clip"` - Video-to-video editing
    *   - `"lucy-2.1"` - Long-form video editing (Lucy 2.1)
    *   - `"lucy-2.1-vton"` - Virtual try-on video editing
+   *   - `"lucy-vton-2"` - Virtual try-on 2 video editing
    *   - `"lucy-restyle-2"` - Video restyling
    */
   video: <T extends VideoModels>(model: T): ModelDefinition<T> & { queueUrlPath: string } => {

--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -15,6 +15,7 @@ const REALTIME_MODELS: RealTimeModels[] = [
   "lucy-restyle-2",
   "lucy-2.1",
   "lucy-2.1-vton",
+  "lucy-vton-2",
   "mirage_v2",
 ];
 

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -3286,6 +3286,15 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
+    it("lucy-vton-2 canonical name works", () => {
+      const model = models.realtime("lucy-vton-2");
+      expect(model.name).toBe("lucy-vton-2");
+      expect(model.urlPath).toBe("/v1/stream");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
+    });
+
     it("lucy-restyle-2 canonical name works", () => {
       const model = models.realtime("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -3317,6 +3326,16 @@ describe("Canonical Model Names", () => {
       expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.1-vton");
     });
 
+    it("lucy-vton-2 as video model works", () => {
+      const model = models.video("lucy-vton-2");
+      expect(model.name).toBe("lucy-vton-2");
+      expect(model.urlPath).toBe("/v1/generate/lucy-vton-2");
+      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-vton-2");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
+    });
+
     it("lucy-restyle-2 as video model works", () => {
       const model = models.video("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -3344,7 +3363,7 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-latest works as realtime model", () => {
+    it("lucy-vton-latest works as realtime model and resolves server-side to lucy-vton-2", () => {
       const model = models.realtime("lucy-vton-latest");
       expect(model.name).toBe("lucy-vton-latest");
       expect(model.urlPath).toBe("/v1/stream");
@@ -3372,7 +3391,7 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-latest works as video model", () => {
+    it("lucy-vton-latest works as video model and resolves server-side to lucy-vton-2", () => {
       const model = models.video("lucy-vton-latest");
       expect(model.name).toBe("lucy-vton-latest");
       expect(model.urlPath).toBe("/v1/generate/lucy-vton-latest");
@@ -3449,6 +3468,21 @@ describe("Canonical Model Names", () => {
       expect(isVideoModel("lucy-2.1-vton")).toBe(true);
     });
 
+    it("lucy-vton-2 is both a realtime and video model", () => {
+      expect(isRealtimeModel("lucy-vton-2")).toBe(true);
+      expect(isVideoModel("lucy-vton-2")).toBe(true);
+    });
+
+    it("lucy-vton is a deprecated alias for lucy-2.1-vton on both surfaces", () => {
+      expect(isRealtimeModel("lucy-vton")).toBe(true);
+      expect(isVideoModel("lucy-vton")).toBe(true);
+    });
+
+    it("lucy-2.1-vton-2 is a deprecated alias for lucy-vton-2 on both surfaces", () => {
+      expect(isRealtimeModel("lucy-2.1-vton-2")).toBe(true);
+      expect(isVideoModel("lucy-2.1-vton-2")).toBe(true);
+    });
+
     it("lucy-restyle-2 is both a realtime and video model", () => {
       expect(isRealtimeModel("lucy-restyle-2")).toBe(true);
       expect(isVideoModel("lucy-restyle-2")).toBe(true);
@@ -3459,6 +3493,44 @@ describe("Canonical Model Names", () => {
     it("mirage_v2 still works as realtime model", () => {
       const model = models.realtime("mirage_v2");
       expect(model.name).toBe("mirage_v2");
+    });
+
+    it("lucy-vton still works as realtime and video alias", () => {
+      _resetDeprecationWarnings();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const realtimeModel = models.realtime("lucy-vton");
+      const videoModel = models.video("lucy-vton");
+
+      expect(realtimeModel.name).toBe("lucy-vton");
+      expect(videoModel.name).toBe("lucy-vton");
+      expect(videoModel.urlPath).toBe("/v1/generate/lucy-vton");
+      expect(videoModel.queueUrlPath).toBe("/v1/jobs/lucy-vton");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Model "lucy-vton" is deprecated. Use "lucy-2.1-vton" instead.'),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it("lucy-2.1-vton-2 still works as realtime and video alias", () => {
+      _resetDeprecationWarnings();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const realtimeModel = models.realtime("lucy-2.1-vton-2");
+      const videoModel = models.video("lucy-2.1-vton-2");
+
+      expect(realtimeModel.name).toBe("lucy-2.1-vton-2");
+      expect(videoModel.name).toBe("lucy-2.1-vton-2");
+      expect(videoModel.urlPath).toBe("/v1/generate/lucy-2.1-vton-2");
+      expect(videoModel.queueUrlPath).toBe("/v1/jobs/lucy-2.1-vton-2");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Model "lucy-2.1-vton-2" is deprecated. Use "lucy-vton-2" instead.'),
+      );
+
+      warnSpy.mockRestore();
     });
 
     it("lucy-pro-v2v still works as video model", () => {
@@ -3480,6 +3552,20 @@ describe("Canonical Model Names", () => {
       models.video("lucy-pro-v2v");
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Model "lucy-pro-v2v" is deprecated. Use "lucy-clip" instead.'),
+      );
+
+      warnSpy.mockClear();
+      _resetDeprecationWarnings();
+      models.realtime("lucy-vton");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Model "lucy-vton" is deprecated. Use "lucy-2.1-vton" instead.'),
+      );
+
+      warnSpy.mockClear();
+      _resetDeprecationWarnings();
+      models.video("lucy-2.1-vton-2");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Model "lucy-2.1-vton-2" is deprecated. Use "lucy-vton-2" instead.'),
       );
 
       warnSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Add `lucy-vton-2` as a new canonical SDK model name on both realtime and video surfaces (new bouncer route `/v1/jobs/lucy-vton-2`).
- Add `lucy-vton` and `lucy-2.1-vton-2` as deprecated aliases — `lucy-vton` → `lucy-2.1-vton`, `lucy-2.1-vton-2` → `lucy-vton-2`. Aliases emit a one-time `console.warn`.
- `lucy-vton-latest` is unchanged in the SDK; the server now resolves it to `lucy-vton-2` (updated inline comment to reflect this).
- Update unit + e2e tests (deprecation warnings, type-guards), demo `index.html`, AGENTS.md, README examples, and add `examples/sdk-core/realtime/lucy-vton-2.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the SDK's public model identifier surface (including deprecated alias resolution), which could impact integrations that rely on exact model IDs despite backward-compat support.
>
> **Overview**
> Adds support for the new VTON model id `lucy-vton-2` across realtime and video surfaces, wiring it into the model registry, input schema mapping, type guards, and model-specific Process API typings.
>
> Introduces deprecated alias mappings `lucy-vton` → `lucy-2.1-vton` and `lucy-2.1-vton-2` → `lucy-vton-2` with one-time deprecation warnings, and updates demos/docs/examples plus unit/e2e coverage to include the new model and alias behavior.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c534384e7e638eae4bc5630a78ca2deb17b93c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
