### PR TITLE
fix(realtime): propagate observability telemetry options

### DIFF
--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -252,12 +252,13 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
 
     let webrtcManager: WebRTCManager | undefined;
     const observability = new RealtimeObservability({
-      telemetryEnabled: false,
+      telemetryEnabled: opts.telemetryEnabled,
       apiKey,
       integration,
       logger,
       onDiagnostic: (event) => emitOrBuffer("diagnostic", event as SubscribeEvents["diagnostic"]),
     });
+    observability.sessionStarted(sid);
 
     try {
       webrtcManager = new WebRTCManager({

--- a/packages/sdk/src/realtime/observability/webrtc-stats.ts
+++ b/packages/sdk/src/realtime/observability/webrtc-stats.ts
@@ -50,7 +50,7 @@ export type WebRTCStats = {
      * Std-dev of inter-frame delay (ms), computed from
      * totalInterFrameDelay + totalSquaredInterFrameDelay.
      */
-    interFrameDelayVarianceMs: number | null;
+    interFrameDelayStdDevMs: number | null;
     /** Current target delay of the jitter buffer (ms). */
     jitterBufferTargetDelayMs: number | null;
     /** Current minimum delay of the jitter buffer (ms). */
@@ -283,10 +283,10 @@ export class WebRTCStatsCollector {
         const avgDecodeTimeMs = framesDecoded > 0 ? (totalDecodeTime / framesDecoded) * 1000 : null;
         const avgProcessingDelayMs = framesDecoded > 0 ? (totalProcessingDelay / framesDecoded) * 1000 : null;
         const avgInterFrameDelayMs = framesDecoded > 0 ? (totalInterFrameDelay / framesDecoded) * 1000 : null;
-        // Variance σ² = E[X²] - E[X]² ; std-dev = sqrt(σ²). Report std-dev
+        // Variance σ² = E[X²] - E[X]²; std-dev = sqrt(σ²). Report std-dev
         // in ms — more actionable than variance for a threshold-based
         // "is the path jittery" check.
-        const interFrameDelayVarianceMs =
+        const interFrameDelayStdDevMs =
           framesDecoded > 0
             ? Math.sqrt(
                 Math.max(0, totalSquaredInterFrameDelay / framesDecoded - (totalInterFrameDelay / framesDecoded) ** 2),
@@ -323,7 +323,7 @@ export class WebRTCStatsCollector {
           avgJitterBufferMs,
           avgProcessingDelayMs,
           avgInterFrameDelayMs,
-          interFrameDelayVarianceMs,
+          interFrameDelayStdDevMs,
           jitterBufferTargetDelayMs,
           jitterBufferMinimumDelayMs,
           decoderImplementation: (r.decoderImplementation as string) ?? "",

--- a/packages/sdk/src/realtime/webrtc-connection.ts
+++ b/packages/sdk/src/realtime/webrtc-connection.ts
@@ -3,7 +3,7 @@ import mitt from "mitt";
 import type { Logger } from "../utils/logger";
 import { buildUserAgent } from "../utils/user-agent";
 import type { IceCandidateEvent } from "./observability/diagnostics";
-import { RealtimeObservability } from "./observability/realtime-observability";
+import type { RealtimeObservability } from "./observability/realtime-observability";
 import type {
   ConnectionState,
   GenerationTickMessage,
@@ -27,7 +27,7 @@ interface ConnectionCallbacks {
   initialImage?: string;
   initialPrompt?: { text: string; enhance?: boolean };
   logger?: Logger;
-  observability?: RealtimeObservability;
+  observability: RealtimeObservability;
 }
 
 type WsMessageEvents = {
@@ -46,15 +46,9 @@ export class WebRTCConnection {
   private observability: RealtimeObservability;
   state: ConnectionState = "disconnected";
   websocketMessagesEmitter = mitt<WsMessageEvents>();
-  constructor(private callbacks: ConnectionCallbacks = {}) {
+  constructor(private callbacks: ConnectionCallbacks) {
     this.logger = callbacks.logger ?? { debug() {}, info() {}, warn() {}, error() {} };
-    this.observability =
-      callbacks.observability ??
-      new RealtimeObservability({
-        telemetryEnabled: false,
-        apiKey: "",
-        logger: this.logger,
-      });
+    this.observability = callbacks.observability;
   }
 
   getPeerConnection(): RTCPeerConnection | null {

--- a/packages/sdk/src/realtime/webrtc-manager.ts
+++ b/packages/sdk/src/realtime/webrtc-manager.ts
@@ -1,7 +1,7 @@
 import pRetry, { AbortError } from "p-retry";
 
 import type { Logger } from "../utils/logger";
-import { RealtimeObservability } from "./observability/realtime-observability";
+import type { RealtimeObservability } from "./observability/realtime-observability";
 import type { ConnectionState, OutgoingMessage } from "./types";
 import { WebRTCConnection } from "./webrtc-connection";
 
@@ -9,7 +9,7 @@ export interface WebRTCConfig {
   webrtcUrl: string;
   integration?: string;
   logger?: Logger;
-  observability?: RealtimeObservability;
+  observability: RealtimeObservability;
   onRemoteStream: (stream: MediaStream) => void;
   onConnectionStateChange?: (state: ConnectionState) => void;
   onError?: (error: Error) => void;
@@ -55,13 +55,7 @@ export class WebRTCManager {
   constructor(config: WebRTCConfig) {
     this.config = config;
     this.logger = config.logger ?? { debug() {}, info() {}, warn() {}, error() {} };
-    this.observability =
-      config.observability ??
-      new RealtimeObservability({
-        telemetryEnabled: false,
-        apiKey: "",
-        logger: this.logger,
-      });
+    this.observability = config.observability;
     this.connection = new WebRTCConnection({
       onRemoteStream: config.onRemoteStream,
       onStateChange: (state) => this.handleConnectionStateChange(state),

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2,11 +2,20 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDecartClient, isRealtimeModel, isVideoModel, models } from "../src/index.js";
+import { RealtimeObservability } from "../src/realtime/observability/realtime-observability.js";
 import { _resetDeprecationWarnings } from "../src/shared/model.js";
 
 const MOCK_RESPONSE_DATA = new Uint8Array([0x00, 0x01, 0x02]).buffer;
 const TEST_API_KEY = "test-api-key";
 const BASE_URL = "http://localhost";
+
+const TEST_LOGGER = { debug() {}, info() {}, warn() {}, error() {} };
+const createTestObservability = () =>
+  new RealtimeObservability({
+    telemetryEnabled: false,
+    apiKey: TEST_API_KEY,
+    logger: TEST_LOGGER,
+  });
 
 describe("Decart SDK", () => {
   describe("createDecartClient", () => {
@@ -1138,14 +1147,14 @@ describe("WebRTCConnection", () => {
   describe("setImageBase64", () => {
     it("rejects immediately when WebSocket is not open", async () => {
       const { WebRTCConnection } = await import("../src/realtime/webrtc-connection.js");
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
 
       await expect(connection.setImageBase64("base64data", { timeout: 5000 })).rejects.toThrow("WebSocket is not open");
     });
 
     it("rejects immediately with default timeout when WebSocket is not open", async () => {
       const { WebRTCConnection } = await import("../src/realtime/webrtc-connection.js");
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
 
       await expect(connection.setImageBase64("base64data")).rejects.toThrow("WebSocket is not open");
     });
@@ -1161,7 +1170,7 @@ describe("WebRTCConnection", () => {
 
       it("uses custom timeout when send succeeds but ack is not received", async () => {
         const { WebRTCConnection } = await import("../src/realtime/webrtc-connection.js");
-        const connection = new WebRTCConnection();
+        const connection = new WebRTCConnection({ observability: createTestObservability() });
         const sendSpy = vi.spyOn(connection, "send").mockReturnValue(true);
 
         const customTimeout = 5000;
@@ -1186,7 +1195,7 @@ describe("WebRTCConnection", () => {
 
       it("uses default timeout (30000ms) when send succeeds but ack is not received", async () => {
         const { WebRTCConnection } = await import("../src/realtime/webrtc-connection.js");
-        const connection = new WebRTCConnection();
+        const connection = new WebRTCConnection({ observability: createTestObservability() });
         const sendSpy = vi.spyOn(connection, "send").mockReturnValue(true);
 
         let rejected = false;
@@ -1213,7 +1222,7 @@ describe("WebRTCConnection", () => {
       vi.useFakeTimers();
       try {
         const { WebRTCConnection } = await import("../src/realtime/webrtc-connection.js");
-        const connection = new WebRTCConnection();
+        const connection = new WebRTCConnection({ observability: createTestObservability() });
         const sendSpy = vi.spyOn(connection, "send").mockReturnValue(true);
 
         const promise = connection.setImageBase64(null, { prompt: null }).catch(() => {});
@@ -1271,7 +1280,7 @@ describe("WebRTCConnection", () => {
       vi.stubGlobal("RTCPeerConnection", FakePeerConnection as unknown as typeof RTCPeerConnection);
 
       try {
-        const connection = new WebRTCConnection();
+        const connection = new WebRTCConnection({ observability: createTestObservability() });
         const internalConnection = connection as unknown as {
           handleSignalingMessage: (msg: unknown) => Promise<void>;
           localStream: { getTracks: () => MediaStreamTrack[] };
@@ -1504,7 +1513,7 @@ describe("Subscribe Client", () => {
     vi.stubGlobal("RTCPeerConnection", FakePeerConnection as unknown as typeof RTCPeerConnection);
 
     try {
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
       const internal = connection as unknown as {
         handleSignalingMessage: (msg: unknown) => Promise<void>;
         localStream: MediaStream | null;
@@ -1530,6 +1539,7 @@ describe("Subscribe Client", () => {
 
     const manager = new WebRTCManager({
       webrtcUrl: "wss://example.com",
+      observability: createTestObservability(),
       onRemoteStream: vi.fn(),
       onError: vi.fn(),
     });
@@ -2731,7 +2741,7 @@ describe("WebSockets Connection", () => {
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
 
     try {
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
       const internal = connection as unknown as {
         setState: (state: import("../src/realtime/types").ConnectionState) => void;
         setupNewPeerConnection: () => Promise<void>;
@@ -2785,7 +2795,7 @@ describe("WebSockets Connection", () => {
     vi.stubGlobal("WebSocket", FakeWebSocket as unknown as typeof WebSocket);
 
     try {
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
       const internal = connection as unknown as {
         setState: (state: import("../src/realtime/types").ConnectionState) => void;
         setupNewPeerConnection: () => Promise<void>;
@@ -2838,7 +2848,7 @@ describe("WebSockets Connection", () => {
     vi.stubGlobal("RTCPeerConnection", FakePeerConnection as unknown as typeof RTCPeerConnection);
 
     try {
-      const connection = new WebRTCConnection();
+      const connection = new WebRTCConnection({ observability: createTestObservability() });
       const internal = connection as unknown as {
         handleSignalingMessage: (msg: unknown) => Promise<void>;
         localStream: { getTracks: () => MediaStreamTrack[] };
@@ -2868,6 +2878,7 @@ describe("WebSockets Connection", () => {
     const { WebRTCManager } = await import("../src/realtime/webrtc-manager.js");
     const manager = new WebRTCManager({
       webrtcUrl: "wss://example.com",
+      observability: createTestObservability(),
       onRemoteStream: vi.fn(),
       onError: vi.fn(),
     });


### PR DESCRIPTION
## Summary
- Propagate the SDK `telemetryEnabled` option through the realtime subscribe path instead of forcing telemetry off.
- Require injected `RealtimeObservability` in `WebRTCManager` / `WebRTCConnection`, removing the hard-coded disabled observability fallback with an empty API key.
- Rename inter-frame delay `Variance` stat to `StdDev` to match the actual computation.

## Checks
- `pnpm --filter @decartai/sdk typecheck`
- `pnpm --filter @decartai/sdk format:check` (passes with existing warnings/info)
- `pnpm --filter @decartai/sdk test -- --run`
- `pnpm --filter @decartai/sdk build` (passes; existing tsdown warning about `define` option)
- Independent Claude Code review of diff vs `origin/alon/livekit-pr1-observability`

Base for DecartAI/sdk#132.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime telemetry behavior (subscribe path now honors `telemetryEnabled`) and makes `WebRTCManager`/`WebRTCConnection` require an injected `RealtimeObservability`, which can be a breaking change for any consumers constructing these classes directly. Renaming a `WebRTCStats` field also risks downstream type/runtime expectations.
> 
> **Overview**
> Realtime subscribe sessions now honor the SDK’s `telemetryEnabled` option and immediately call `observability.sessionStarted(sid)` so telemetry/diagnostics are associated with the session.
> 
> `WebRTCManager` and `WebRTCConnection` no longer create an internal fallback `RealtimeObservability` (previously hard-coded telemetry off with an empty API key); callers must pass `observability` explicitly, and unit tests are updated accordingly.
> 
> In `WebRTCStats`, the inter-frame delay metric is renamed from `interFrameDelayVarianceMs` to `interFrameDelayStdDevMs` to match the actual std-dev calculation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16388f0bc749fb1c8c8bbeea2077d96797e7f7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->