### PR TITLE
fix(realtime): wait for initial ack before LiveKit publish

### DIFF
--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -2,9 +2,7 @@ import {
   type RemoteParticipant,
   type RemoteTrack,
   Room,
-  type RoomConnectOptions,
   RoomEvent,
-  type RoomOptions,
   Track,
   TrackEvent,
   type TrackPublishOptions,
@@ -22,26 +20,10 @@ const DEFAULT_VIDEO_CODEC = "h264" as const;
 const DEFAULT_MAX_VIDEO_BITRATE_BPS = 3_000_000;
 const DEFAULT_PUBLISH_FPS = 20;
 
-export const LIVEKIT_ROOM_OPTIONS: RoomOptions = {
+export const LIVEKIT_ROOM_OPTIONS = {
   adaptiveStream: false,
   dynacast: false,
-  singlePeerConnection: true,
-  publishDefaults: {
-    simulcast: false,
-    degradationPreference: "maintain-framerate",
-  },
-};
-
-export const LIVEKIT_CONNECT_OPTIONS: RoomConnectOptions = {
-  peerConnectionTimeout: 8_000,
-  websocketTimeout: 8_000,
-  maxRetries: 1,
-  rtcConfig: {
-    iceCandidatePoolSize: 4,
-    bundlePolicy: "max-bundle",
-    rtcpMuxPolicy: "require",
-  },
-};
+} as const;
 
 export function getDefaultVideoPublishOptions(model: PublishModel): TrackPublishOptions {
   const videoEncoding = {
@@ -49,7 +31,7 @@ export function getDefaultVideoPublishOptions(model: PublishModel): TrackPublish
     maxFramerate: model.fps,
   };
 
-  return { source: Track.Source.Camera, videoCodec: DEFAULT_VIDEO_CODEC, videoEncoding };
+  return { source: Track.Source.Camera, videoCodec: DEFAULT_VIDEO_CODEC, simulcast: true, videoEncoding };
 }
 
 export type MediaChannelEvents = {
@@ -114,7 +96,7 @@ export class MediaChannel {
       this.events.emit("disconnected");
     });
 
-    await room.connect(opts.url, opts.token, LIVEKIT_CONNECT_OPTIONS);
+    await room.connect(opts.url, opts.token);
     this.config.observability?.setLiveKitRoom(room);
 
     if (this.config.localStream) {

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -59,11 +59,7 @@ export class SignalingChannel {
   }
 
   async connect(
-    opts: {
-      connectTimeout?: number;
-      handshakeTimeout?: number;
-      initialState?: InitialState;
-    } = {},
+    opts: { connectTimeout?: number; handshakeTimeout?: number; initialState?: InitialState } = {},
   ): Promise<void> {
     const connectTimeout = opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT_MS;
     const handshakeTimeout = opts.handshakeTimeout ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
@@ -115,17 +111,6 @@ export class SignalingChannel {
     if (!ack.success) throw new Error(ack.error ?? "Failed to send image");
   }
 
-  sendPromptNoWait(text: string, opts: { enhance?: boolean } = {}): void {
-    this.writeMessage({ type: "prompt", prompt: text, enhance_prompt: opts.enhance ?? true });
-  }
-
-  setImageNoWait(image: string | null, opts: { prompt?: string | null; enhance?: boolean } = {}): void {
-    const message: OutgoingRealtimeMessage = { type: "set_image", image_data: image };
-    if (opts.prompt !== undefined) message.prompt = opts.prompt;
-    if (opts.enhance !== undefined) message.enhance_prompt = opts.enhance;
-    this.writeMessage(message);
-  }
-
   private async openSocket(timeout: number): Promise<void> {
     const userAgent = encodeURIComponent(buildUserAgent(this.config.integration));
     const separator = this.config.url.includes("?") ? "&" : "?";
@@ -165,35 +150,52 @@ export class SignalingChannel {
   }
 
   private async runHandshake(timeoutMs: number, initialState?: InitialState): Promise<void> {
-    this.writeMessage({ type: "livekit_join" });
+    const roomInfoWait = this.waitForRoomInfo(timeoutMs);
 
-    if (initialState?.image) {
-      this.setImageNoWait(initialState.image, {
-        prompt: initialState.prompt,
-        enhance: initialState.enhance,
-      });
-    } else if (initialState?.prompt) {
-      this.sendPromptNoWait(initialState.prompt, { enhance: initialState.enhance });
+    try {
+      if (!this.writeMessage({ type: "livekit_join" })) {
+        throw new Error("WebSocket is not open");
+      }
+
+      await Promise.all([roomInfoWait.promise, this.sendInitialState(initialState)]);
+    } catch (error) {
+      roomInfoWait.cancel();
+      this.rejectAllPending(error instanceof Error ? error : new Error(String(error)));
+      throw error;
     }
+  }
 
-
-    return new Promise<void>((resolve, reject) => {
+  private waitForRoomInfo(timeoutMs: number): { promise: Promise<void>; cancel: () => void } {
+    let cleanup: () => void = () => {};
+    const promise = new Promise<void>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
         cleanup();
         reject(new Error(`livekit_room_info timeout (${timeoutMs}ms)`));
       }, timeoutMs);
 
-      const onRoomInfo = () => { cleanup(); resolve(); };
-      const onQueue = () => {
-        if (timer) { clearTimeout(timer); timer = null; }
+      const onRoomInfo = () => {
+        cleanup();
+        resolve();
       };
-      const onServerError = (err: Error) => { cleanup(); reject(err); };
+      const onQueue = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      };
+      const onServerError = (err: Error) => {
+        cleanup();
+        reject(err);
+      };
       const onClosed = (e: { code: number; reason: string }) => {
         cleanup();
         reject(new Error(`WebSocket closed: ${e.code} ${e.reason}`));
       };
-      const cleanup = () => {
-        if (timer) { clearTimeout(timer); timer = null; }
+      cleanup = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
         this.events.off("roomInfo", onRoomInfo);
         this.events.off("queuePosition", onQueue);
         this.events.off("serverError", onServerError);
@@ -205,6 +207,24 @@ export class SignalingChannel {
       this.events.on("serverError", onServerError);
       this.events.on("closed", onClosed);
     });
+
+    return { promise, cancel: cleanup };
+  }
+
+  private async sendInitialState(initialState?: InitialState): Promise<void> {
+    if (!initialState) return;
+
+    if (initialState.image !== undefined) {
+      await this.setImage(initialState.image, {
+        prompt: initialState.prompt,
+        enhance: initialState.enhance,
+      });
+      return;
+    }
+
+    if (initialState.prompt !== undefined && initialState.prompt !== null) {
+      await this.sendPrompt(initialState.prompt, { enhance: initialState.enhance });
+    }
   }
 
   private async request<TAck extends IncomingRealtimeMessage>(

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -2,10 +2,10 @@ import mitt, { type Emitter } from "mitt";
 import pRetry, { AbortError } from "p-retry";
 
 import type { ModelDefinition } from "../shared/model";
-import { SignalingChannel, type RoomInfo } from "./signaling-channel";
 import { MediaChannel } from "./media-channel";
 import type { RealtimeObservability } from "./observability/realtime-observability";
-import type { ConnectionState, QueuePosition } from "./types";
+import { type RoomInfo, SignalingChannel } from "./signaling-channel";
+import type { ConnectionState, InitialState, QueuePosition } from "./types";
 
 const PERMANENT_ERRORS = [
   "permission denied",
@@ -146,11 +146,7 @@ export class StreamSession {
     this.resetHandshakeState();
     await this.signaling.connect({
       connectTimeout: CONNECTION_TIMEOUT_MS,
-      initialState: {
-        image: this.config.initialImage,
-        prompt: this.config.initialPrompt?.text,
-        enhance: this.config.initialPrompt?.enhance,
-      },
+      initialState: this.getInitialState(),
     });
 
     if (!this.roomInfo) {
@@ -174,7 +170,28 @@ export class StreamSession {
     this.setState("connected");
   }
 
- 
+  private getInitialState(): InitialState | undefined {
+    if (this.config.initialImage !== undefined) {
+      return {
+        image: this.config.initialImage,
+        prompt: this.config.initialPrompt?.text,
+        enhance: this.config.initialPrompt?.enhance,
+      };
+    }
+
+    if (this.config.initialPrompt) {
+      return {
+        prompt: this.config.initialPrompt.text,
+        enhance: this.config.initialPrompt.enhance,
+      };
+    }
+
+    if (this.config.localStream) {
+      return { image: null, prompt: null };
+    }
+
+    return undefined;
+  }
 
   private wireSignalingEvents(): void {
     this.signaling.on("roomInfo", (info) => {

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -66,8 +66,8 @@ export type QueuePosition = {
 export type ConnectionState = "connecting" | "connected" | "generating" | "disconnected" | "reconnecting";
 
 export type InitialState = {
-  image?: string;
-  prompt?: string;
+  image?: string | null;
+  prompt?: string | null;
   enhance?: boolean;
 };
 

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models } from "../src/index.js";
 
 describe("Lucy 2.1 realtime", () => {
@@ -175,6 +175,116 @@ describe("Subscribe Token", () => {
     const { decodeSubscribeToken } = await import("../src/realtime/subscribe-client.js");
     const token = btoa(JSON.stringify({ sid: "s" }));
     expect(() => decodeSubscribeToken(token)).toThrow("Invalid subscribe token");
+  });
+});
+
+describe("SignalingChannel initial handshake", () => {
+  class FakeWebSocket {
+    static OPEN = 1;
+
+    static instances: FakeWebSocket[] = [];
+
+    readyState = FakeWebSocket.OPEN;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onclose: ((event: { code: number; reason: string }) => void) | null = null;
+    sentMessages: unknown[] = [];
+
+    constructor(readonly url: string) {
+      FakeWebSocket.instances.push(this);
+    }
+
+    send(data: string): void {
+      this.sentMessages.push(JSON.parse(data));
+    }
+
+    close(): void {
+      this.onclose?.({ code: 1000, reason: "closed" });
+    }
+
+    receive(message: unknown): void {
+      this.onmessage?.({ data: JSON.stringify(message) });
+    }
+  }
+
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("waits for the initial set_image ack before resolving the handshake", async () => {
+    const { SignalingChannel } = await import("../src/realtime/signaling-channel.js");
+    const channel = new SignalingChannel({ url: "wss://example.test/realtime" });
+
+    const connectPromise = channel.connect({
+      initialState: { image: "base64-image", prompt: "wear a hat", enhance: false },
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ws.sentMessages).toEqual([
+      { type: "livekit_join" },
+      { type: "set_image", image_data: "base64-image", prompt: "wear a hat", enhance_prompt: false },
+    ]);
+
+    let resolved = false;
+    connectPromise.then(() => {
+      resolved = true;
+    });
+
+    ws.receive({
+      type: "livekit_room_info",
+      livekit_url: "wss://livekit.example.test",
+      token: "token",
+      room_name: "room",
+      session_id: "session",
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    ws.receive({ type: "set_image_ack", success: true, error: null });
+    await expect(connectPromise).resolves.toBeUndefined();
+    expect(resolved).toBe(true);
+  });
+
+  it("waits for the initial null set_image ack before resolving the handshake", async () => {
+    const { SignalingChannel } = await import("../src/realtime/signaling-channel.js");
+    const channel = new SignalingChannel({ url: "wss://example.test/realtime" });
+
+    const connectPromise = channel.connect({
+      initialState: { image: null, prompt: null },
+    });
+
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(ws.sentMessages).toEqual([{ type: "livekit_join" }, { type: "set_image", image_data: null, prompt: null }]);
+
+    let resolved = false;
+    connectPromise.then(() => {
+      resolved = true;
+    });
+
+    ws.receive({
+      type: "livekit_room_info",
+      livekit_url: "wss://livekit.example.test",
+      token: "token",
+      room_name: "room",
+      session_id: "session",
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    ws.receive({ type: "set_image_ack", success: true, error: null });
+    await expect(connectPromise).resolves.toBeUndefined();
+    expect(resolved).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Re-enable LiveKit video simulcast by setting `simulcast: true` in the default publish options.
- Revert the other experimental LiveKit connection/room config changes from `alon/livekit-prod` (`singlePeerConnection`, publish defaults, custom connect options, RTC config overrides).
- Keep the latest join + initial image/prompt handshake behavior, but make the handshake wait for the initial `set_image` / `prompt` ack before connecting LiveKit media and publishing frames.
- Add unit coverage that verifies the handshake does not resolve on `livekit_room_info` alone and waits for `set_image_ack`, including the null-image/local-stream initial state path.

## Testing
- `pnpm exec vitest run tests/realtime.unit.test.ts -t 'SignalingChannel initial handshake' --reporter=verbose`
- `pnpm typecheck`
- `pnpm format:check` (passes with existing `noConfusingVoidType` warnings in `MediaChannelEvents`)
- `pnpm lint` (passes with same existing warnings)
- `pnpm build` (passes with existing tsdown warnings)
- `pnpm test` currently fails on target-branch issues unrelated to this change: realtime observability telemetry fetch mocks not called, and `lucy-2.1` / `lucy-2.1-vton` tests expecting fps `20` while the target branch model definitions return `18`. The new handshake tests pass.

Requested in DM with Alon Bar-El.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime handshake ordering and LiveKit publish settings; issues could manifest as delayed connects or missed/duplicated initial state if edge cases aren’t covered.
> 
> **Overview**
> Realtime connection flow now **waits for the initial `set_image`/`prompt` ack** (in addition to `livekit_room_info`) before considering the signaling handshake complete, including explicit handling for `null` initial image/prompt and improved cleanup/error rejection on handshake failure.
> 
> LiveKit configuration is simplified by removing custom `RoomConnectOptions`/experimental room settings, and default video publishing re-enables **`simulcast: true`**. Unit tests add coverage that `SignalingChannel.connect()` does not resolve on `livekit_room_info` alone and only completes after `set_image_ack`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af50fb453fc141ee894031ad7576e27f8c0b95c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->