### PR TITLE
feat(realtime): force VP8 on desktop Safari

### DIFF
--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -4,6 +4,7 @@ import { modelStateSchema } from "../shared/types";
 import { classifyWebrtcError, type DecartSDKError } from "../utils/errors";
 import { createConsoleLogger, type Logger } from "../utils/logger";
 import { imageToBase64 } from "../utils/media";
+import { isDesktopSafari } from "../utils/platform";
 import { createEventBuffer } from "./event-buffer";
 import { realtimeMethods, type SetInput } from "./methods";
 import { createMirroredStream, type MirroredStream, shouldMirrorTrack } from "./mirror-stream";
@@ -128,7 +129,10 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         onStats: (stats) => emitOrBuffer("stats", stats),
       });
 
+      const safariCodec = isDesktopSafari() ? "vp8" : undefined;
+
       const queryParams = new URLSearchParams({
+        ...(safariCodec ? { livekit_server_codec: safariCodec } : {}),
         ...(options.queryParams ?? {}),
         api_key: apiKey,
         model: options.model.name,
@@ -142,6 +146,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         initialImage,
         initialPrompt,
         logger,
+        videoCodec: safariCodec,
       });
 
       let sessionId: string | null = null;

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -14,7 +14,9 @@ import { createConsoleLogger, type Logger } from "../utils/logger";
 import { REALTIME_CONFIG } from "./config-realtime";
 import type { RealtimeObservability } from "./observability/realtime-observability";
 
-export function getDefaultVideoPublishOptions(): TrackPublishOptions {
+export type VideoCodec = "h264" | "vp8" | "vp9" | "av1";
+
+export function getDefaultVideoPublishOptions(videoCodec?: VideoCodec): TrackPublishOptions {
   const videoEncoding = {
     maxBitrate: REALTIME_CONFIG.livekit.defaultMaxVideoBitrateBps,
     maxFramerate: REALTIME_CONFIG.livekit.defaultPublishFps,
@@ -22,7 +24,7 @@ export function getDefaultVideoPublishOptions(): TrackPublishOptions {
 
   return {
     source: Track.Source.Camera,
-    videoCodec: REALTIME_CONFIG.livekit.defaultVideoCodec,
+    videoCodec: videoCodec ?? REALTIME_CONFIG.livekit.defaultVideoCodec,
     simulcast: true,
     videoEncoding,
   };
@@ -38,6 +40,7 @@ export interface MediaChannelConfig {
   observability?: RealtimeObservability;
   localStream: MediaStream | null;
   logger?: Logger;
+  videoCodec?: VideoCodec;
 }
 
 export type MediaConnectOptions = {
@@ -115,7 +118,7 @@ export class MediaChannel {
     if (!this.room) return;
     for (const track of stream.getTracks()) {
       if (track.kind === "video") {
-        await this.room.localParticipant.publishTrack(track, getDefaultVideoPublishOptions());
+        await this.room.localParticipant.publishTrack(track, getDefaultVideoPublishOptions(this.config.videoCodec));
       } else {
         await this.room.localParticipant.publishTrack(track);
       }

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -3,7 +3,7 @@ import pRetry, { AbortError } from "p-retry";
 
 import { createConsoleLogger, type Logger } from "../utils/logger";
 import { REALTIME_CONFIG } from "./config-realtime";
-import { MediaChannel } from "./media-channel";
+import { MediaChannel, type VideoCodec } from "./media-channel";
 import type { RealtimeObservability } from "./observability/realtime-observability";
 import { RemoteStreamExposure } from "./remote-stream-exposure";
 import { SignalingChannel } from "./signaling-channel";
@@ -49,6 +49,7 @@ interface StreamSessionConfig {
   initialImage?: string;
   initialPrompt?: InitialPrompt;
   logger?: Logger;
+  videoCodec?: VideoCodec;
 }
 
 export class StreamSession {
@@ -287,6 +288,7 @@ export class StreamSession {
       observability: this.config.observability,
       localStream: this.config.localStream,
       logger: this.logger,
+      videoCodec: this.config.videoCodec,
     });
     this.wireSignalingEvents();
     this.wireMediaEvents();

--- a/packages/sdk/src/utils/platform.ts
+++ b/packages/sdk/src/utils/platform.ts
@@ -7,3 +7,18 @@ export function detectPlatform(): Platform {
   if (/iPhone|iPad|iPod|Android|Mobi/i.test(ua)) return "mobile";
   return "desktop";
 }
+
+export function isDesktopSafari(): boolean {
+  // biome-ignore lint/suspicious/noExplicitAny: runtime detection
+  const g = globalThis as any;
+  const ua: string = g?.navigator?.userAgent ?? "";
+  const platform: string = g?.navigator?.platform ?? "";
+  const maxTouchPoints: number = g?.navigator?.maxTouchPoints ?? 0;
+
+  if (!/^((?!chrome|chromium|crios|fxios|edg|firefox|opr|opera|android).)*safari/i.test(ua)) {
+    return false;
+  }
+  if (/iPad|iPhone|iPod/.test(ua)) return false;
+  if (platform === "MacIntel" && maxTouchPoints > 1) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

- Desktop Safari has interop issues with the SDK's default H.264; on desktop Safari, switch the video pipeline to VP8 in both directions.
- Adds an `isDesktopSafari()` UA helper that excludes iOS / iPadOS desktop-mode (`MacIntel` + `maxTouchPoints > 1`) and non-Safari engines (Chrome / Chromium / Edge / Firefox / Opera / Android).
- Publish leg: `videoCodec` threads through `StreamSession` → `MediaChannel` so `getDefaultVideoPublishOptions()` returns `videoCodec: "vp8"` when Safari is detected.
- Server-encode leg: prepends `livekit_server_codec=vp8` to the WS query string. The bouncer already accepts this query param (`bouncer/src/realtime/stream.py:491`) and forwards it to the inference server (`inference_server/base_rt_server.py:245` → `rt/livekit/conn.py`).
- Caller-supplied `queryParams.livekit_server_codec` still wins (spread order preserves the escape hatch).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — all 183 unit tests pass
- [x] `pnpm build` succeeds
- [ ] Manual desktop Safari: WS URL contains `livekit_server_codec=vp8`; `getStats()` shows VP8 on both inbound + outbound video tracks
- [ ] Manual iOS Safari / iPadOS regression: WS URL has no `livekit_server_codec`; tracks remain H.264 (unchanged)
- [ ] Manual Chrome regression: WS URL has no `livekit_server_codec`; tracks remain H.264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC codec negotiation and server-side codec selection for a specific browser, which can affect realtime media connectivity and video quality if detection or codec support is wrong.
> 
> **Overview**
> For **desktop Safari only**, the realtime SDK now forces VP8 end-to-end to avoid H.264 interop issues.
> 
> It adds an `isDesktopSafari()` platform helper and, when detected, (1) appends `livekit_server_codec=vp8` to the session URL query and (2) threads a `videoCodec` override through `StreamSession` → `MediaChannel` so LiveKit publishes local video with VP8 instead of the default (`h264`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bafa97d753b600f664fbbc4085fe602f02c5dfc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->