### PR TITLE
feat(realtime): cap capture FPS at 30 via ideal/max constraint

### DIFF
--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { type CustomModelDefinition, type ModelDefinition, modelDefinitionSchema } from "../shared/model";
+import {
+  type CustomModelDefinition,
+  type ModelDefinition,
+  modelDefinitionSchema,
+  resolveFpsNumber,
+} from "../shared/model";
 import { modelStateSchema } from "../shared/types";
 import { classifyWebrtcError, type DecartSDKError } from "../utils/errors";
 import type { Logger } from "../utils/logger";
@@ -153,7 +158,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       try {
         const firstVideoTrack = inputStream.getVideoTracks?.()[0];
         if (firstVideoTrack && (mirror === true || shouldMirrorTrack(firstVideoTrack))) {
-          mirroredStream = createMirroredStream(inputStream, { fps: options.model.fps });
+          mirroredStream = createMirroredStream(inputStream, { fps: resolveFpsNumber(options.model.fps) });
           inputStream = mirroredStream.stream;
         } else if (mirror === true && !firstVideoTrack) {
           logger.warn("mirror: true requested but no video track was found on the input stream");

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -273,15 +273,22 @@ export const modelInputSchemas = {
 
 export type ModelInputSchemas = typeof modelInputSchemas;
 
+export type ModelFps = number | { max?: number; min?: number; ideal?: number; exact?: number };
+
 export type ModelDefinition<T extends Model = Model> = {
   name: T;
   urlPath: string;
   queueUrlPath?: string;
-  fps: number;
+  fps: ModelFps;
   width: number;
   height: number;
   inputSchema: T extends keyof ModelInputSchemas ? ModelInputSchemas[T] : z.ZodTypeAny;
 };
+
+export function resolveFpsNumber(fps: ModelFps, fallback = 30): number {
+  if (typeof fps === "number") return fps;
+  return fps.ideal ?? fps.max ?? fps.exact ?? fps.min ?? fallback;
+}
 
 /**
  * A model definition with an arbitrary (non-registry) model name.
@@ -297,20 +304,28 @@ export type CustomModelDefinition = Omit<ModelDefinition, "name" | "inputSchema"
  * Only image models support the sync/process API.
  * Requires `queueUrlPath` to distinguish from realtime definitions of the same model name.
  */
-export type ImageModelDefinition = ModelDefinition<ImageModels> & { queueUrlPath: string };
+export type ImageModelDefinition = ModelDefinition<ImageModels> & { fps: number; queueUrlPath: string };
 
 /**
  * Type alias for model definitions that support queue processing.
  * Only video models support the queue API.
  * Requires `queueUrlPath` to distinguish from realtime definitions of the same model name.
  */
-export type VideoModelDefinition = ModelDefinition<VideoModels> & { queueUrlPath: string };
+export type VideoModelDefinition = ModelDefinition<VideoModels> & { fps: number; queueUrlPath: string };
 
 export const modelDefinitionSchema = z.object({
   name: z.string(),
   urlPath: z.string(),
   queueUrlPath: z.string().optional(),
-  fps: z.number().min(1),
+  fps: z.union([
+    z.number().min(1),
+    z.object({
+      max: z.number().min(1).optional(),
+      min: z.number().min(1).optional(),
+      ideal: z.number().min(1).optional(),
+      exact: z.number().min(1).optional(),
+    }),
+  ]),
   width: z.number().min(1),
   height: z.number().min(1),
   inputSchema: z.any().optional(),
@@ -322,7 +337,7 @@ const _models = {
     "lucy-2.1": {
       urlPath: "/v1/stream",
       name: "lucy-2.1" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -330,7 +345,7 @@ const _models = {
     "lucy-2.1-vton": {
       urlPath: "/v1/stream",
       name: "lucy-2.1-vton" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -338,7 +353,7 @@ const _models = {
     "lucy-vton-2": {
       urlPath: "/v1/stream",
       name: "lucy-vton-2" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -346,7 +361,7 @@ const _models = {
     "lucy-restyle-2": {
       urlPath: "/v1/stream",
       name: "lucy-restyle-2" as const,
-      fps: 22,
+      fps: { ideal: 30, max: 30 },
       width: 1280,
       height: 704,
       inputSchema: z.object({}),
@@ -355,7 +370,7 @@ const _models = {
     "lucy-latest": {
       urlPath: "/v1/stream",
       name: "lucy-latest" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -364,7 +379,7 @@ const _models = {
     "lucy-vton-latest": {
       urlPath: "/v1/stream",
       name: "lucy-vton-latest" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -372,7 +387,7 @@ const _models = {
     "lucy-restyle-latest": {
       urlPath: "/v1/stream",
       name: "lucy-restyle-latest" as const,
-      fps: 22,
+      fps: { ideal: 30, max: 30 },
       width: 1280,
       height: 704,
       inputSchema: z.object({}),
@@ -381,7 +396,7 @@ const _models = {
     mirage_v2: {
       urlPath: "/v1/stream",
       name: "mirage_v2" as const,
-      fps: 22,
+      fps: { ideal: 30, max: 30 },
       width: 1280,
       height: 704,
       inputSchema: z.object({}),
@@ -389,7 +404,7 @@ const _models = {
     "lucy-vton": {
       urlPath: "/v1/stream",
       name: "lucy-vton" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -397,7 +412,7 @@ const _models = {
     "lucy-2.1-vton-2": {
       urlPath: "/v1/stream",
       name: "lucy-2.1-vton-2" as const,
-      fps: 20,
+      fps: { ideal: 30, max: 30 },
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -616,13 +631,13 @@ export const models = {
    *   - `"lucy-vton-2"` - Virtual try-on 2 video editing
    *   - `"lucy-restyle-2"` - Video restyling
    */
-  video: <T extends VideoModels>(model: T): ModelDefinition<T> & { queueUrlPath: string } => {
+  video: <T extends VideoModels>(model: T): ModelDefinition<T> & { fps: number; queueUrlPath: string } => {
     warnDeprecated(model);
     const modelDefinition = _models.video[model];
     if (!modelDefinition) {
       throw createModelNotFoundError(model);
     }
-    return modelDefinition as ModelDefinition<T> & { queueUrlPath: string };
+    return modelDefinition as ModelDefinition<T> & { fps: number; queueUrlPath: string };
   },
   /**
    * Get an image model identifier.
@@ -630,12 +645,12 @@ export const models = {
    * Available options:
    *   - `"lucy-image-2"` - Image-to-image editing
    */
-  image: <T extends ImageModels>(model: T): ModelDefinition<T> & { queueUrlPath: string } => {
+  image: <T extends ImageModels>(model: T): ModelDefinition<T> & { fps: number; queueUrlPath: string } => {
     warnDeprecated(model);
     const modelDefinition = _models.image[model];
     if (!modelDefinition) {
       throw createModelNotFoundError(model);
     }
-    return modelDefinition as ModelDefinition<T> & { queueUrlPath: string };
+    return modelDefinition as ModelDefinition<T> & { fps: number; queueUrlPath: string };
   },
 };

--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -3,11 +3,11 @@ declare const __DECART_API_KEY__: string;
 import { createDecartClient, type DecartSDKError, models, type RealTimeModels } from "@decartai/sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-function createSyntheticStream(fps: number, width: number, height: number): MediaStream {
+function createSyntheticStream(width: number, height: number): MediaStream {
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;
-  return canvas.captureStream(fps);
+  return canvas.captureStream(30);
 }
 
 const REALTIME_MODELS: RealTimeModels[] = [
@@ -37,7 +37,7 @@ describe.concurrent("Realtime E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => 
   for (const modelName of REALTIME_MODELS) {
     it(modelName, async () => {
       const model = models.realtime(modelName);
-      const stream = createSyntheticStream(model.fps, model.width, model.height);
+      const stream = createSyntheticStream(model.width, model.height);
 
       let remoteStreamReceived = false;
 

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -27,6 +27,7 @@ import {
   imageModels,
   modelSchema,
   realtimeModels,
+  resolveFpsNumber,
   videoModels,
 } from "../src/shared/model.js";
 
@@ -1159,12 +1160,42 @@ describe("Lucy 2.1 realtime", () => {
 
     it("has correct fps", () => {
       const lucyModel = models.realtime("lucy-2.1");
-      expect(lucyModel.fps).toBe(20);
+      expect(lucyModel.fps).toEqual({ ideal: 30, max: 30 });
     });
 
     it("is recognized as a realtime model", () => {
       expect(models.realtime("lucy-2.1")).toBeDefined();
     });
+  });
+});
+
+describe("resolveFpsNumber", () => {
+  it("returns the number for a scalar fps value", () => {
+    expect(resolveFpsNumber(25)).toBe(25);
+  });
+
+  it("prefers ideal, then max, then exact, then min", () => {
+    expect(resolveFpsNumber({ ideal: 30, max: 60 })).toBe(30);
+    expect(resolveFpsNumber({ max: 30 })).toBe(30);
+    expect(resolveFpsNumber({ exact: 24 })).toBe(24);
+    expect(resolveFpsNumber({ min: 15 })).toBe(15);
+  });
+
+  it("falls back to 30 when the constraint object is empty", () => {
+    expect(resolveFpsNumber({})).toBe(30);
+  });
+
+  it("resolves the realtime model default to 30 for canvas.captureStream-style consumers", () => {
+    expect(resolveFpsNumber(models.realtime("lucy-2.1").fps)).toBe(30);
+  });
+});
+
+describe("Model fps types", () => {
+  it("video and image model fps stays typed as number", () => {
+    // Compile-time check: arithmetic on .fps must work for video/image models without narrowing.
+    const videoFps: number = models.video("lucy-clip").fps;
+    const imageFps: number = models.image("lucy-image-2").fps;
+    expect(videoFps + imageFps).toBeGreaterThan(0);
   });
 });
 
@@ -3596,7 +3627,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-2.1");
       expect(model.name).toBe("lucy-2.1");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
@@ -3605,7 +3636,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-2.1-vton");
       expect(model.name).toBe("lucy-2.1-vton");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
@@ -3614,7 +3645,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-vton-2");
       expect(model.name).toBe("lucy-vton-2");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
@@ -3622,7 +3653,7 @@ describe("Canonical Model Names", () => {
     it("lucy-restyle-2 canonical name works", () => {
       const model = models.realtime("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
-      expect(model.fps).toBe(22);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
     });
   });
 
@@ -3682,7 +3713,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-latest");
       expect(model.name).toBe("lucy-latest");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
@@ -3691,7 +3722,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-vton-latest");
       expect(model.name).toBe("lucy-vton-latest");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
@@ -3700,7 +3731,7 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-restyle-latest");
       expect(model.name).toBe("lucy-restyle-latest");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(22);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
       expect(model.width).toBe(1280);
       expect(model.height).toBe(704);
     });


### PR DESCRIPTION
## Summary

Realtime models now request capture FPS via an `{ ideal: 30, max: 30 }` constraint instead of a hardcoded per-model rate (was 20 for Lucy 2.1, 22 for Lucy Restyle 2). The camera delivers its native rate (typically 24/25/30) and the server resamples to whatever the model needs.

## Why

- Decouples the SDK from server-side FPS support — bumping a model's supported rate no longer requires a client release.
- Avoids client-side frame duplication / dropping when the camera's native rate doesn't match the model's rate. Resampling now happens once, on the server, where it can be done correctly with PTS-aware logic.
- Keeps a steady frame supply ahead of inference so the GPU isn't waiting on the next frame.

## User-facing impact

None for the documented pattern — `frameRate: model.fps` in `getUserMedia` still compiles and works, because `MediaTrackConstraints["frameRate"]` natively accepts both `number` and constraint-object forms:

```ts
const model = models.realtime("lucy-2.1");
const stream = await navigator.mediaDevices.getUserMedia({
  video: { frameRate: model.fps, width: model.width, height: model.height },
});
```

Video/image model `fps` stays a `number` (it's output-rate metadata, not a capture constraint); the type narrowing is enforced at the `models.video(...)` / `models.image(...)` getter boundary so consumers of those registries see no change.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 199/199 unit tests pass (added regression guard that video/image `fps` stays typed as `number`)
- [ ] `pnpm test:e2e:realtime` against staging across all realtime models
- [ ] Manual browser check: `track.getSettings().frameRate` is ≤ 30 across cameras with native 24/25/30/60 rates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `models.realtime(...).fps` shape from a number to a constraint object, which may break consumers doing numeric operations or passing it to APIs expecting a scalar. Runtime behavior changes capture/mirroring FPS handling, so regressions would show up as altered stream cadence or compatibility issues in edge browsers.
> 
> **Overview**
> **Realtime model FPS is now represented as a capture constraint object** rather than a fixed per-model number. The realtime registry entries switch to `fps: { ideal: 30, max: 30 }`, and `modelDefinitionSchema`/`ModelDefinition` are updated to accept either a number or constraint-object form.
> 
> Adds `resolveFpsNumber()` to derive a scalar FPS when needed, and uses it in `realtime/client.ts` when creating mirrored streams. Tests are updated to assert the new realtime `fps` shape, add coverage for `resolveFpsNumber`, and ensure `models.video(...)`/`models.image(...)` still expose `fps` as a `number`; the realtime E2E synthetic stream now captures at 30 FPS explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49342d194d7fe88903e5d545464d1ccf902ca05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->