### PR TITLE
chore(playground): add resolution selector

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -254,6 +254,13 @@
             </select>
         </div>
         <div class="control-group">
+            <label for="resolution-select">Resolution:</label>
+            <select id="resolution-select">
+                <option value="720p" selected>720p (default)</option>
+                <option value="1080p">1080p</option>
+            </select>
+        </div>
+        <div class="control-group">
             <label for="initial-prompt">Initial Prompt (empty = passthrough):</label>
             <input type="text" id="initial-prompt" placeholder="e.g. Lego World">
         </div>
@@ -390,6 +397,7 @@
             apiKey: document.getElementById('api-key'),
             modelSelect: document.getElementById('model-select'),
             realtimeBaseUrl: document.getElementById('realtime-base-url'),
+            resolutionSelect: document.getElementById('resolution-select'),
             initialPrompt: document.getElementById('initial-prompt'),
             startCamera: document.getElementById('start-camera'),
             connectBtn: document.getElementById('connect-btn'),
@@ -544,8 +552,12 @@
                     initialImage = await initialImageResponse.blob();
                 }
 
+                const resolution = elements.resolutionSelect.value;
+                addLog(`Resolution: ${resolution}`, 'info');
+
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
+                    resolution,
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;


### PR DESCRIPTION
## Summary

Adds a Resolution dropdown (720p default, 1080p) to the local SDK test page so we can exercise the new `resolution` option end-to-end without code edits.

## Usage

In `packages/sdk/index.html` (the playground), pick a resolution from the new dropdown before connecting. The selected value is passed through to `client.realtime.connect()`:

```ts
const realtimeClient = await client.realtime.connect(stream, {
  model,
  resolution: "1080p", // default: "720p"
  onRemoteStream,
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: playground-only UI wiring that passes a new `resolution` option through to `realtime.connect`, with no changes to core SDK logic.
> 
> **Overview**
> Adds a **Resolution** dropdown ("720p" default, "1080p") to the SDK playground (`packages/sdk/index.html`).
> 
> On connect, the selected value is logged and forwarded as the `resolution` option in `decartClient.realtime.connect(...)` so resolution can be tested end-to-end without editing code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0b5ca7fef47853566422deb98de2f26fd77a6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->