### PR TITLE
test: make realtime E2E wait for LiveKit stream

### DIFF
--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -3,11 +3,56 @@ declare const __DECART_API_KEY__: string;
 import { createDecartClient, type DecartSDKError, models, type RealTimeModels } from "@decartai/sdk";
 import { beforeAll, describe, expect, it } from "vitest";
 
-function createSyntheticStream(width: number, height: number): MediaStream {
+function createSyntheticStream(width: number, height: number): { stream: MediaStream; stop: () => void } {
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;
-  return canvas.captureStream(30);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2D canvas context unavailable");
+
+  let frame = 0;
+  const draw = () => {
+    ctx.fillStyle = `hsl(${(frame * 5) % 360}, 80%, 45%)`;
+    ctx.fillRect(0, 0, width, height);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+    ctx.fillRect((frame * 7) % Math.max(1, width - 160), 32, 140, 100);
+    ctx.fillStyle = "rgba(0, 0, 0, 0.85)";
+    ctx.font = "32px sans-serif";
+    ctx.fillText(`${width}x${height}`, 48, 92);
+    ctx.fillText(`frame ${frame}`, 48, 136);
+    frame += 1;
+  };
+
+  draw();
+  const intervalId = window.setInterval(draw, 1000 / 30);
+  const stream = canvas.captureStream(30);
+
+  return {
+    stream,
+    stop: () => {
+      window.clearInterval(intervalId);
+      for (const track of stream.getTracks()) track.stop();
+    },
+  };
+}
+
+function waitUntil(condition: () => boolean, message: string, timeoutMs = 15_000): Promise<void> {
+  if (condition()) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    const intervalId = window.setInterval(() => {
+      if (!condition()) return;
+      window.clearInterval(intervalId);
+      window.clearTimeout(timeoutId);
+      resolve();
+    }, 50);
+
+    const timeoutId = window.setTimeout(() => {
+      window.clearInterval(intervalId);
+      reject(new Error(message));
+    }, timeoutMs);
+  });
 }
 
 const REALTIME_MODELS: RealTimeModels[] = [
@@ -37,37 +82,40 @@ describe.concurrent("Realtime E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => 
   for (const modelName of REALTIME_MODELS) {
     it(modelName, async () => {
       const model = models.realtime(modelName);
-      const stream = createSyntheticStream(model.width, model.height);
+      const syntheticStream = createSyntheticStream(model.width, model.height);
 
       let remoteStreamReceived = false;
-
-      const realtimeClient = await client.realtime.connect(stream, {
-        model,
-        onRemoteStream: () => {
-          remoteStreamReceived = true;
-        },
-        initialState: {
-          prompt: { text: "Anime style", enhance: false },
-        },
-      });
-
-      const errors: DecartSDKError[] = [];
-      realtimeClient.on("error", (err) => errors.push(err));
+      let realtimeClient: Awaited<ReturnType<typeof client.realtime.connect>> | undefined;
 
       try {
+        realtimeClient = await client.realtime.connect(syntheticStream.stream, {
+          model,
+          onRemoteStream: () => {
+            remoteStreamReceived = true;
+          },
+          initialState: {
+            prompt: { text: "Anime style", enhance: false },
+          },
+        });
+
+        const errors: DecartSDKError[] = [];
+        realtimeClient.on("error", (err) => errors.push(err));
+
         expect(["connected", "generating"]).toContain(realtimeClient.getConnectionState());
         expect(realtimeClient.sessionId).toBeTruthy();
+
+        await waitUntil(() => remoteStreamReceived, `Timed out waiting for remote stream callback for ${modelName}`);
         expect(remoteStreamReceived).toBe(true);
 
         await realtimeClient.setPrompt("Cyberpunk city");
 
         expect(errors).toEqual([]);
       } finally {
-        realtimeClient.disconnect();
-        for (const track of stream.getTracks()) track.stop();
+        realtimeClient?.disconnect();
+        syntheticStream.stop();
       }
 
-      expect(realtimeClient.getConnectionState()).toBe("disconnected");
+      expect(realtimeClient?.getConnectionState()).toBe("disconnected");
     });
   }
 });


### PR DESCRIPTION
## Summary
- drive the realtime E2E synthetic canvas with actual frame updates so LiveKit receives a live video track
- wait up to 15s for the async `onRemoteStream` callback instead of asserting immediately after `connect()` returns
- clean up the synthetic stream even if realtime connect fails

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec biome check tests/e2e-realtime.test.ts`
- `DECART_API_KEY=*** pnpm vitest --config vitest.config.e2e-realtime.ts --run --reporter=default --reporter=json --outputFile=test-report.json` (5/5 passed)
- independent Claude Code review: clean / ship it

Requested by Eilon in Slack ([#decart-api-alerts](https://decart.slack.com/archives/C09G2C5MBCZ)) - [message link](https://decart.slack.com/archives/C09G2C5MBCZ/p1779212046046029)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to an E2E test, but they alter async timing/cleanup and could affect test flakiness or runtime in CI.
> 
> **Overview**
> Improves realtime E2E stability by generating a *truly live* synthetic video track (canvas redraw loop) and providing a `stop()` helper to reliably tear down intervals and tracks.
> 
> Updates the test flow to **wait (up to 15s)** for the async `onRemoteStream` callback via a new `waitUntil` helper, and hardens cleanup by disconnecting/disposing the stream even if `connect()` fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b55694e0010fb6bc9a0892ebc5845147aec4ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->