### PR TITLE
feat(realtime): add playRemoteAudio connect option to gate audio playback

### DIFF
--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -56,6 +56,16 @@ const realTimeClientConnectOptionsSchema = z.object({
   resolution: z.enum(["720p", "1080p"]).optional(),
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
+  /**
+   * Play remote audio tracks published by the server. Default `false`.
+   *
+   * Set `true` for models that emit meaningful audio (avatars, voice
+   * sessions, V2V passthrough where input audio should round-trip). When
+   * `false`, audio tracks are dropped on the client — no hidden `<audio>`
+   * element is created by livekit-client and audio is not added to the
+   * stream passed to `onRemoteStream`.
+   */
+  playRemoteAudio: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -102,8 +112,15 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
     const parsedOptions = realTimeClientConnectOptionsSchema.safeParse(options);
     if (!parsedOptions.success) throw parsedOptions.error;
 
-    const { onRemoteStream, onConnectionChange, onQueuePosition, initialState, resolution, preferredVideoCodec } =
-      parsedOptions.data;
+    const {
+      onRemoteStream,
+      onConnectionChange,
+      onQueuePosition,
+      initialState,
+      resolution,
+      preferredVideoCodec,
+      playRemoteAudio,
+    } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
     let inputStream: MediaStream = stream ?? new MediaStream();
 
@@ -169,6 +186,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         initialPrompt,
         logger,
         videoCodec: publishCodec,
+        playRemoteAudio,
       });
 
       let sessionId: string | null = null;

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -57,13 +57,12 @@ const realTimeClientConnectOptionsSchema = z.object({
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
   /**
-   * Play remote audio tracks published by the server. Default `false`.
+   * Play remote audio tracks. Default `false`.
    *
-   * Set `true` for models that emit meaningful audio (avatars, voice
-   * sessions, V2V passthrough where input audio should round-trip). When
-   * `false`, audio tracks are dropped on the client — no hidden `<audio>`
-   * element is created by livekit-client and audio is not added to the
-   * stream passed to `onRemoteStream`.
+   * When `false`, any audio the model emits is dropped on the client — no
+   * playback element is attached and audio is not added to the stream
+   * passed to `onRemoteStream`. Set `true` when the model emits audio you
+   * want the user to hear.
    */
   playRemoteAudio: z.boolean().optional(),
 });

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -46,14 +46,12 @@ export interface MediaChannelConfig {
   logger?: Logger;
   videoCodec?: VideoCodec;
   /**
-   * Play remote audio tracks published by the server. Default `false`.
+   * Play remote audio tracks. Default `false`.
    *
-   * When `false`, audio tracks subscribed from the server are dropped on the
-   * client: livekit-client's `track.attach()` is skipped (so no hidden
-   * `<audio>` element is created) and the track is not added to the remote
-   * stream. Set to `true` for models that emit meaningful audio output
-   * (avatars, voice-driven sessions, or V2V where the input audio should
-   * round-trip to subscribers).
+   * When `false`, any audio tracks delivered to this room are dropped on the
+   * client: no playback element is attached and the track is not added to
+   * the stream emitted on `remoteStream`. Set to `true` when the model emits
+   * audio you want the user to hear.
    */
   playRemoteAudio?: boolean;
 }

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -45,6 +45,17 @@ export interface MediaChannelConfig {
   localStream: MediaStream | null;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  /**
+   * Play remote audio tracks published by the server. Default `false`.
+   *
+   * When `false`, audio tracks subscribed from the server are dropped on the
+   * client: livekit-client's `track.attach()` is skipped (so no hidden
+   * `<audio>` element is created) and the track is not added to the remote
+   * stream. Set to `true` for models that emit meaningful audio output
+   * (avatars, voice-driven sessions, or V2V where the input audio should
+   * round-trip to subscribers).
+   */
+  playRemoteAudio?: boolean;
 }
 
 export type MediaConnectOptions = {
@@ -81,6 +92,7 @@ export class MediaChannel {
     room.on(RoomEvent.TrackSubscribed, (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
       if (!participant.identity.startsWith(REALTIME_CONFIG.livekit.inferenceServerIdentityPrefix)) return;
       if (track.kind !== Track.Kind.Video && track.kind !== Track.Kind.Audio) return;
+      if (track.kind === Track.Kind.Audio && !this.config.playRemoteAudio) return;
 
       track.attach();
       const mediaStreamTrack = track.mediaStreamTrack;

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -61,6 +61,7 @@ interface StreamSessionConfig {
   initialPrompt?: InitialPrompt;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  playRemoteAudio?: boolean;
 }
 
 export class StreamSession {
@@ -317,6 +318,7 @@ export class StreamSession {
       localStream: this.config.localStream,
       logger: this.logger,
       videoCodec: this.config.videoCodec,
+      playRemoteAudio: this.config.playRemoteAudio,
     });
     this.wireSignalingEvents();
     this.wireMediaEvents();

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -62,14 +62,12 @@ export type SubscribeOptions = {
   onRemoteStream: (stream: MediaStream) => void;
   onConnectionChange?: (state: ConnectionState) => void;
   /**
-   * Play remote audio tracks published by the server. Default `false`.
+   * Play remote audio tracks. Default `false`.
    *
-   * Mirrors the publisher-side `realtime.connect()` option. When `false`,
-   * audio tracks subscribed from the inference server are dropped on the
-   * client: livekit-client's `track.attach()` is skipped (so no hidden
-   * `<audio>` element is created) and the track is not added to the stream
-   * passed to `onRemoteStream`. Set `true` for viewers of avatar / V2V /
-   * voice-driven sessions where the server-side audio is meaningful.
+   * When `false`, any audio the model emits is dropped on the client — no
+   * playback element is attached and audio is not added to the stream
+   * passed to `onRemoteStream`. Set `true` when the model emits audio you
+   * want the viewer to hear.
    */
   playRemoteAudio?: boolean;
 };

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -61,6 +61,17 @@ export type SubscribeOptions = {
   token: string;
   onRemoteStream: (stream: MediaStream) => void;
   onConnectionChange?: (state: ConnectionState) => void;
+  /**
+   * Play remote audio tracks published by the server. Default `false`.
+   *
+   * Mirrors the publisher-side `realtime.connect()` option. When `false`,
+   * audio tracks subscribed from the inference server are dropped on the
+   * client: livekit-client's `track.attach()` is skipped (so no hidden
+   * `<audio>` element is created) and the track is not added to the stream
+   * passed to `onRemoteStream`. Set `true` for viewers of avatar / V2V /
+   * voice-driven sessions where the server-side audio is meaningful.
+   */
+  playRemoteAudio?: boolean;
 };
 
 export type RealTimeSubscribeClientOptions = {
@@ -148,6 +159,7 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
       activeRoom.on(RoomEvent.TrackSubscribed, (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
         if (!participant.identity.startsWith(REALTIME_CONFIG.livekit.inferenceServerIdentityPrefix)) return;
         if (track.kind !== Track.Kind.Video && track.kind !== Track.Kind.Audio) return;
+        if (track.kind === Track.Kind.Audio && !options.playRemoteAudio) return;
 
         track.attach();
         const mediaStreamTrack = track.mediaStreamTrack;

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -743,16 +743,18 @@ describe("StreamSession startup orchestration", () => {
     });
   };
 
-  const subscribeRemoteTrack = () => {
+  const subscribeRemoteTrack = (kind: "video" | "audio" = "video") => {
     const room = liveKitMock.roomInstances.at(-1) as InstanceType<typeof liveKitMock.MockRoom>;
-    const mediaStreamTrack = { id: "remote-video", kind: "video" };
+    const mediaStreamTrack = { id: `remote-${kind}`, kind };
+    const trackKind = kind === "video" ? liveKitMock.Track.Kind.Video : liveKitMock.Track.Kind.Audio;
     const track = {
-      kind: liveKitMock.Track.Kind.Video,
+      kind: trackKind,
       mediaStreamTrack,
       attach: vi.fn(),
       on: vi.fn(),
     };
     room.emit(liveKitMock.RoomEvent.TrackSubscribed, track, {}, { identity: "inference-server-1" });
+    return track;
   };
 
   const createLocalStream = () =>
@@ -975,6 +977,61 @@ describe("StreamSession startup orchestration", () => {
 
     expect(firstRoom.localParticipant.publishTrack).not.toHaveBeenCalled();
     await expect(connectPromise).rejects.toThrow("WebSocket closed: 1000 closed");
+  });
+
+  it("drops remote audio tracks by default — no attach, not added to remoteStream", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({
+      url: "wss://example.test/realtime",
+      localStream: null,
+      initialPrompt: { text: "go" },
+    });
+    const remoteStreams: MediaStream[] = [];
+    session.on("remoteStream", (stream) => remoteStreams.push(stream));
+
+    session.connect().catch(() => {});
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await flushMicrotasks();
+    sendRoomInfo(ws);
+    await flushMicrotasks();
+
+    const audioTrack = subscribeRemoteTrack("audio");
+    expect(audioTrack.attach).not.toHaveBeenCalled();
+    expect(remoteStreams).toHaveLength(0);
+
+    const videoTrack = subscribeRemoteTrack("video");
+    expect(videoTrack.attach).toHaveBeenCalledTimes(1);
+    expect(remoteStreams).toHaveLength(1);
+    expect((remoteStreams[0] as unknown as FakeMediaStream).getTracks()).toEqual([
+      expect.objectContaining({ kind: "video" }),
+    ]);
+  });
+
+  it("plays remote audio tracks when playRemoteAudio is true", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({
+      url: "wss://example.test/realtime",
+      localStream: null,
+      initialPrompt: { text: "go" },
+      playRemoteAudio: true,
+    });
+    const remoteStreams: MediaStream[] = [];
+    session.on("remoteStream", (stream) => remoteStreams.push(stream));
+
+    session.connect().catch(() => {});
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await flushMicrotasks();
+    sendRoomInfo(ws);
+    await flushMicrotasks();
+
+    const audioTrack = subscribeRemoteTrack("audio");
+    expect(audioTrack.attach).toHaveBeenCalledTimes(1);
+    expect(remoteStreams).toHaveLength(1);
+    expect((remoteStreams[0] as unknown as FakeMediaStream).getTracks()).toEqual([
+      expect.objectContaining({ kind: "audio" }),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add opt-in `playRemoteAudio: boolean` to both `client.realtime.connect()` and `client.realtime.subscribe()`. Default `false`.
- When `false`, audio tracks the model emits are dropped on the client: no playback element is attached, and the track is not added to the stream passed to `onRemoteStream`.
- When `true`, current behavior is preserved (auto-attach + included in `remoteStream`).
- Video tracks are untouched.

## Why

`livekit-client`'s `track.attach()` creates a hidden, un-muted `<audio>` element per subscribed audio track and plays it. That element is independent of any `<video muted>` an app wires up via `onRemoteStream` — muting the app's video element does not silence the audio playback.

Apps that previously assumed "no audio output unless I unmute my own `<video>`" started hearing unexpected playback when the upstream service began publishing audio tracks (e.g. for models that echo input audio or generate speech). The right gate is in the SDK: only the SDK knows the difference between "an audio track was delivered" and "the app actually wants to play it." Apps that do want audio opt in.

## Behavior matrix

|                                              | `playRemoteAudio` unset / `false` | `playRemoteAudio: true` |
|----------------------------------------------|-----------------------------------|-------------------------|
| `track.attach()` for audio                   | skipped                           | called (default LK behavior) |
| Audio in `MediaStream` from `onRemoteStream` | omitted                           | included                |
| Video handling                               | unchanged                         | unchanged               |

## Default rationale

Default is `false` — audio is an explicit opt-in. Defaulting to `true` would be a silent breaking change for apps that already exist: they'd start hearing audio they never asked for and that they tried to silence with `<video muted>`. False matches the implicit "audio is off unless I ask for it" behavior most existing apps already rely on.

## Test plan

- [x] Added unit tests in `tests/realtime.unit.test.ts`:
  - `drops remote audio tracks by default — no attach, not added to remoteStream` (and verifies video still flows through in the same session)
  - `plays remote audio tracks when playRemoteAudio is true`
- [x] `pnpm test` — 208/208 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean

## Notes / follow-ups

- The audio track is still subscribed by livekit-client and consumes bandwidth even when `playRemoteAudio: false`. A future optimization could unsubscribe at the publication level (`publication.setSubscribed(false)` on `RoomEvent.TrackPublished`) to also save bandwidth, but that's a larger change and orthogonal to silencing.
- The same gate is applied to both `realtime.connect()` (publisher) and `realtime.subscribe()` (viewer) so audio behavior is consistent across both API surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side media gating with safe default false; no auth or server contract changes beyond optional connect/subscribe options and documented behavior.
> 
> **Overview**
> Adds an opt-in **`playRemoteAudio`** flag (default **`false`**) on **`client.realtime.connect()`** and **`subscribe()`**, threaded through **`StreamSession`** into **`MediaChannel`** (and the subscribe LiveKit handler).
> 
> When **`playRemoteAudio`** is unset or **`false`**, subscribed **remote audio** from the inference server is ignored: **`track.attach()`** is not called and the audio **`MediaStreamTrack`** is **not** added to the stream delivered via **`onRemoteStream`**, so LiveKit’s hidden playback element does not play model/mic echo audio. **`true`** restores prior behavior (attach + audio in the remote stream). **Video** handling is unchanged.
> 
> Unit tests cover default-off audio dropping vs video still flowing, and **`playRemoteAudio: true`** enabling audio attach and stream inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89a1c1a0b368a1dc176cb3b51843e537991b757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->