### PR TITLE
feat(realtime): block TCP ICE candidates by default

### DIFF
--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -57,15 +57,15 @@ const realTimeClientConnectOptionsSchema = z.object({
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
   /**
-   * Allow TCP ICE candidates (direct TCP to LiveKit + TURN-TCP/TLS). Defaults to `false`.
+   * Allow TCP ICE candidates (direct TCP to the SFU + TURN-TCP/TLS). Defaults to `false`.
    *
-   * Production telemetry shows TCP-direct fallback degrades quality (stalls, choppy
-   * playback) for ~10% of clients because TCP head-of-line blocking interacts badly
-   * with WebRTC's real-time pacing. By default the SDK now blocks TCP candidates so
-   * the connection either succeeds over UDP (direct or TURN-UDP) or fails fast.
+   * The SDK blocks TCP by default as a quality choice: WebRTC media over TCP
+   * suffers from head-of-line blocking that produces visible stalls. UDP-only
+   * connections either work well or fail fast — both are better outcomes than
+   * a session limping along on TCP.
    *
-   * Set to `true` only if you knowingly accept TCP fallback — e.g. for diagnostic
-   * builds, or for users whose networks block UDP entirely (~4% of clients).
+   * Pass `true` if your users insist on TCP fallback — e.g. enterprise networks
+   * where outbound UDP is blocked and TURN-TLS:443 is the only path that works.
    */
   allowTcpIce: z.boolean().optional(),
 });

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -56,6 +56,18 @@ const realTimeClientConnectOptionsSchema = z.object({
   resolution: z.enum(["720p", "1080p"]).optional(),
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
+  /**
+   * Allow TCP ICE candidates (direct TCP to LiveKit + TURN-TCP/TLS). Defaults to `false`.
+   *
+   * Production telemetry shows TCP-direct fallback degrades quality (stalls, choppy
+   * playback) for ~10% of clients because TCP head-of-line blocking interacts badly
+   * with WebRTC's real-time pacing. By default the SDK now blocks TCP candidates so
+   * the connection either succeeds over UDP (direct or TURN-UDP) or fails fast.
+   *
+   * Set to `true` only if you knowingly accept TCP fallback — e.g. for diagnostic
+   * builds, or for users whose networks block UDP entirely (~4% of clients).
+   */
+  allowTcpIce: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -102,8 +114,15 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
     const parsedOptions = realTimeClientConnectOptionsSchema.safeParse(options);
     if (!parsedOptions.success) throw parsedOptions.error;
 
-    const { onRemoteStream, onConnectionChange, onQueuePosition, initialState, resolution, preferredVideoCodec } =
-      parsedOptions.data;
+    const {
+      onRemoteStream,
+      onConnectionChange,
+      onQueuePosition,
+      initialState,
+      resolution,
+      preferredVideoCodec,
+      allowTcpIce,
+    } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
     let inputStream: MediaStream = stream ?? new MediaStream();
 
@@ -169,6 +188,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         initialPrompt,
         logger,
         videoCodec: publishCodec,
+        allowTcpIce,
       });
 
       let sessionId: string | null = null;

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -13,6 +13,7 @@ import mitt, { type Emitter } from "mitt";
 import { createConsoleLogger, type Logger } from "../utils/logger";
 import { REALTIME_CONFIG } from "./config-realtime";
 import type { RealtimeObservability } from "./observability/realtime-observability";
+import { installIceFilter } from "./webrtc-ice-filter";
 
 export type VideoCodec = "h264" | "vp8" | "vp9" | "av1";
 
@@ -45,6 +46,14 @@ export interface MediaChannelConfig {
   localStream: MediaStream | null;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  /**
+   * When true, allow TCP ICE candidates (regular + TURN-TCP/TLS).
+   * Default `false` — TCP is blocked because the TCP-direct fallback to LiveKit
+   * `:7881` carries media under TCP head-of-line blocking that produces stalls
+   * for ~10% of production sessions. Set to true only when you need TCP as a
+   * fallback for clients with UDP fully blocked outbound.
+   */
+  allowTcpIce?: boolean;
 }
 
 export type MediaConnectOptions = {
@@ -57,6 +66,7 @@ export class MediaChannel {
   private remoteStream: MediaStream | null = null;
   private events: Emitter<MediaChannelEvents> = mitt();
   private readonly logger: Logger;
+  private releaseIceFilter: (() => void) | null = null;
 
   constructor(private readonly config: MediaChannelConfig) {
     this.logger = config.logger ?? createConsoleLogger("warn");
@@ -75,6 +85,9 @@ export class MediaChannel {
   }
 
   async connect(opts: MediaConnectOptions): Promise<void> {
+    // Install the TCP-ICE filter BEFORE constructing the Room so that all
+    // PCs created by LiveKit go through the filtered RTCPeerConnection.
+    this.releaseIceFilter ??= installIceFilter({ allowTcp: this.config.allowTcpIce ?? false });
     this.room ??= new Room(REALTIME_CONFIG.livekit.roomOptions);
     const room = this.room;
 
@@ -122,6 +135,8 @@ export class MediaChannel {
     if (room) {
       room.disconnect().catch(() => {});
     }
+    this.releaseIceFilter?.();
+    this.releaseIceFilter = null;
   }
 
   private async publishTracks(stream: MediaStream): Promise<void> {

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -47,11 +47,8 @@ export interface MediaChannelConfig {
   logger?: Logger;
   videoCodec?: VideoCodec;
   /**
-   * When true, allow TCP ICE candidates (regular + TURN-TCP/TLS).
-   * Default `false` — TCP is blocked because the TCP-direct fallback to LiveKit
-   * `:7881` carries media under TCP head-of-line blocking that produces stalls
-   * for ~10% of production sessions. Set to true only when you need TCP as a
-   * fallback for clients with UDP fully blocked outbound.
+   * Allow TCP ICE candidates. Default `false`; see
+   * `RealTimeClientConnectOptions.allowTcpIce` for the rationale.
    */
   allowTcpIce?: boolean;
 }
@@ -85,8 +82,9 @@ export class MediaChannel {
   }
 
   async connect(opts: MediaConnectOptions): Promise<void> {
-    // Install the TCP-ICE filter BEFORE constructing the Room so that all
-    // PCs created by LiveKit go through the filtered RTCPeerConnection.
+    // Install the TCP-ICE filter before constructing the Room so that every PC
+    // LiveKit creates goes through the filtered RTCPeerConnection. No-op when
+    // the caller opted in to TCP via `allowTcpIce: true`.
     this.releaseIceFilter ??= installIceFilter({ allowTcp: this.config.allowTcpIce ?? false });
     this.room ??= new Room(REALTIME_CONFIG.livekit.roomOptions);
     const room = this.room;

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -61,6 +61,7 @@ interface StreamSessionConfig {
   initialPrompt?: InitialPrompt;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  allowTcpIce?: boolean;
 }
 
 export class StreamSession {
@@ -317,6 +318,7 @@ export class StreamSession {
       localStream: this.config.localStream,
       logger: this.logger,
       videoCodec: this.config.videoCodec,
+      allowTcpIce: this.config.allowTcpIce,
     });
     this.wireSignalingEvents();
     this.wireMediaEvents();

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -14,6 +14,7 @@ import { createEventBuffer } from "./event-buffer";
 import type { DiagnosticEvent } from "./observability/diagnostics";
 import { RealtimeObservability } from "./observability/realtime-observability";
 import type { ConnectionState } from "./types";
+import { installIceFilter } from "./webrtc-ice-filter";
 
 type TokenPayload = {
   room_name: string;
@@ -61,6 +62,11 @@ export type SubscribeOptions = {
   token: string;
   onRemoteStream: (stream: MediaStream) => void;
   onConnectionChange?: (state: ConnectionState) => void;
+  /**
+   * Allow TCP ICE candidates. Defaults to `false`. See `RealTimeClientConnectOptions.allowTcpIce`
+   * on the publisher side for the rationale — same caveats apply to subscribers.
+   */
+  allowTcpIce?: boolean;
 };
 
 export type RealTimeSubscribeClientOptions = {
@@ -121,6 +127,11 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
     let room: Room | undefined;
     let currentState: ConnectionState = "connecting";
     let remoteStream: MediaStream | null = null;
+    let releaseIceFilter: (() => void) | null = installIceFilter({ allowTcp: options.allowTcpIce ?? false });
+    const releaseFilter = () => {
+      releaseIceFilter?.();
+      releaseIceFilter = null;
+    };
 
     const setState = (state: ConnectionState) => {
       if (currentState === state) return;
@@ -178,6 +189,7 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
           observability?.stop();
           stop();
           activeRoom.disconnect().catch(() => {});
+          releaseFilter();
         },
         on: emitter.on,
         off: emitter.off,
@@ -190,6 +202,7 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
       if (room) {
         room.disconnect().catch(() => {});
       }
+      releaseFilter();
       const err = error instanceof Error ? error : new Error(String(error));
       logger.error("Realtime subscribe error", { error: err.message });
       throw classifyWebrtcError(err);

--- a/packages/sdk/src/realtime/webrtc-ice-filter.ts
+++ b/packages/sdk/src/realtime/webrtc-ice-filter.ts
@@ -1,33 +1,45 @@
 /**
- * Globally wraps `RTCPeerConnection` to drop TCP ICE candidates so the realtime
- * connection only attempts UDP transports (direct UDP host/srflx and TURN-UDP).
+ * Wraps `globalThis.RTCPeerConnection` to drop TCP ICE candidates so the
+ * realtime media path only attempts UDP (direct UDP host/srflx and TURN-UDP).
  *
- * Why: telemetry from production shows ~10% of successfully-connected clients
- * land on TCP-direct to LiveKit's `:7881` even though 90% of them had a working
- * `udp srflx` candidate — meaning UDP reaches our STUN but the SFU UDP path is
- * lossy enough to fail ICE connectivity checks. TCP fallback then carries
- * media under HOL blocking, producing the stalls customers experience. Forcing
- * UDP-only either succeeds via direct UDP / TURN-UDP, or fails fast — both are
- * better outcomes than a session limping along on TCP.
+ * Why this exists — it's a quality-of-experience knob, not a security one.
+ * In production ~10% of clients negotiate TCP to the SFU when their UDP ICE
+ * checks fail, even though ~90% of those clients had a working `udp srflx`
+ * candidate (so UDP works at the network layer; it's the SFU-specific UDP
+ * path that's lossy enough to lose connectivity checks). WebRTC media over
+ * TCP is the worst of both worlds: TCP's head-of-line blocking and
+ * retransmits fight WebRTC's real-time pacing and produce the stalls and
+ * choppy playback customers report. Forcing UDP-only either succeeds (good
+ * experience) or fails fast (clean error the app can show) — both are
+ * preferable to a session limping along on TCP.
  *
- * Three filter points (defence in depth):
- *  1. `RTCConfiguration.iceServers` — drop `?transport=tcp` and `turns:` URLs
- *     so the browser never gathers TURN-TCP/TLS relay candidates.
- *  2. `setRemoteDescription` — strip `a=candidate ... TCP ...` lines from the
- *     SFU's SDP so its TCP host candidate is never paired against locals.
- *  3. `addIceCandidate` — drop trickled TCP candidates as a belt-and-braces
- *     guard in case any slip past the SDP filter.
+ * TCP candidates can reach a `PeerConnection` through three independent
+ * paths, so the filter closes all three:
+ *  1. `RTCConfiguration.iceServers` — strip `?transport=tcp` and `turns:`
+ *     URLs so the browser never gathers TURN-TCP/TLS relay candidates.
+ *  2. `setRemoteDescription` SDP — strip `a=candidate ... TCP ...` lines so
+ *     the SFU's TCP host candidate is never paired against ours.
+ *  3. `addIceCandidate` — drop trickled TCP candidates that arrive after
+ *     the initial SDP exchange.
  *
  * The patch is reference-counted: the first `installIceFilter` swaps
  * `globalThis.RTCPeerConnection` for a `Proxy`, the matching uninstall
- * function restores the original constructor when the last caller releases.
+ * restores the original constructor when the last caller releases.
  *
- * Caller can opt out via `allowTcp: true` (e.g. for diagnostic builds or
- * specific clients we know need TCP fallback).
+ * Opting out: a caller who insists on keeping TCP — e.g. an app whose
+ * users sit behind networks that block UDP entirely — passes
+ * `allowTcp: true` and gets the unfiltered constructor back. Default is
+ * `false` because in our 48h sample only ~0.4% of total sessions had no
+ * UDP candidate at all and would actually benefit from TCP fallback.
  */
 
 export interface IceFilterOptions {
-  /** When true, do not patch `RTCPeerConnection` — TCP candidates remain enabled. */
+  /**
+   * Opt out of TCP filtering. Default `false` (TCP candidates blocked).
+   * Set to `true` for callers whose users need TCP fallback because UDP
+   * is unreachable on their network — at the cost of the choppy-playback
+   * behavior we're trying to avoid.
+   */
   allowTcp: boolean;
 }
 

--- a/packages/sdk/src/realtime/webrtc-ice-filter.ts
+++ b/packages/sdk/src/realtime/webrtc-ice-filter.ts
@@ -1,0 +1,198 @@
+/**
+ * Globally wraps `RTCPeerConnection` to drop TCP ICE candidates so the realtime
+ * connection only attempts UDP transports (direct UDP host/srflx and TURN-UDP).
+ *
+ * Why: telemetry from production shows ~10% of successfully-connected clients
+ * land on TCP-direct to LiveKit's `:7881` even though 90% of them had a working
+ * `udp srflx` candidate — meaning UDP reaches our STUN but the SFU UDP path is
+ * lossy enough to fail ICE connectivity checks. TCP fallback then carries
+ * media under HOL blocking, producing the stalls customers experience. Forcing
+ * UDP-only either succeeds via direct UDP / TURN-UDP, or fails fast — both are
+ * better outcomes than a session limping along on TCP.
+ *
+ * Three filter points (defence in depth):
+ *  1. `RTCConfiguration.iceServers` — drop `?transport=tcp` and `turns:` URLs
+ *     so the browser never gathers TURN-TCP/TLS relay candidates.
+ *  2. `setRemoteDescription` — strip `a=candidate ... TCP ...` lines from the
+ *     SFU's SDP so its TCP host candidate is never paired against locals.
+ *  3. `addIceCandidate` — drop trickled TCP candidates as a belt-and-braces
+ *     guard in case any slip past the SDP filter.
+ *
+ * The patch is reference-counted: the first `installIceFilter` swaps
+ * `globalThis.RTCPeerConnection` for a `Proxy`, the matching uninstall
+ * function restores the original constructor when the last caller releases.
+ *
+ * Caller can opt out via `allowTcp: true` (e.g. for diagnostic builds or
+ * specific clients we know need TCP fallback).
+ */
+
+export interface IceFilterOptions {
+  /** When true, do not patch `RTCPeerConnection` — TCP candidates remain enabled. */
+  allowTcp: boolean;
+}
+
+type PeerConnectionCtor = typeof RTCPeerConnection;
+
+interface InstalledState {
+  original: PeerConnectionCtor;
+}
+
+let installed: InstalledState | null = null;
+let refcount = 0;
+
+/**
+ * Patch `globalThis.RTCPeerConnection` to drop TCP ICE candidates.
+ * Returns an uninstall function — call it when the session ends to release.
+ *
+ * If `allowTcp` is true, this is a no-op and the returned function is also a no-op.
+ * If `RTCPeerConnection` is not available in the runtime (Node without polyfill),
+ * this is a no-op.
+ */
+export function installIceFilter(options: IceFilterOptions): () => void {
+  if (options.allowTcp) return noop;
+
+  const ctor = (globalThis as { RTCPeerConnection?: PeerConnectionCtor }).RTCPeerConnection;
+  if (!ctor) return noop;
+
+  refcount += 1;
+  if (!installed) {
+    installed = { original: ctor };
+    (globalThis as { RTCPeerConnection?: PeerConnectionCtor }).RTCPeerConnection = makeFilteredPeerConnection(ctor);
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    refcount -= 1;
+    if (refcount <= 0) {
+      refcount = 0;
+      if (installed) {
+        (globalThis as { RTCPeerConnection?: PeerConnectionCtor }).RTCPeerConnection = installed.original;
+        installed = null;
+      }
+    }
+  };
+}
+
+function noop(): void {
+  /* no-op */
+}
+
+function makeFilteredPeerConnection(Original: PeerConnectionCtor): PeerConnectionCtor {
+  return new Proxy(Original, {
+    construct(target, args) {
+      const [config, ...rest] = args as [RTCConfiguration | undefined, ...unknown[]];
+      const filteredConfig = filterRtcConfiguration(config);
+      const pc = Reflect.construct(target, [filteredConfig, ...rest]);
+      attachInstanceFilters(pc);
+      return pc;
+    },
+  }) as PeerConnectionCtor;
+}
+
+/**
+ * Filter `iceServers` URLs to remove TCP-TURN entries (and TURNS, which is TLS-over-TCP).
+ * Returns the config unmodified if there is nothing to filter.
+ */
+export function filterRtcConfiguration(config: RTCConfiguration | undefined): RTCConfiguration | undefined {
+  if (!config?.iceServers || config.iceServers.length === 0) return config;
+  const filteredServers = config.iceServers
+    .map((server) => filterIceServer(server))
+    .filter((server): server is RTCIceServer => server !== null);
+  return { ...config, iceServers: filteredServers };
+}
+
+function filterIceServer(server: RTCIceServer): RTCIceServer | null {
+  const rawUrls = server.urls;
+  const urls = Array.isArray(rawUrls) ? rawUrls : [rawUrls];
+  const filtered = urls.filter((url) => typeof url === "string" && !isTcpTurnUrl(url));
+  if (filtered.length === 0) return null;
+  return { ...server, urls: filtered.length === 1 ? filtered[0] : filtered };
+}
+
+/**
+ * `turn:host:port?transport=tcp` → TCP transport to TURN. Drop.
+ * `turns:host:port` (any scheme starting `turns:`) → TLS-over-TCP. Drop.
+ * `turn:host:port` (no transport) → defaults to UDP. Keep.
+ * `turn:host:port?transport=udp` → UDP. Keep.
+ * Anything that is not `turn:` or `turns:` (e.g. `stun:`) → Keep.
+ */
+export function isTcpTurnUrl(url: string): boolean {
+  const lower = url.toLowerCase();
+  if (lower.startsWith("turns:")) return true;
+  if (!lower.startsWith("turn:")) return false;
+  return /[?&]transport=tcp\b/.test(lower);
+}
+
+function attachInstanceFilters(pc: RTCPeerConnection): void {
+  const originalSetRemoteDescription = pc.setRemoteDescription.bind(pc);
+  pc.setRemoteDescription = function patchedSetRemoteDescription(
+    description: RTCSessionDescriptionInit,
+  ): Promise<void> {
+    return originalSetRemoteDescription(filterTcpFromSdp(description));
+  } as RTCPeerConnection["setRemoteDescription"];
+
+  const originalAddIceCandidate = pc.addIceCandidate.bind(pc);
+  pc.addIceCandidate = function patchedAddIceCandidate(
+    candidate?: RTCIceCandidateInit | RTCIceCandidate,
+  ): Promise<void> {
+    if (isTcpIceCandidate(candidate)) return Promise.resolve();
+    return originalAddIceCandidate(candidate);
+  } as RTCPeerConnection["addIceCandidate"];
+}
+
+/**
+ * Returns true if the given candidate is a TCP candidate that should be dropped.
+ * Accepts both `RTCIceCandidate` (has `.protocol`) and `RTCIceCandidateInit`
+ * (only has the raw `candidate` string).
+ */
+export function isTcpIceCandidate(candidate: RTCIceCandidate | RTCIceCandidateInit | null | undefined): boolean {
+  if (!candidate) return false;
+  // End-of-candidates marker has empty `candidate` string — leave alone.
+  const candidateString = "candidate" in candidate ? (candidate.candidate ?? "") : "";
+  // Prefer the parsed `.protocol` on real RTCIceCandidate objects.
+  const protocol = (candidate as RTCIceCandidate).protocol;
+  if (typeof protocol === "string") {
+    return protocol.toLowerCase() === "tcp";
+  }
+  if (!candidateString) return false;
+  return isTcpCandidateString(candidateString);
+}
+
+/**
+ * SDP candidate format (RFC 5245):
+ *   `candidate:<foundation> <component> <transport> <priority> <ip> <port> typ <type> ...`
+ * The transport token is the 3rd whitespace-separated field. We only drop when
+ * that token is TCP (case-insensitive), to avoid matching IP/port strings that
+ * coincidentally contain "tcp".
+ */
+export function isTcpCandidateString(candidateLine: string): boolean {
+  // Strip the leading "a=" if present (SDP context) and the "candidate:" prefix.
+  let body = candidateLine.trim();
+  if (body.startsWith("a=")) body = body.slice(2);
+  if (body.startsWith("candidate:")) body = body.slice("candidate:".length);
+  const fields = body.split(/\s+/);
+  if (fields.length < 3) return false;
+  return fields[2].toLowerCase() === "tcp";
+}
+
+/**
+ * Strip TCP `a=candidate:` lines from an SDP description.
+ * Preserves the description's `type` and any other fields; mutates only `sdp`.
+ */
+export function filterTcpFromSdp(description: RTCSessionDescriptionInit): RTCSessionDescriptionInit {
+  if (!description.sdp) return description;
+  const lines = description.sdp.split(/\r?\n/);
+  let dropped = 0;
+  const kept: string[] = [];
+  for (const line of lines) {
+    if (line.startsWith("a=candidate:") && isTcpCandidateString(line)) {
+      dropped += 1;
+      continue;
+    }
+    kept.push(line);
+  }
+  if (dropped === 0) return description;
+  return { ...description, sdp: kept.join("\r\n") };
+}

--- a/packages/sdk/tests/webrtc-ice-filter.unit.test.ts
+++ b/packages/sdk/tests/webrtc-ice-filter.unit.test.ts
@@ -1,0 +1,325 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  filterRtcConfiguration,
+  filterTcpFromSdp,
+  installIceFilter,
+  isTcpCandidateString,
+  isTcpIceCandidate,
+  isTcpTurnUrl,
+} from "../src/realtime/webrtc-ice-filter.js";
+
+describe("isTcpTurnUrl", () => {
+  it("flags turn:?transport=tcp as TCP", () => {
+    expect(isTcpTurnUrl("turn:turn.decart.ai:3478?transport=tcp")).toBe(true);
+  });
+
+  it("flags turns: as TCP (TLS over TCP)", () => {
+    expect(isTcpTurnUrl("turns:turn.decart.ai:443?transport=tcp")).toBe(true);
+    expect(isTcpTurnUrl("turns:turn.decart.ai:5349")).toBe(true);
+  });
+
+  it("keeps turn: with explicit UDP transport", () => {
+    expect(isTcpTurnUrl("turn:35.93.188.1:3478?transport=udp")).toBe(false);
+  });
+
+  it("keeps turn: without explicit transport (defaults to UDP)", () => {
+    expect(isTcpTurnUrl("turn:35.93.188.1:3478")).toBe(false);
+  });
+
+  it("keeps stun: URLs", () => {
+    expect(isTcpTurnUrl("stun:stun.l.google.com:19302")).toBe(false);
+  });
+
+  it("is case-insensitive on scheme + transport", () => {
+    expect(isTcpTurnUrl("TURNS:turn.decart.ai:443")).toBe(true);
+    expect(isTcpTurnUrl("Turn:host:3478?Transport=TCP")).toBe(true);
+  });
+});
+
+describe("isTcpCandidateString", () => {
+  it("flags TCP candidate lines", () => {
+    expect(isTcpCandidateString("candidate:1 1 TCP 1518280447 192.168.1.1 9 typ host tcptype active")).toBe(true);
+  });
+
+  it("flags TCP candidate lines with a= prefix", () => {
+    expect(isTcpCandidateString("a=candidate:1 1 TCP 1518280447 192.168.1.1 9 typ host tcptype active")).toBe(true);
+  });
+
+  it("keeps UDP candidate lines", () => {
+    expect(isTcpCandidateString("candidate:2 1 UDP 2122252543 10.0.0.1 56432 typ host")).toBe(false);
+  });
+
+  it("is case-insensitive on the transport token", () => {
+    expect(isTcpCandidateString("candidate:1 1 tcp 1518280447 192.168.1.1 9 typ host")).toBe(true);
+    expect(isTcpCandidateString("candidate:1 1 udp 2122252543 10.0.0.1 56432 typ host")).toBe(false);
+  });
+
+  it("returns false for malformed strings without transport token", () => {
+    expect(isTcpCandidateString("candidate:foo")).toBe(false);
+    expect(isTcpCandidateString("")).toBe(false);
+  });
+});
+
+describe("isTcpIceCandidate", () => {
+  it("uses RTCIceCandidate.protocol when available", () => {
+    expect(isTcpIceCandidate({ protocol: "tcp" } as RTCIceCandidate)).toBe(true);
+    expect(isTcpIceCandidate({ protocol: "udp" } as RTCIceCandidate)).toBe(false);
+  });
+
+  it("falls back to parsing the candidate string in RTCIceCandidateInit", () => {
+    const tcpInit: RTCIceCandidateInit = {
+      candidate: "candidate:1 1 TCP 1518280447 192.168.1.1 9 typ host tcptype active",
+      sdpMid: "0",
+    };
+    expect(isTcpIceCandidate(tcpInit)).toBe(true);
+    const udpInit: RTCIceCandidateInit = {
+      candidate: "candidate:2 1 UDP 2122252543 10.0.0.1 56432 typ host",
+      sdpMid: "0",
+    };
+    expect(isTcpIceCandidate(udpInit)).toBe(false);
+  });
+
+  it("returns false for end-of-candidates marker (empty candidate string)", () => {
+    expect(isTcpIceCandidate({ candidate: "", sdpMid: "0" })).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isTcpIceCandidate(null)).toBe(false);
+    expect(isTcpIceCandidate(undefined)).toBe(false);
+  });
+});
+
+describe("filterRtcConfiguration", () => {
+  it("drops TURN-TCP and TURNS URLs while keeping UDP ones", () => {
+    const config: RTCConfiguration = {
+      iceServers: [
+        {
+          urls: [
+            "turn:35.93.188.1:3478?transport=udp",
+            "turns:turn.decart.ai:443?transport=tcp",
+            "stun:stun.l.google.com:19302",
+          ],
+          username: "user",
+          credential: "secret",
+        },
+      ],
+    };
+    const filtered = filterRtcConfiguration(config);
+    expect(filtered?.iceServers).toEqual([
+      {
+        urls: ["turn:35.93.188.1:3478?transport=udp", "stun:stun.l.google.com:19302"],
+        username: "user",
+        credential: "secret",
+      },
+    ]);
+  });
+
+  it("flattens single-element urls back to a string", () => {
+    const config: RTCConfiguration = {
+      iceServers: [{ urls: ["turn:host:3478?transport=udp", "turns:host:443"] }],
+    };
+    const filtered = filterRtcConfiguration(config);
+    expect(filtered?.iceServers).toEqual([{ urls: "turn:host:3478?transport=udp" }]);
+  });
+
+  it("drops servers whose URLs are entirely TCP", () => {
+    const config: RTCConfiguration = {
+      iceServers: [{ urls: ["turns:turn.decart.ai:443"] }, { urls: ["turn:35.93.188.1:3478?transport=udp"] }],
+    };
+    const filtered = filterRtcConfiguration(config);
+    expect(filtered?.iceServers).toEqual([{ urls: "turn:35.93.188.1:3478?transport=udp" }]);
+  });
+
+  it("returns the original config unchanged if there are no iceServers", () => {
+    const config: RTCConfiguration = { iceTransportPolicy: "all" };
+    expect(filterRtcConfiguration(config)).toEqual(config);
+  });
+
+  it("returns undefined for undefined input", () => {
+    expect(filterRtcConfiguration(undefined)).toBeUndefined();
+  });
+});
+
+describe("filterTcpFromSdp", () => {
+  const sdp = [
+    "v=0",
+    "o=- 1 2 IN IP4 0.0.0.0",
+    "s=-",
+    "m=video 9 UDP/TLS/RTP/SAVPF 96",
+    "a=candidate:1 1 UDP 2122252543 10.0.0.1 56432 typ host",
+    "a=candidate:2 1 TCP 1518280447 10.0.0.1 9 typ host tcptype active",
+    "a=candidate:3 1 udp 1694498815 1.2.3.4 56432 typ srflx raddr 10.0.0.1 rport 56432",
+    "a=candidate:4 1 tcp 1518214143 1.2.3.4 9 typ srflx raddr 10.0.0.1 rport 9 tcptype passive",
+    "a=end-of-candidates",
+  ].join("\r\n");
+
+  it("removes TCP a=candidate lines and keeps everything else", () => {
+    const result = filterTcpFromSdp({ type: "offer", sdp });
+    expect(result.sdp).toBeDefined();
+    expect(result.sdp).not.toMatch(/candidate:2/);
+    expect(result.sdp).not.toMatch(/candidate:4/);
+    expect(result.sdp).toMatch(/candidate:1 1 UDP/);
+    expect(result.sdp).toMatch(/candidate:3 1 udp/);
+    expect(result.sdp).toMatch(/a=end-of-candidates/);
+  });
+
+  it("returns the input unchanged when there are no TCP candidates", () => {
+    const udpOnly = ["v=0", "a=candidate:1 1 UDP 2122252543 10.0.0.1 56432 typ host"].join("\r\n");
+    const input = { type: "offer" as const, sdp: udpOnly };
+    expect(filterTcpFromSdp(input)).toBe(input);
+  });
+
+  it("returns the input unchanged when sdp is undefined", () => {
+    const input = { type: "offer" as const };
+    expect(filterTcpFromSdp(input)).toBe(input);
+  });
+});
+
+describe("installIceFilter", () => {
+  let originalCtor: typeof RTCPeerConnection | undefined;
+
+  afterEach(() => {
+    // Restore whatever global may have been set up by tests.
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = originalCtor;
+    originalCtor = undefined;
+  });
+
+  it("is a no-op when allowTcp is true", () => {
+    const stubCtor = vi.fn() as unknown as typeof RTCPeerConnection;
+    originalCtor = stubCtor;
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = stubCtor;
+    const release = installIceFilter({ allowTcp: true });
+    expect((globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection).toBe(stubCtor);
+    release(); // should not throw
+  });
+
+  it("is a no-op when RTCPeerConnection is undefined (Node without polyfill)", () => {
+    originalCtor = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+    delete (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+    const release = installIceFilter({ allowTcp: false });
+    expect((globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection).toBeUndefined();
+    release();
+  });
+
+  it("wraps RTCPeerConnection and restores on last release (refcounted)", () => {
+    const stubCtor = vi.fn(function StubPC(this: object, config: RTCConfiguration | undefined) {
+      Object.assign(this, {
+        _config: config,
+        setRemoteDescription: vi.fn(async (_d: RTCSessionDescriptionInit) => {}),
+        addIceCandidate: vi.fn(async (_c?: RTCIceCandidateInit | RTCIceCandidate) => {}),
+      });
+    }) as unknown as typeof RTCPeerConnection;
+    originalCtor = stubCtor;
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = stubCtor;
+
+    const release1 = installIceFilter({ allowTcp: false });
+    const wrapped1 = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+    expect(wrapped1).not.toBe(stubCtor);
+
+    const release2 = installIceFilter({ allowTcp: false });
+    const wrapped2 = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+    expect(wrapped2).toBe(wrapped1); // same wrapper across nested installs
+
+    release1();
+    expect((globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection).toBe(wrapped1); // still wrapped
+    release2();
+    expect((globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection).toBe(stubCtor); // restored
+  });
+
+  it("filters TCP TURN URLs from the constructor config", () => {
+    const seenConfigs: Array<RTCConfiguration | undefined> = [];
+    const stubCtor = vi.fn(function StubPC(this: object, config: RTCConfiguration | undefined) {
+      seenConfigs.push(config);
+      Object.assign(this, {
+        setRemoteDescription: vi.fn(async (_d: RTCSessionDescriptionInit) => {}),
+        addIceCandidate: vi.fn(async (_c?: RTCIceCandidateInit | RTCIceCandidate) => {}),
+      });
+    }) as unknown as typeof RTCPeerConnection;
+    originalCtor = stubCtor;
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = stubCtor;
+
+    const release = installIceFilter({ allowTcp: false });
+    try {
+      const PC = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+      if (!PC) throw new Error("expected wrapped constructor");
+      new PC({
+        iceServers: [
+          {
+            urls: ["turn:host:3478?transport=udp", "turns:host:443?transport=tcp"],
+            username: "u",
+            credential: "c",
+          },
+        ],
+      });
+      expect(seenConfigs).toHaveLength(1);
+      expect(seenConfigs[0]?.iceServers).toEqual([
+        { urls: "turn:host:3478?transport=udp", username: "u", credential: "c" },
+      ]);
+    } finally {
+      release();
+    }
+  });
+
+  it("filters TCP candidates passed to addIceCandidate", async () => {
+    let realAddIceCalls = 0;
+    const stubCtor = vi.fn(function StubPC(this: object) {
+      Object.assign(this, {
+        setRemoteDescription: vi.fn(async (_d: RTCSessionDescriptionInit) => {}),
+        addIceCandidate: vi.fn(async (_c?: RTCIceCandidateInit | RTCIceCandidate) => {
+          realAddIceCalls += 1;
+        }),
+      });
+    }) as unknown as typeof RTCPeerConnection;
+    originalCtor = stubCtor;
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = stubCtor;
+
+    const release = installIceFilter({ allowTcp: false });
+    try {
+      const PC = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+      if (!PC) throw new Error("expected wrapped constructor");
+      const pc = new PC();
+      await pc.addIceCandidate({
+        candidate: "candidate:1 1 TCP 1518280447 1.2.3.4 9 typ host tcptype active",
+        sdpMid: "0",
+      });
+      await pc.addIceCandidate({ candidate: "candidate:2 1 UDP 2122252543 1.2.3.4 56432 typ host", sdpMid: "0" });
+      expect(realAddIceCalls).toBe(1); // only the UDP one passes through
+    } finally {
+      release();
+    }
+  });
+
+  it("filters TCP candidate lines from SDP in setRemoteDescription", async () => {
+    let receivedSdp: string | undefined;
+    const stubCtor = vi.fn(function StubPC(this: object) {
+      Object.assign(this, {
+        setRemoteDescription: vi.fn(async (d: RTCSessionDescriptionInit) => {
+          receivedSdp = d.sdp;
+        }),
+        addIceCandidate: vi.fn(async (_c?: RTCIceCandidateInit | RTCIceCandidate) => {}),
+      });
+    }) as unknown as typeof RTCPeerConnection;
+    originalCtor = stubCtor;
+    (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection = stubCtor;
+
+    const release = installIceFilter({ allowTcp: false });
+    try {
+      const PC = (globalThis as { RTCPeerConnection?: typeof RTCPeerConnection }).RTCPeerConnection;
+      if (!PC) throw new Error("expected wrapped constructor");
+      const pc = new PC();
+      const sdp = [
+        "v=0",
+        "a=candidate:1 1 UDP 2122252543 10.0.0.1 56432 typ host",
+        "a=candidate:2 1 TCP 1518280447 10.0.0.1 9 typ host tcptype active",
+        "a=end-of-candidates",
+      ].join("\r\n");
+      await pc.setRemoteDescription({ type: "offer", sdp });
+      expect(receivedSdp).toBeDefined();
+      expect(receivedSdp).toMatch(/candidate:1 1 UDP/);
+      expect(receivedSdp).not.toMatch(/candidate:2 1 TCP/);
+    } finally {
+      release();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The SDK blocks TCP ICE candidates by default. WebRTC media over TCP suffers from head-of-line blocking that produces visible stalls — UDP-only either works well or fails fast, both of which are better than limping along on TCP.
- Adds `allowTcpIce?: boolean` to `RealTimeClientConnectOptions` and `SubscribeOptions`. Callers who insist on TCP (e.g. enterprise networks where outbound UDP is blocked) opt in by passing `true`.

## Motivation
Last 48h of `livekit-server "participant active" @participant:client-*`:

| Transport | Count | % |
|---|---|---|
| UDP direct | 53,291 | **88.9%** |
| TCP direct (LiveKit `:7881`) | 6,299 | **10.5%** |
| TURN-UDP | 355 | 0.6% |
| TURN-TCP / TLS | 0 | 0% |

Inside the 10.5% TCP-direct slice we sampled 473 sessions and parsed `publisherCandidates`:

- **90.1% had a `udp srflx` candidate** (STUN responded over UDP) — so the client's network does carry UDP. The SFU-specific UDP path failed connectivity checks, and ICE fell back to TCP. The session then carried real-time media under TCP HOL blocking — exactly the choppy-playback pattern reported by customers.
- **Only 4.2% had zero UDP candidates gathered** — these are the clients who genuinely can't do UDP and need TCP/TLS:443 to connect at all. They keep working via `allowTcpIce: true`.

## Implementation
`packages/sdk/src/realtime/webrtc-ice-filter.ts` — pure helpers + a reference-counted install that swaps `globalThis.RTCPeerConnection` for a `Proxy` while a session is open. TCP candidates can reach a PC through three independent paths, so the filter closes each:
1. `RTCConfiguration.iceServers` — strip `?transport=tcp` URLs and any `turns:` (TLS-over-TCP).
2. `setRemoteDescription` SDP — strip `a=candidate:N M TCP ...` lines so the SFU's TCP host candidate is never paired against ours.
3. `addIceCandidate` — drop trickled TCP candidates arriving after the initial SDP.

Threaded through `client.ts` → `stream-session.ts` → `media-channel.ts` (publisher) and directly in `subscribe-client.ts` (subscriber).

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 235/235 passing (22 new unit tests cover URL parsing, candidate-string parsing, SDP filtering, RTCConfiguration filtering, ref-counted install/uninstall, the constructor proxy, `addIceCandidate` filtering, and `setRemoteDescription` SDP munging)
- [x] `pnpm lint` + `pnpm format:check` clean
- [ ] Manual: load `packages/sdk/index.html` against staging, connect, and verify in `chrome://webrtc-internals` that the selected candidate pair is UDP and that no TCP candidates appear in the gathered list.
- [ ] Manual: set `allowTcpIce: true`, confirm TCP candidates reappear (opt-in works).
- [ ] Smoke against the Korean customer's network (tester URL) — expected: UDP succeeds and quality is good, or the connection fails cleanly (no TCP-stall regime).

## Rollout considerations
- **Behavioural change.** Clients whose only viable path was TCP-direct will now fail to connect. Telemetry suggests this is ≤4% of currently-successful sessions; those callers can keep TCP via `allowTcpIce: true`.
- We have zero TURN-TLS adoption in 48h, so dropping `turns:turn.decart.ai:443` from the gathered list doesn't regress any live traffic — but it removes the theoretical "UDP blocked everywhere → TURN-TLS:443" fallback for callers who don't pass `allowTcpIce: true`.
- The patch monkey-patches `globalThis.RTCPeerConnection` — apps embedding this SDK alongside their own WebRTC code will see the patch active during a realtime session. The ref count restores the original constructor when the last session disconnects.
- The right *belt* for this *braces* is a LiveKit-side change (`livekit.rtc.tcp_port: 0` on the server) so old SDK versions and other clients also stop seeing the SFU's TCP host candidate. This SDK change protects new builds and gives callers the per-session `allowTcpIce` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)