### PR TITLE
fix: Play remote audio and video through a single media element

### DIFF
--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -82,13 +82,19 @@ export class MediaChannel {
       if (!participant.identity.startsWith(REALTIME_CONFIG.livekit.inferenceServerIdentityPrefix)) return;
       if (track.kind !== Track.Kind.Video && track.kind !== Track.Kind.Audio) return;
 
-      track.attach();
       const mediaStreamTrack = track.mediaStreamTrack;
       if (mediaStreamTrack) {
-        this.remoteStream ??= new MediaStream();
-        if (!this.remoteStream.getTracks().includes(mediaStreamTrack)) {
-          this.remoteStream.addTrack(mediaStreamTrack);
+        // Emit a fresh MediaStream whenever the track set changes. Consumers
+        // assign this to an element's `srcObject`; mutating the existing stream
+        // in place would not work because assigning the same MediaStream
+        // reference is a no-op and a late-arriving audio track would never get
+        // an output sink. A new object forces the element to re-read its tracks,
+        // so a single <video> element plays both video and audio.
+        const tracks = this.remoteStream?.getTracks() ?? [];
+        if (!tracks.includes(mediaStreamTrack)) {
+          tracks.push(mediaStreamTrack);
         }
+        this.remoteStream = new MediaStream(tracks);
         this.events.emit("remoteStream", this.remoteStream);
       }
       track.on(TrackEvent.VideoPlaybackStarted, () => {

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -5,7 +5,6 @@ import {
   Room,
   RoomEvent,
   Track,
-  TrackEvent,
   type TrackPublishOptions,
 } from "livekit-client";
 import mitt, { type Emitter } from "mitt";
@@ -36,7 +35,6 @@ export function getDefaultVideoPublishOptions(videoCodec?: VideoCodec): TrackPub
 
 export type MediaChannelEvents = {
   remoteStream: MediaStream;
-  firstFrame: undefined;
   disconnected: { reason?: DisconnectReason };
 };
 
@@ -97,9 +95,6 @@ export class MediaChannel {
         this.remoteStream = new MediaStream(tracks);
         this.events.emit("remoteStream", this.remoteStream);
       }
-      track.on(TrackEvent.VideoPlaybackStarted, () => {
-        this.events.emit("firstFrame");
-      });
     });
 
     room.on(RoomEvent.Disconnected, (reason?: DisconnectReason) => {

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -29,6 +29,7 @@ export type RoomInfo = {
 
 export type SignalingChannelEvents = {
   queuePosition: QueuePosition;
+  generationStarted: undefined;
   generationTick: GenerationTick;
   generationEnded: GenerationEnded;
   serverError: Error;
@@ -366,6 +367,9 @@ export class SignalingChannel {
           position: msg.position,
           queueSize: msg.queue_size,
         });
+        break;
+      case "generation_started":
+        this.events.emit("generationStarted");
         break;
       case "generation_tick":
         this.events.emit("generationTick", { seconds: msg.seconds });

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -255,17 +255,25 @@ export class StreamSession {
       this.queue = qp;
       this.events.emit("queuePosition", qp);
     });
-    this.signaling.on("generationTick", (e) => this.events.emit("generationTick", e));
+    // The server signals generation start over the websocket. `generation_started`
+    // fires immediately when generation begins; the first `generation_tick` is a
+    // later fallback in case that message is ever absent.
+    this.signaling.on("generationStarted", () => this.markGenerating());
+    this.signaling.on("generationTick", (e) => {
+      this.markGenerating();
+      this.events.emit("generationTick", e);
+    });
     this.signaling.on("generationEnded", (e) => this.events.emit("generationEnded", e));
     this.signaling.on("serverError", (err) => this.events.emit("error", err));
     this.signaling.on("closed", (info) => this.handleConnectionLoss({ source: "signaling", ...info }));
   }
 
+  private markGenerating(): void {
+    if (this.state === "connected") this.setState("generating");
+  }
+
   private wireMediaEvents(): void {
     this.media.on("remoteStream", (stream) => this.events.emit("remoteStream", stream));
-    this.media.on("firstFrame", () => {
-      if (this.state === "connected") this.setState("generating");
-    });
     this.media.on("disconnected", (info) => this.handleConnectionLoss({ source: "media", reason: info.reason }));
   }
 

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -149,13 +149,17 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
         if (!participant.identity.startsWith(REALTIME_CONFIG.livekit.inferenceServerIdentityPrefix)) return;
         if (track.kind !== Track.Kind.Video && track.kind !== Track.Kind.Audio) return;
 
-        track.attach();
         const mediaStreamTrack = track.mediaStreamTrack;
         if (!mediaStreamTrack) return;
-        remoteStream ??= new MediaStream();
-        if (!remoteStream.getTracks().includes(mediaStreamTrack)) {
-          remoteStream.addTrack(mediaStreamTrack);
+        // Emit a fresh MediaStream whenever the track set changes so the
+        // consumer's element re-reads its tracks (assigning the same reference
+        // is a no-op, leaving a late-arriving audio track without a sink). A
+        // single <video> element then plays both video and audio.
+        const tracks = remoteStream?.getTracks() ?? [];
+        if (!tracks.includes(mediaStreamTrack)) {
+          tracks.push(mediaStreamTrack);
         }
+        remoteStream = new MediaStream(tracks);
         options.onRemoteStream(remoteStream);
       });
 

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -41,6 +41,10 @@ export type GenerationEndedMessage = GenerationEnded & {
   type: "generation_ended";
 };
 
+export type GenerationStartedMessage = {
+  type: "generation_started";
+};
+
 export type LiveKitJoinMessage = {
   type: "livekit_join";
 };
@@ -126,6 +130,7 @@ export type IncomingRealtimeMessage =
   | SetImageAckMessage
   | GenerationTickMessage
   | GenerationEndedMessage
+  | GenerationStartedMessage
   | LiveKitRoomInfoMessage
   | QueuePositionMessage;
 

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -814,6 +814,61 @@ describe("StreamSession startup orchestration", () => {
     expect(states).toEqual(["connecting", "connected"]);
   });
 
+  it("transitions to generating on generation_started over the websocket", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({
+      url: "wss://example.test/realtime",
+      localStream: null,
+      initialPrompt: { text: "wear a hat", enhance: false },
+    });
+    const states: string[] = [];
+    session.on("connectionChange", (state) => states.push(state));
+
+    const connectPromise = session.connect();
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await flushMicrotasks();
+    sendRoomInfo(ws);
+    await flushMicrotasks();
+
+    ws.receive({ type: "prompt_ack", prompt: "wear a hat", success: true, error: null });
+    await expect(connectPromise).resolves.toBeUndefined();
+    expect(states).toEqual(["connecting", "connected"]);
+
+    ws.receive({ type: "generation_started" });
+    expect(states).toEqual(["connecting", "connected", "generating"]);
+    expect(session.getConnectionState()).toBe("generating");
+
+    // Subsequent ticks must not re-emit the transition.
+    ws.receive({ type: "generation_tick", seconds: 5 });
+    expect(states).toEqual(["connecting", "connected", "generating"]);
+  });
+
+  it("transitions to generating on the first generation_tick as a fallback", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({
+      url: "wss://example.test/realtime",
+      localStream: null,
+      initialPrompt: { text: "wear a hat", enhance: false },
+    });
+    const states: string[] = [];
+    session.on("connectionChange", (state) => states.push(state));
+
+    const connectPromise = session.connect();
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await flushMicrotasks();
+    sendRoomInfo(ws);
+    await flushMicrotasks();
+
+    ws.receive({ type: "prompt_ack", prompt: "wear a hat", success: true, error: null });
+    await expect(connectPromise).resolves.toBeUndefined();
+    expect(states).toEqual(["connecting", "connected"]);
+
+    ws.receive({ type: "generation_tick", seconds: 5 });
+    expect(states).toEqual(["connecting", "connected", "generating"]);
+  });
+
   it("emits remoteStream before caller initial-state ack while connect remains pending", async () => {
     const { StreamSession } = await import("../src/realtime/stream-session.js");
     const session = new StreamSession({


### PR DESCRIPTION
## What

Remote realtime streams now deliver audio and video as one `MediaStream` that a host app can render through a single `<video>` element it owns and controls — both play together, with the app in full control of the playback element. The `"generating"` connection state is now reported reliably, driven by the server's generation signal rather than as a side effect of internal playback.

## Why

Previously remote audio only played because the SDK silently spun up its own hidden media elements, leaving apps with no handle on playback (volume, sink device, muting, lifecycle), and a late-arriving audio track could be dropped entirely. Handing the app a single stream resolves both. Removing those hidden elements also meant the `connected → generating` transition (which had been a side effect of internal video playback) no longer fired, so it's now tied to the server's `generation_started` signal — the same approach used before the move to LiveKit — making the state both correct and decoupled from rendering.

No public API changed — `onRemoteStream` still receives a `MediaStream`, and `onConnectionChange` still reports the same states.