### PR TITLE
feat(batch): remove 1000-char prompt limit for v2v models

### DIFF
--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -187,7 +187,7 @@ const v2vResolutionSchema = z
   .default("720p");
 
 const videoEditSchema = z.object({
-  prompt: z.string().min(1).max(1000).describe("The prompt to use for the generation"),
+  prompt: z.string().min(1).describe("The prompt to use for the generation"),
   data: fileInputSchema.describe(
     "The video data to use for generation (File, Blob, ReadableStream, URL, or string URL). Output video is limited to 5 seconds.",
   ),
@@ -216,7 +216,7 @@ const imageEditSchema = z.object({
 
 const restyleSchema = z
   .object({
-    prompt: z.string().min(1).max(1000).optional().describe("Text prompt for the video editing"),
+    prompt: z.string().min(1).optional().describe("Text prompt for the video editing"),
     reference_image: fileInputSchema
       .optional()
       .describe("Reference image to transform into a prompt (File, Blob, ReadableStream, URL, or string URL)"),
@@ -236,10 +236,7 @@ const restyleSchema = z
   });
 
 const videoEdit2Schema = z.object({
-  prompt: z
-    .string()
-    .max(1000)
-    .describe("Text prompt for the video editing. Send an empty string if you want no text prompt."),
+  prompt: z.string().describe("Text prompt for the video editing. Send an empty string if you want no text prompt."),
   reference_image: fileInputSchema
     .optional()
     .describe("Optional reference image to guide the edit (File, Blob, ReadableStream, URL, or string URL)"),


### PR DESCRIPTION
## What

Removes the `.max(1000)` prompt cap from the batch (`client.process`) v2v schemas:

- `videoEditSchema` — `lucy-clip`, `lucy-pro-v2v`
- `restyleSchema` — `lucy-restyle-2`, `lucy-restyle-v2v`
- `videoEdit2Schema` — `lucy-2.1`, `lucy-2.1-vton`, `lucy-vton-2`

`.min(1)` (and the empty-string allowance on `videoEdit2Schema`) is preserved — only the upper bound is removed.

## Out of scope

- **Image-to-image** (`imageEditSchema`, e.g. `lucy-image-2` / `lucy-pro-i2i`) keeps its 1000-char cap. Its unit test is unchanged and still passes.
- Realtime already had no client-side cap.

## Notes

Any remaining length enforcement happens server-side. This change only relaxes client-side validation.

## Testing

- `pnpm test` — 206 passed
- `pnpm typecheck` — clean
- `pnpm format:check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Zod relaxation for batch v2v prompts; image caps and server validation are unchanged.
> 
> **Overview**
> Removes the **1000-character upper bound** on `prompt` in the SDK’s batch video-to-video Zod schemas (`videoEditSchema`, `restyleSchema`, `videoEdit2Schema` in `model.ts`), so `client.process` no longer rejects longer prompts before the request is sent.
> 
> **Unchanged:** `.min(1)` where it applied, optional/empty-string behavior on `videoEdit2Schema`, and the **image** path (`imageEditSchema` still uses `.max(1000)`). Any length limits after submit remain **server-side** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9698dae63627f19509c723f11fdd8475e7e9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->