### PR TITLE
feat(realtime): connectivity detection — preflight check + live quality

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -200,6 +200,8 @@
             background: #f8f9fa;
             border-radius: 4px;
             border-left: 3px solid #ddd;
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
         }
         
         .log-error {
@@ -292,6 +294,11 @@
             <span id="status-indicator" class="status-indicator status-disconnected"></span>
             <span id="status-text">Disconnected</span>
         </div>
+        <div id="connection-quality-row" style="display: none; margin-top: 10px;">
+            <strong>Connection Quality:</strong>
+            <span id="connection-quality-badge" style="display: inline-block; padding: 2px 10px; border-radius: 12px; color: #fff; font-weight: bold; font-size: 12px;">-</span>
+            <span id="connection-quality-detail" style="font-family: 'Courier New', monospace; font-size: 12px; color: #555; margin-left: 8px;"></span>
+        </div>
         <div id="session-info" style="display: none; margin-top: 10px; font-family: 'Courier New', monospace; font-size: 14px;">
             <strong>Session ID:</strong> <span id="session-id-text">-</span>
         </div>
@@ -375,6 +382,22 @@
             <button id="start-camera">Start Camera</button>
             <button id="connect-btn" disabled>Connect to Decart</button>
             <button id="disconnect-btn" disabled>Disconnect</button>
+        </div>
+    </div>
+
+    <!-- Connectivity Check (Preflight) -->
+    <div class="controls">
+        <h3>Connectivity Check (Preflight)</h3>
+        <p style="margin: 0 0 10px 0; font-size: 12px; color: #666;">
+            SDK-only WebRTC reachability + latency probe — no session, no inference. Use it to decide whether to show the integration <em>before</em> connecting. Needs an API key above (the client factory requires one), but the probe itself only hits public STUN.
+        </p>
+        <div class="inline-controls">
+            <button id="check-connectivity-btn">Check Connectivity</button>
+        </div>
+        <div id="connectivity-result" style="margin-top: 10px; padding: 10px 12px; border-radius: 6px; display: none; background: #f8f9fa;">
+            <div style="font-size: 15px; font-weight: bold;" id="connectivity-headline">-</div>
+            <div style="margin-top: 6px; font-family: 'Courier New', monospace; font-size: 12px; color: #333;" id="connectivity-metrics"></div>
+            <ul id="connectivity-reasons" style="margin: 8px 0 0 0; padding-left: 18px; font-size: 12px; color: #555;"></ul>
         </div>
     </div>
 
@@ -599,6 +622,16 @@
             subscribeTokenInput: document.getElementById('subscribe-token-input'),
             subscribeBtn: document.getElementById('subscribe-btn'),
             logsContainer: document.getElementById('logs-container'),
+            // Connection quality (in-session) elements
+            connectionQualityRow: document.getElementById('connection-quality-row'),
+            connectionQualityBadge: document.getElementById('connection-quality-badge'),
+            connectionQualityDetail: document.getElementById('connection-quality-detail'),
+            // Connectivity preflight elements
+            checkConnectivityBtn: document.getElementById('check-connectivity-btn'),
+            connectivityResult: document.getElementById('connectivity-result'),
+            connectivityHeadline: document.getElementById('connectivity-headline'),
+            connectivityMetrics: document.getElementById('connectivity-metrics'),
+            connectivityReasons: document.getElementById('connectivity-reasons'),
             // Image reference elements
             referenceImage: document.getElementById('reference-image'),
             setImage: document.getElementById('send-image'),
@@ -724,6 +757,85 @@
             elements.statusIndicator.className = `status-indicator ${statusClass[status] || statusClass.disconnected}`;
             elements.statusText.textContent = status.charAt(0).toUpperCase() + status.slice(1);
         }
+
+        // ---------- Connection quality (in-session) ----------
+        const QUALITY_COLORS = { good: '#4CAF50', fair: '#c9a227', poor: '#ff9800', critical: '#f44336' };
+
+        function updateConnectionQuality(report) {
+            elements.connectionQualityRow.style.display = 'block';
+            elements.connectionQualityBadge.style.background = QUALITY_COLORS[report.quality] ?? '#777';
+            elements.connectionQualityBadge.textContent =
+                report.quality.toUpperCase() + (report.warmingUp ? ' (warming up)' : '');
+
+            const m = report.metrics;
+            const parts = [];
+            if (report.limitingFactor && report.limitingFactor !== 'none') parts.push(`limited by ${report.limitingFactor}`);
+            if (m.rttMs != null) parts.push(`rtt ${Math.round(m.rttMs)}ms`);
+            if (m.fps != null) parts.push(`${Math.round(m.fps)}fps`);
+            if (m.packetLoss != null) parts.push(`loss ${(m.packetLoss * 100).toFixed(1)}%`);
+            if (m.availableUpstreamKbps != null) parts.push(`↑avail ${Math.round(m.availableUpstreamKbps)}kbps`);
+            elements.connectionQualityDetail.textContent = parts.join('  ·  ');
+        }
+
+        function resetConnectionQuality() {
+            elements.connectionQualityRow.style.display = 'none';
+            elements.connectionQualityBadge.textContent = '-';
+            elements.connectionQualityBadge.style.background = '#777';
+            elements.connectionQualityDetail.textContent = '';
+        }
+
+        // ---------- Connectivity preflight ----------
+        // The SDK reports a quality state; the app decides what to do with it.
+        const CONNECTIVITY_STYLE = {
+            good: { bg: '#e8f5e8', color: '#2e7d32', label: '✅ Good — connection looks ready', log: 'success' },
+            fair: { bg: '#fff8e1', color: '#b8860b', label: '⚠️ Fair — usable, with caveats', log: 'info' },
+            poor: { bg: '#fff3e0', color: '#e65100', label: '⚠️ Poor — connection is degraded', log: 'info' },
+            critical: { bg: '#ffebee', color: '#c62828', label: '⛔ Critical — cannot establish a connection', log: 'error' },
+        };
+
+        async function runConnectivityCheck() {
+            const client = ensureDecartClient();
+            if (!client) return;
+
+            try {
+                elements.checkConnectivityBtn.disabled = true;
+                elements.connectivityResult.style.display = 'block';
+                elements.connectivityResult.style.background = '#f8f9fa';
+                elements.connectivityHeadline.style.color = '#333';
+                elements.connectivityHeadline.textContent = '⏳ Probing network…';
+                elements.connectivityMetrics.textContent = '';
+                elements.connectivityReasons.innerHTML = '';
+                addLog('Running connectivity preflight…', 'info');
+
+                const report = await client.realtime.checkConnectivity();
+
+                const style = CONNECTIVITY_STYLE[report.quality] ?? CONNECTIVITY_STYLE.fair;
+                elements.connectivityResult.style.background = style.bg;
+                elements.connectivityHeadline.style.color = style.color;
+                elements.connectivityHeadline.textContent = style.label;
+
+                const m = report.metrics;
+                elements.connectivityMetrics.textContent =
+                    `quality=${report.quality}   transport=${m.transport}   rtt=${m.rttMs != null ? `${m.rttMs}ms` : 'n/a'}`;
+
+                elements.connectivityReasons.innerHTML = '';
+                for (const reason of report.reasons) {
+                    const li = document.createElement('li');
+                    li.textContent = reason;
+                    elements.connectivityReasons.appendChild(li);
+                }
+
+                addLog(`checkConnectivity() →\n${JSON.stringify(report, null, 2)}`, style.log);
+            } catch (error) {
+                elements.connectivityHeadline.style.color = '#c62828';
+                elements.connectivityHeadline.textContent = `❌ Probe failed: ${error.message ?? error}`;
+                addLog(`Connectivity check failed: ${error.message ?? error}`, 'error');
+            } finally {
+                elements.checkConnectivityBtn.disabled = false;
+            }
+        }
+
+        elements.checkConnectivityBtn.addEventListener('click', runConnectivityCheck);
 
         function syncPublisherSubscribeToken() {
             if (activeConnectionMode !== 'publisher' || !decartRealtime?.getSubscribeToken) {
@@ -869,7 +981,8 @@
                 elements.connectBtn.disabled = true;
                 elements.subscribeBtn.disabled = true;
                 activeConnectionMode = 'publisher';
-                
+                resetConnectionQuality();
+
                 addLog('Initializing Decart client...', 'info');
                 
                 const realtimeBaseUrl = elements.realtimeBaseUrl.value.trim();
@@ -922,6 +1035,13 @@
                     },
                     onQueuePosition: (queuePosition) => {
                         addLog(`Queue position: ${queuePosition.position}/${queuePosition.queueSize}`, 'info');
+                    },
+                    onConnectionQuality: (report) => {
+                        updateConnectionQuality(report);
+                        addLog(
+                            `onConnectionQuality →\n${JSON.stringify(report, null, 2)}`,
+                            report.quality === 'poor' || report.quality === 'critical' ? 'error' : 'info',
+                        );
                     },
                     initialState: {
                         ...(promptValue && { prompt: promptValue }),
@@ -1102,6 +1222,7 @@
             elements.referenceImage.value = '';
             elements.imageStatus.style.display = 'none';
             elements.imagePreview.style.display = 'none';
+            resetConnectionQuality();
             updateUseRefAsImageBtnState();
 
             addLog('Disconnected successfully', 'info');

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@ import { createFilesClient } from "./files/client";
 import { createProcessClient } from "./process/client";
 import { createQueueClient } from "./queue/client";
 import { createRealTimeClient } from "./realtime/client";
+import { createPreflight } from "./realtime/preflight";
 import { createRealTimeSubscribeClient } from "./realtime/subscribe-client";
 import { createTokensClient } from "./tokens/client";
 import { readEnv } from "./utils/env";
@@ -30,6 +31,12 @@ export type {
 } from "./realtime/client";
 export type { SetInput } from "./realtime/methods";
 export type {
+  ConnectionQuality,
+  ConnectionQualityLimitingFactor,
+  ConnectionQualityMetrics,
+  ConnectionQualityReport,
+} from "./realtime/observability/connection-quality";
+export type {
   ClientSessionConnectionBreakdownEvent,
   ClientSessionConnectionBreakdownPhase,
   DiagnosticEvent,
@@ -39,6 +46,12 @@ export type {
   VideoStallEvent,
 } from "./realtime/observability/diagnostics";
 export type { WebRTCStats } from "./realtime/observability/webrtc-stats";
+export type {
+  CheckConnectivityOptions,
+  ConnectivityMetrics,
+  ConnectivityReport,
+  ConnectivityTransport,
+} from "./realtime/preflight";
 export type {
   RealTimeSubscribeClient,
   SubscribeEvents,
@@ -210,6 +223,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
     integration,
     logger,
   });
+  const preflight = createPreflight({ logger });
 
   const process = createProcessClient({
     baseUrl,
@@ -239,6 +253,19 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
     realtime: {
       connect: realtimePublish.connect,
       subscribe: realtimeSubscribe.subscribe,
+      /**
+       * Check whether the user's network can support a real-time session
+       * *before* connecting — so you can gate showing the integration.
+       * SDK-only: validates WebRTC reachability (UDP egress / TURN need) and
+       * latency via a throwaway peer connection. Does not start a session.
+       *
+       * @example
+       * ```ts
+       * const { quality, reasons } = await client.realtime.checkConnectivity();
+       * if (quality === "critical") showFallbackUI(reasons); // your call what counts as "adequate"
+       * ```
+       */
+      checkConnectivity: preflight.checkConnectivity,
     },
 
     /**

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -15,6 +15,7 @@ import { createEventBuffer } from "./event-buffer";
 import type { VideoCodec } from "./media-channel";
 import { realtimeMethods, type SetInput } from "./methods";
 import { createMirroredStream, type MirroredStream, shouldMirrorTrack } from "./mirror-stream";
+import type { ConnectionQualityReport } from "./observability/connection-quality";
 import type { DiagnosticEvent } from "./observability/diagnostics";
 import { RealtimeObservability } from "./observability/realtime-observability";
 import type { WebRTCStats } from "./observability/webrtc-stats";
@@ -32,6 +33,7 @@ export type RealTimeClientOptions = {
 const realTimeClientInitialStateSchema = modelStateSchema;
 type OnRemoteStreamFn = (stream: MediaStream) => void;
 type OnConnectionChangeFn = (state: ConnectionState) => void;
+type OnConnectionQualityFn = (report: ConnectionQualityReport) => void;
 type OnQueuePositionFn = (queuePosition: QueuePosition) => void;
 export type RealTimeClientInitialState = z.infer<typeof realTimeClientInitialStateSchema>;
 
@@ -43,6 +45,11 @@ const realTimeClientConnectOptionsSchema = z.object({
   onConnectionChange: z
     .custom<OnConnectionChangeFn>((val) => typeof val === "function", {
       message: "onConnectionChange must be a function",
+    })
+    .optional(),
+  onConnectionQuality: z
+    .custom<OnConnectionQualityFn>((val) => typeof val === "function", {
+      message: "onConnectionQuality must be a function",
     })
     .optional(),
   onQueuePosition: z
@@ -63,6 +70,7 @@ export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientCon
 
 export type Events = {
   connectionChange: ConnectionState;
+  connectionQuality: ConnectionQualityReport;
   queuePosition: QueuePosition;
   error: DecartSDKError;
   generationTick: GenerationTick;
@@ -76,6 +84,8 @@ export type RealTimeClient = {
   setPrompt: (prompt: string, { enhance }?: { enhance?: boolean }) => Promise<void>;
   isConnected: () => boolean;
   getConnectionState: () => ConnectionState;
+  /** Latest interpreted connection-quality verdict, or null before any stats arrive. */
+  getConnectionQuality: () => ConnectionQualityReport | null;
   disconnect: () => void;
   on: <K extends keyof Events>(event: K, listener: (data: Events[K]) => void) => void;
   off: <K extends keyof Events>(event: K, listener: (data: Events[K]) => void) => void;
@@ -102,8 +112,15 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
     const parsedOptions = realTimeClientConnectOptionsSchema.safeParse(options);
     if (!parsedOptions.success) throw parsedOptions.error;
 
-    const { onRemoteStream, onConnectionChange, onQueuePosition, initialState, resolution, preferredVideoCodec } =
-      parsedOptions.data;
+    const {
+      onRemoteStream,
+      onConnectionChange,
+      onConnectionQuality,
+      onQueuePosition,
+      initialState,
+      resolution,
+      preferredVideoCodec,
+    } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
     let inputStream: MediaStream = stream ?? new MediaStream();
 
@@ -146,6 +163,10 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         logger,
         onDiagnostic: (event) => emitOrBuffer("diagnostic", event),
         onStats: (stats) => emitOrBuffer("stats", stats),
+        onConnectionQuality: (report) => {
+          emitOrBuffer("connectionQuality", report);
+          onConnectionQuality?.(report);
+        },
       });
 
       const safariCodec = isDesktopSafari() ? "vp8" : undefined;
@@ -209,6 +230,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         ...methods,
         isConnected: () => activeSession.isConnected(),
         getConnectionState: () => activeSession.getConnectionState(),
+        getConnectionQuality: () => observability?.getConnectionQuality() ?? null,
         disconnect: () => {
           observability?.stop();
           stop();

--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -43,5 +43,47 @@ export const REALTIME_CONFIG = {
     telemetryReportIntervalMs: 10_000,
     telemetryUrl: "https://platform.decart.ai/api/v1/telemetry",
     telemetryMaxItemsPerReport: 120,
+    /**
+     * Thresholds for the derived in-session connection-quality signal
+     * (see observability/connection-quality.ts). Tuned for a camera-up
+     * real-time pipeline (~3–3.5 Mbps upstream, model fps ~25–30). All
+     * values are tunable here so behaviour can change without code edits.
+     */
+    connectionQuality: {
+      /** Rolling-window size used to smooth raw per-sample metrics. */
+      windowSamples: 5,
+      /**
+       * Samples to wait before the bitrate dimensions count — the encoder
+       * and BWE ramp for several seconds after connect, so early low
+       * bitrate is not a slow network. RTT/loss/stall start scoring sooner.
+       * `decart-try-on` waits 30 samples watching inbound bitrate alone.
+       */
+      warmupSamples: 8,
+      /** Consecutive worse samples required before the level downgrades. */
+      downgradeConsecutive: 5,
+      /** Consecutive better samples required before the level upgrades (recover slow). */
+      upgradeConsecutive: 5,
+      /** Round-trip time bands (ms). Bands widen by relayExtraMs on TURN-relayed paths. */
+      rtt: { goodMs: 150, fairMs: 300, poorMs: 500, relayExtraMs: 100 },
+      /** Fraction of outbound packets the server reports lost (0..1). */
+      loss: { good: 0.02, fair: 0.05, poor: 0.1 },
+      /** Upstream headroom = available BWE ÷ the intended publish bitrate (requiredUpstreamKbps). */
+      upstream: { goodRatio: 1.0, fairRatio: 0.8, poorRatio: 0.5, requiredUpstreamKbps: 3500 },
+      /** Rendered (inbound) frames-per-second. */
+      stall: { goodFps: 20, fairFps: 12, poorFps: 5 },
+    },
+  },
+  /**
+   * SDK-only preflight (see preflight.ts). Validates WebRTC reachability
+   * (does UDP egress work / will the path need TURN) and latency via a
+   * throwaway RTCPeerConnection — no backend session, no media server.
+   */
+  preflight: {
+    /** Public STUN servers used to gather server-reflexive candidates. */
+    defaultStunUrls: ["stun:stun.l.google.com:19302"],
+    /** Abort candidate gathering after this long. */
+    iceGatherTimeoutMs: 5_000,
+    /** RTT bands (ms) for the preflight verdict. */
+    rtt: { goodMs: 150, marginalMs: 300 },
   },
 } as const;

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -4,6 +4,10 @@ import type { WebRTCStats } from "./webrtc-stats";
 /**
  * Smoothed verdict on whether the connection is good enough for the realtime
  * pipeline, derived from the raw `WebRTCStats` the SDK already collects.
+ *
+ * Note: the bandwidth dimension relies on Chromium-only stats
+ * (`availableOutgoingBitrate`), so on Safari/Firefox the verdict reflects
+ * latency, loss, and fps only.
  */
 export type ConnectionQuality = "good" | "fair" | "poor" | "critical";
 
@@ -18,7 +22,7 @@ export type ConnectionQualityMetrics = {
   fps: number | null;
   /** Fraction (0–1) of our outbound packets the server reports lost, or null until measured. */
   packetLoss: number | null;
-  /** Estimated available upstream bandwidth in kbps, or null until measured. */
+  /** Estimated available upstream bandwidth in kbps. Chromium-only — null on Safari/Firefox. */
   availableUpstreamKbps: number | null;
 };
 

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -1,0 +1,366 @@
+import { REALTIME_CONFIG } from "../config-realtime";
+import type { WebRTCStats } from "./webrtc-stats";
+
+/**
+ * Interpreted, smoothed verdict on whether the user's connection is good
+ * enough for the real-time camera-up pipeline. Derived entirely from the
+ * raw `WebRTCStats` the SDK already collects — no new transport or polling.
+ *
+ * "good" — show normally · "fair" — usable, optional subtle warning ·
+ * "poor" — degraded, prominent warning · "critical" — effectively unusable.
+ */
+export type ConnectionQuality = "good" | "fair" | "poor" | "critical";
+
+/** Which dimension pulled the verdict down to its current level. */
+export type ConnectionQualityLimitingFactor =
+  | "bandwidth" // upstream BWE below need, encoder bandwidth-limited, or low inbound bitrate
+  | "latency" // RTT too high
+  | "loss" // server reports too many of our packets lost
+  | "stall" // rendered stream froze / fps collapsed
+  | "cpu" // encoder CPU-limited (a device issue, never drags quality down)
+  | "none"; // nothing limiting
+
+/**
+ * The human-meaningful numbers behind the verdict — one per scored dimension
+ * (`rttMs`→latency, `packetLoss`→loss, `fps`→stall, `availableUpstreamKbps`→
+ * bandwidth). For the full raw WebRTC firehose, subscribe to the `stats` event.
+ */
+export type ConnectionQualityMetrics = {
+  /** Round-trip time in ms, or null until measured. */
+  rttMs: number | null;
+  /** Rendered (inbound) frames per second, or null until measured. */
+  fps: number | null;
+  /** Fraction (0–1) of our outbound packets the server reports lost, or null until measured. */
+  packetLoss: number | null;
+  /** Estimated available upstream bandwidth in kbps, or null until measured. */
+  availableUpstreamKbps: number | null;
+};
+
+export type ConnectionQualityReport = {
+  quality: ConnectionQuality;
+  limitingFactor: ConnectionQualityLimitingFactor;
+  /** True while the connection ramps; the verdict is provisional (see warmupSamples). */
+  warmingUp: boolean;
+  metrics: ConnectionQualityMetrics;
+};
+
+export type ConnectionQualityThresholds = {
+  windowSamples: number;
+  warmupSamples: number;
+  downgradeConsecutive: number;
+  upgradeConsecutive: number;
+  rtt: { goodMs: number; fairMs: number; poorMs: number; relayExtraMs: number };
+  loss: { good: number; fair: number; poor: number };
+  upstream: { goodRatio: number; fairRatio: number; poorRatio: number; requiredUpstreamKbps: number };
+  stall: { goodFps: number; fairFps: number; poorFps: number };
+};
+
+const RANK: Record<ConnectionQuality, number> = { critical: 0, poor: 1, fair: 2, good: 3 };
+
+/** Worst (lowest-rank) of the given qualities. */
+function worst(...qualities: ConnectionQuality[]): ConnectionQuality {
+  return qualities.reduce((a, b) => (RANK[a] <= RANK[b] ? a : b));
+}
+
+/** Score a metric where lower is better (RTT, loss). `null` → "good" (absence of evidence ≠ bad). */
+function scoreLowerBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
+  if (value === null) return "good";
+  if (value <= good) return "good";
+  if (value <= fair) return "fair";
+  if (value <= poor) return "poor";
+  return "critical";
+}
+
+/** Score a metric where higher is better (bitrate, fps). `null` → "good". */
+function scoreHigherBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
+  if (value === null) return "good";
+  if (value >= good) return "good";
+  if (value >= fair) return "fair";
+  if (value >= poor) return "poor";
+  return "critical";
+}
+
+/**
+ * Full set of raw signals the scorer needs (internal). The public report
+ * exposes only a human-meaningful subset; everything here is also on `stats`.
+ */
+type QualitySignals = {
+  rttMs: number | null;
+  fractionLost: number | null;
+  availableOutgoingKbps: number | null;
+  fps: number | null;
+  freezeCountDelta: number | null;
+  qualityLimitationReason: string | null;
+  isRelayed: boolean;
+};
+
+/** Pull the scoring-relevant signals out of a raw stats snapshot. */
+function extractSignals(stats: WebRTCStats): QualitySignals {
+  const rttSec = stats.remoteInbound?.roundTripTime ?? stats.connection.currentRoundTripTime;
+  const isRelayed = stats.connection.selectedCandidatePairs.some(
+    (pair) => pair.local.candidateType === "relay" || pair.remote.candidateType === "relay",
+  );
+
+  return {
+    rttMs: rttSec != null ? rttSec * 1000 : null,
+    fractionLost: stats.remoteInbound?.fractionLost ?? null,
+    availableOutgoingKbps:
+      stats.connection.availableOutgoingBitrate != null ? stats.connection.availableOutgoingBitrate / 1000 : null,
+    fps: stats.video?.framesPerSecond ?? null,
+    freezeCountDelta: stats.video?.freezeCountDelta ?? null,
+    qualityLimitationReason: stats.outboundVideo?.qualityLimitationReason ?? null,
+    isRelayed,
+  };
+}
+
+type ScoreOptions = {
+  /** Skip the bandwidth dimension while the connection is still ramping. */
+  skipBitrate?: boolean;
+};
+
+/** Score an already-extracted (optionally smoothed) signal set. Pure. */
+export function scoreMetrics(
+  signals: QualitySignals,
+  thresholds: ConnectionQualityThresholds,
+  options: ScoreOptions = {},
+): { quality: ConnectionQuality; limitingFactor: ConnectionQualityLimitingFactor } {
+  const relayExtra = signals.isRelayed ? thresholds.rtt.relayExtraMs : 0;
+  const latency = scoreLowerBetter(
+    signals.rttMs,
+    thresholds.rtt.goodMs + relayExtra,
+    thresholds.rtt.fairMs + relayExtra,
+    thresholds.rtt.poorMs + relayExtra,
+  );
+
+  const loss = scoreLowerBetter(signals.fractionLost, thresholds.loss.good, thresholds.loss.fair, thresholds.loss.poor);
+
+  // Bandwidth is scored on the UPSTREAM path only, as available BWE ÷ the
+  // INTENDED publish bitrate (a stable reference). We deliberately do NOT divide
+  // by the encoder's current target/outbound: congestion control lowers those
+  // to match a weak uplink, so the ratio would sit near 1.0 and report "good"
+  // even while the stream is throttled far below intended quality.
+  //
+  // The DOWNSTREAM (received) bitrate is not scored at all — its value is chosen
+  // by the server's encoder for the model, not by the network. Real downstream
+  // trouble surfaces through the stall (fps/freezes) and loss dimensions.
+  let bandwidth: ConnectionQuality = "good";
+  if (!options.skipBitrate) {
+    const ratio =
+      signals.availableOutgoingKbps != null
+        ? signals.availableOutgoingKbps / thresholds.upstream.requiredUpstreamKbps
+        : null;
+    bandwidth = scoreHigherBetter(
+      ratio,
+      thresholds.upstream.goodRatio,
+      thresholds.upstream.fairRatio,
+      thresholds.upstream.poorRatio,
+    );
+    // The encoder explicitly telling us it throttled for the network is a
+    // stronger signal than the BWE ratio — cap at "fair".
+    if (signals.qualityLimitationReason === "bandwidth") bandwidth = worst(bandwidth, "fair");
+  }
+
+  let stall = scoreHigherBetter(
+    signals.fps,
+    thresholds.stall.goodFps,
+    thresholds.stall.fairFps,
+    thresholds.stall.poorFps,
+  );
+  // A freeze this sample means the rendered stream can't be called "good".
+  if (signals.freezeCountDelta != null && signals.freezeCountDelta > 0) stall = worst(stall, "fair");
+
+  const quality = worst(bandwidth, latency, loss, stall);
+
+  // limitingFactor: the worst network dimension (tie-break bandwidth > loss >
+  // latency > stall). CPU limitation is surfaced only when the network is
+  // otherwise clean — it's a device problem, never a reason to hide.
+  let limitingFactor: ConnectionQualityLimitingFactor;
+  if (quality === "good") {
+    limitingFactor = signals.qualityLimitationReason === "cpu" ? "cpu" : "none";
+  } else if (bandwidth === quality) {
+    limitingFactor = "bandwidth";
+  } else if (loss === quality) {
+    limitingFactor = "loss";
+  } else if (latency === quality) {
+    limitingFactor = "latency";
+  } else {
+    limitingFactor = "stall";
+  }
+
+  return { quality, limitingFactor };
+}
+
+/** Convenience: extract + score a raw snapshot in one call (used in tests). */
+export function scoreSnapshot(
+  stats: WebRTCStats,
+  thresholds: ConnectionQualityThresholds = REALTIME_CONFIG.observability.connectionQuality,
+  options: ScoreOptions = {},
+): { quality: ConnectionQuality; limitingFactor: ConnectionQualityLimitingFactor } {
+  return scoreMetrics(extractSignals(stats), thresholds, options);
+}
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function minOrNull(values: number[]): number | null {
+  return values.length === 0 ? null : Math.min(...values);
+}
+
+class RingBuffer {
+  private values: number[] = [];
+  constructor(private readonly size: number) {}
+  push(value: number | null): void {
+    if (value === null) return;
+    this.values.push(value);
+    if (this.values.length > this.size) this.values.shift();
+  }
+  median(): number | null {
+    return median(this.values);
+  }
+  min(): number | null {
+    return minOrNull(this.values);
+  }
+  clear(): void {
+    this.values = [];
+  }
+}
+
+/**
+ * Stateful wrapper around the pure scorer: smooths metrics over a rolling
+ * window and applies asymmetric hysteresis so the emitted level doesn't flap
+ * every second. `update()` returns a report only when the debounced level
+ * changes; `current()` returns the latest report at any time.
+ */
+export class ConnectionQualityEvaluator {
+  private readonly rtt: RingBuffer;
+  private readonly loss: RingBuffer;
+  private readonly availableOutgoing: RingBuffer;
+  private readonly fps: RingBuffer;
+  private sampleCount = 0;
+  private currentLevel: ConnectionQuality | null = null;
+  // Captured when a level is committed so a held verdict keeps the reason that
+  // produced it — not whatever the latest (possibly recovering) sample reads.
+  private currentFactor: ConnectionQualityLimitingFactor = "none";
+  private candidateLevel: ConnectionQuality | null = null;
+  private candidateCount = 0;
+  private prevWarmingUp = true;
+  private lastReport: ConnectionQualityReport | null = null;
+
+  constructor(
+    private readonly thresholds: ConnectionQualityThresholds = REALTIME_CONFIG.observability.connectionQuality,
+  ) {
+    const w = thresholds.windowSamples;
+    this.rtt = new RingBuffer(w);
+    this.loss = new RingBuffer(w);
+    this.availableOutgoing = new RingBuffer(w);
+    this.fps = new RingBuffer(w);
+  }
+
+  /** Feed one raw stats sample. Returns a report only when the level or warm-up state changes. */
+  update(stats: WebRTCStats): ConnectionQualityReport | null {
+    this.sampleCount++;
+    const raw = extractSignals(stats);
+
+    this.rtt.push(raw.rttMs);
+    this.loss.push(raw.fractionLost);
+    this.availableOutgoing.push(raw.availableOutgoingKbps);
+    this.fps.push(raw.fps);
+
+    // Smooth the noisy signals over the window; encoder/path fields reflect the
+    // latest sample, not a window aggregate.
+    const smoothed: QualitySignals = {
+      ...raw,
+      rttMs: this.rtt.median(),
+      fractionLost: this.loss.median(),
+      availableOutgoingKbps: this.availableOutgoing.median(),
+      fps: this.fps.min(),
+    };
+
+    const warmingUp = this.sampleCount < this.thresholds.warmupSamples;
+    const { quality, limitingFactor } = scoreMetrics(smoothed, this.thresholds, { skipBitrate: warmingUp });
+
+    const changed = this.applyHysteresis(quality);
+    // Capture the reason only when the level actually commits, so it stays in
+    // sync with the (debounced) quality being reported between changes.
+    if (changed) {
+      this.currentFactor = quality === "good" ? (limitingFactor === "cpu" ? "cpu" : "none") : limitingFactor;
+    }
+    const emitted = this.currentLevel ?? quality;
+
+    this.lastReport = {
+      quality: emitted,
+      limitingFactor: this.currentFactor,
+      warmingUp,
+      metrics: {
+        rttMs: smoothed.rttMs,
+        fps: smoothed.fps,
+        packetLoss: smoothed.fractionLost,
+        availableUpstreamKbps: smoothed.availableOutgoingKbps,
+      },
+    };
+
+    // Also emit when warm-up ends so callback consumers receive the first
+    // non-provisional verdict — on a steady connection the level never changes,
+    // so they'd otherwise stay stuck on the initial `warmingUp: true` report.
+    const warmingUpChanged = warmingUp !== this.prevWarmingUp;
+    this.prevWarmingUp = warmingUp;
+
+    return changed || warmingUpChanged ? this.lastReport : null;
+  }
+
+  current(): ConnectionQualityReport | null {
+    return this.lastReport;
+  }
+
+  reset(): void {
+    this.rtt.clear();
+    this.loss.clear();
+    this.availableOutgoing.clear();
+    this.fps.clear();
+    this.sampleCount = 0;
+    this.currentLevel = null;
+    this.currentFactor = "none";
+    this.candidateLevel = null;
+    this.candidateCount = 0;
+    this.prevWarmingUp = true;
+    this.lastReport = null;
+  }
+
+  /** Returns true if the debounced level changed this tick. */
+  private applyHysteresis(raw: ConnectionQuality): boolean {
+    // First verdict is emitted immediately so consumers get an initial state.
+    if (this.currentLevel === null) {
+      this.currentLevel = raw;
+      this.candidateLevel = null;
+      this.candidateCount = 0;
+      return true;
+    }
+
+    if (raw === this.currentLevel) {
+      this.candidateLevel = null;
+      this.candidateCount = 0;
+      return false;
+    }
+
+    if (raw === this.candidateLevel) {
+      this.candidateCount++;
+    } else {
+      this.candidateLevel = raw;
+      this.candidateCount = 1;
+    }
+
+    const isDowngrade = RANK[raw] < RANK[this.currentLevel];
+    const required = isDowngrade ? this.thresholds.downgradeConsecutive : this.thresholds.upgradeConsecutive;
+    if (this.candidateCount >= required) {
+      this.currentLevel = raw;
+      this.candidateLevel = null;
+      this.candidateCount = 0;
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -216,7 +216,8 @@ export class ConnectionQualityEvaluator {
   private readonly fps: RingBuffer;
   private sampleCount = 0;
   private currentLevel: ConnectionQuality | null = null;
-  // Captured when a level commits so a held verdict keeps the reason that produced it.
+  // Reason for the current verdict; refreshed to the live cause, but held across a
+  // recovery lag (bad level still debounced while the latest sample improved).
   private currentFactor: ConnectionQualityLimitingFactor = "none";
   private candidateLevel: ConnectionQuality | null = null;
   private candidateCount = 0;
@@ -270,10 +271,16 @@ export class ConnectionQualityEvaluator {
       changed = this.applyHysteresis(quality);
     }
 
-    if (changed || warmupJustEnded) {
-      this.currentFactor = quality === "good" ? (limitingFactor === "cpu" ? "cpu" : "none") : limitingFactor;
-    }
     const emitted = this.currentLevel ?? quality;
+
+    // limitingFactor explains why we're at `emitted`: nothing when good; otherwise
+    // the current worst dimension — but keep the last committed reason while a bad
+    // level is held and the latest sample has already recovered above it.
+    if (emitted === "good") {
+      this.currentFactor = smoothed.qualityLimitationReason === "cpu" ? "cpu" : "none";
+    } else if (RANK[quality] <= RANK[emitted]) {
+      this.currentFactor = limitingFactor;
+    }
 
     this.lastReport = {
       quality: emitted,

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -87,7 +87,8 @@ function extractSignals(stats: WebRTCStats): QualitySignals {
 
   return {
     rttMs: rttSec != null ? rttSec * 1000 : null,
-    fractionLost: stats.remoteInbound?.fractionLost ?? null,
+    // WebRTC reports fractionLost as the RFC 3550 8-bit value (loss × 256); normalize to a 0–1 fraction.
+    fractionLost: stats.remoteInbound?.fractionLost != null ? stats.remoteInbound.fractionLost / 256 : null,
     availableOutgoingKbps:
       stats.connection.availableOutgoingBitrate != null ? stats.connection.availableOutgoingBitrate / 1000 : null,
     fps: stats.video?.framesPerSecond ?? null,

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -283,10 +283,28 @@ export class ConnectionQualityEvaluator {
     const warmingUp = this.sampleCount < this.thresholds.warmupSamples;
     const { quality, limitingFactor } = scoreMetrics(smoothed, this.thresholds, { skipBitrate: warmingUp });
 
-    const changed = this.applyHysteresis(quality);
-    // Capture the reason only when the level actually commits, so it stays in
-    // sync with the (debounced) quality being reported between changes.
-    if (changed) {
+    // Warm-up skips bandwidth scoring while the encoder/BWE ramp. The moment it
+    // ends we have a trustworthy, fully-scored verdict — commit it immediately
+    // instead of letting the optimistic warm-up "good" linger through the
+    // downgrade debounce, so the first non-warming report is authoritative.
+    // (This also delivers that first non-provisional report to callback
+    // consumers, who would otherwise stay stuck on `warmingUp: true`.)
+    const warmupJustEnded = this.prevWarmingUp && !warmingUp;
+    this.prevWarmingUp = warmingUp;
+
+    let changed: boolean;
+    if (warmupJustEnded) {
+      changed = this.currentLevel !== quality;
+      this.currentLevel = quality;
+      this.candidateLevel = null;
+      this.candidateCount = 0;
+    } else {
+      changed = this.applyHysteresis(quality);
+    }
+
+    // Capture the reason whenever the level (re)commits, so it stays in sync
+    // with the quality being reported between changes.
+    if (changed || warmupJustEnded) {
       this.currentFactor = quality === "good" ? (limitingFactor === "cpu" ? "cpu" : "none") : limitingFactor;
     }
     const emitted = this.currentLevel ?? quality;
@@ -303,13 +321,7 @@ export class ConnectionQualityEvaluator {
       },
     };
 
-    // Also emit when warm-up ends so callback consumers receive the first
-    // non-provisional verdict — on a steady connection the level never changes,
-    // so they'd otherwise stay stuck on the initial `warmingUp: true` report.
-    const warmingUpChanged = warmingUp !== this.prevWarmingUp;
-    this.prevWarmingUp = warmingUp;
-
-    return changed || warmingUpChanged ? this.lastReport : null;
+    return changed || warmupJustEnded ? this.lastReport : null;
   }
 
   current(): ConnectionQualityReport | null {

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -2,29 +2,15 @@ import { REALTIME_CONFIG } from "../config-realtime";
 import type { WebRTCStats } from "./webrtc-stats";
 
 /**
- * Interpreted, smoothed verdict on whether the user's connection is good
- * enough for the real-time camera-up pipeline. Derived entirely from the
- * raw `WebRTCStats` the SDK already collects — no new transport or polling.
- *
- * "good" — show normally · "fair" — usable, optional subtle warning ·
- * "poor" — degraded, prominent warning · "critical" — effectively unusable.
+ * Smoothed verdict on whether the connection is good enough for the realtime
+ * pipeline, derived from the raw `WebRTCStats` the SDK already collects.
  */
 export type ConnectionQuality = "good" | "fair" | "poor" | "critical";
 
 /** Which dimension pulled the verdict down to its current level. */
-export type ConnectionQualityLimitingFactor =
-  | "bandwidth" // upstream BWE below need, encoder bandwidth-limited, or low inbound bitrate
-  | "latency" // RTT too high
-  | "loss" // server reports too many of our packets lost
-  | "stall" // rendered stream froze / fps collapsed
-  | "cpu" // encoder CPU-limited (a device issue, never drags quality down)
-  | "none"; // nothing limiting
+export type ConnectionQualityLimitingFactor = "bandwidth" | "latency" | "loss" | "stall" | "cpu" | "none";
 
-/**
- * The human-meaningful numbers behind the verdict — one per scored dimension
- * (`rttMs`→latency, `packetLoss`→loss, `fps`→stall, `availableUpstreamKbps`→
- * bandwidth). For the full raw WebRTC firehose, subscribe to the `stats` event.
- */
+/** Human-meaningful numbers behind the verdict; the full raw stats are on the `stats` event. */
 export type ConnectionQualityMetrics = {
   /** Round-trip time in ms, or null until measured. */
   rttMs: number | null;
@@ -39,7 +25,7 @@ export type ConnectionQualityMetrics = {
 export type ConnectionQualityReport = {
   quality: ConnectionQuality;
   limitingFactor: ConnectionQualityLimitingFactor;
-  /** True while the connection ramps; the verdict is provisional (see warmupSamples). */
+  /** True while the connection ramps; the verdict is provisional. */
   warmingUp: boolean;
   metrics: ConnectionQualityMetrics;
 };
@@ -57,12 +43,11 @@ export type ConnectionQualityThresholds = {
 
 const RANK: Record<ConnectionQuality, number> = { critical: 0, poor: 1, fair: 2, good: 3 };
 
-/** Worst (lowest-rank) of the given qualities. */
 function worst(...qualities: ConnectionQuality[]): ConnectionQuality {
   return qualities.reduce((a, b) => (RANK[a] <= RANK[b] ? a : b));
 }
 
-/** Score a metric where lower is better (RTT, loss). `null` → "good" (absence of evidence ≠ bad). */
+// A null metric scores "good" — absence of evidence is not evidence of badness.
 function scoreLowerBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
   if (value === null) return "good";
   if (value <= good) return "good";
@@ -71,7 +56,6 @@ function scoreLowerBetter(value: number | null, good: number, fair: number, poor
   return "critical";
 }
 
-/** Score a metric where higher is better (bitrate, fps). `null` → "good". */
 function scoreHigherBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
   if (value === null) return "good";
   if (value >= good) return "good";
@@ -80,10 +64,7 @@ function scoreHigherBetter(value: number | null, good: number, fair: number, poo
   return "critical";
 }
 
-/**
- * Full set of raw signals the scorer needs (internal). The public report
- * exposes only a human-meaningful subset; everything here is also on `stats`.
- */
+/** Full set of raw signals the scorer needs; the public report exposes a subset. */
 type QualitySignals = {
   rttMs: number | null;
   fractionLost: number | null;
@@ -94,7 +75,6 @@ type QualitySignals = {
   isRelayed: boolean;
 };
 
-/** Pull the scoring-relevant signals out of a raw stats snapshot. */
 function extractSignals(stats: WebRTCStats): QualitySignals {
   const rttSec = stats.remoteInbound?.roundTripTime ?? stats.connection.currentRoundTripTime;
   const isRelayed = stats.connection.selectedCandidatePairs.some(
@@ -134,15 +114,9 @@ export function scoreMetrics(
 
   const loss = scoreLowerBetter(signals.fractionLost, thresholds.loss.good, thresholds.loss.fair, thresholds.loss.poor);
 
-  // Bandwidth is scored on the UPSTREAM path only, as available BWE ÷ the
-  // INTENDED publish bitrate (a stable reference). We deliberately do NOT divide
-  // by the encoder's current target/outbound: congestion control lowers those
-  // to match a weak uplink, so the ratio would sit near 1.0 and report "good"
-  // even while the stream is throttled far below intended quality.
-  //
-  // The DOWNSTREAM (received) bitrate is not scored at all — its value is chosen
-  // by the server's encoder for the model, not by the network. Real downstream
-  // trouble surfaces through the stall (fps/freezes) and loss dimensions.
+  // Upstream only: available BWE ÷ the INTENDED publish bitrate. Dividing by the
+  // encoder's adaptive target would mask throttling (it drops with the uplink).
+  // Downstream bitrate is intentionally not scored — it's server-chosen.
   let bandwidth: ConnectionQuality = "good";
   if (!options.skipBitrate) {
     const ratio =
@@ -155,25 +129,17 @@ export function scoreMetrics(
       thresholds.upstream.fairRatio,
       thresholds.upstream.poorRatio,
     );
-    // The encoder explicitly telling us it throttled for the network is a
-    // stronger signal than the BWE ratio — cap at "fair".
+    // Encoder self-reporting a bandwidth limit is a stronger signal than the ratio.
     if (signals.qualityLimitationReason === "bandwidth") bandwidth = worst(bandwidth, "fair");
   }
 
-  let stall = scoreHigherBetter(
-    signals.fps,
-    thresholds.stall.goodFps,
-    thresholds.stall.fairFps,
-    thresholds.stall.poorFps,
-  );
-  // A freeze this sample means the rendered stream can't be called "good".
+  let stall = scoreHigherBetter(signals.fps, thresholds.stall.goodFps, thresholds.stall.fairFps, thresholds.stall.poorFps);
   if (signals.freezeCountDelta != null && signals.freezeCountDelta > 0) stall = worst(stall, "fair");
 
   const quality = worst(bandwidth, latency, loss, stall);
 
-  // limitingFactor: the worst network dimension (tie-break bandwidth > loss >
-  // latency > stall). CPU limitation is surfaced only when the network is
-  // otherwise clean — it's a device problem, never a reason to hide.
+  // Worst network dimension (tie-break bandwidth > loss > latency > stall). "cpu"
+  // is informational and only surfaces when the network is otherwise clean.
   let limitingFactor: ConnectionQualityLimitingFactor;
   if (quality === "good") {
     limitingFactor = signals.qualityLimitationReason === "cpu" ? "cpu" : "none";
@@ -230,10 +196,9 @@ class RingBuffer {
 }
 
 /**
- * Stateful wrapper around the pure scorer: smooths metrics over a rolling
- * window and applies asymmetric hysteresis so the emitted level doesn't flap
- * every second. `update()` returns a report only when the debounced level
- * changes; `current()` returns the latest report at any time.
+ * Smooths metrics over a rolling window and applies asymmetric hysteresis so the
+ * emitted level doesn't flap. `update()` returns a report only when the level or
+ * warm-up state changes; `current()` returns the latest at any time.
  */
 export class ConnectionQualityEvaluator {
   private readonly rtt: RingBuffer;
@@ -242,8 +207,7 @@ export class ConnectionQualityEvaluator {
   private readonly fps: RingBuffer;
   private sampleCount = 0;
   private currentLevel: ConnectionQuality | null = null;
-  // Captured when a level is committed so a held verdict keeps the reason that
-  // produced it — not whatever the latest (possibly recovering) sample reads.
+  // Captured when a level commits so a held verdict keeps the reason that produced it.
   private currentFactor: ConnectionQualityLimitingFactor = "none";
   private candidateLevel: ConnectionQuality | null = null;
   private candidateCount = 0;
@@ -270,8 +234,6 @@ export class ConnectionQualityEvaluator {
     this.availableOutgoing.push(raw.availableOutgoingKbps);
     this.fps.push(raw.fps);
 
-    // Smooth the noisy signals over the window; encoder/path fields reflect the
-    // latest sample, not a window aggregate.
     const smoothed: QualitySignals = {
       ...raw,
       rttMs: this.rtt.median(),
@@ -283,12 +245,9 @@ export class ConnectionQualityEvaluator {
     const warmingUp = this.sampleCount < this.thresholds.warmupSamples;
     const { quality, limitingFactor } = scoreMetrics(smoothed, this.thresholds, { skipBitrate: warmingUp });
 
-    // Warm-up skips bandwidth scoring while the encoder/BWE ramp. The moment it
-    // ends we have a trustworthy, fully-scored verdict — commit it immediately
-    // instead of letting the optimistic warm-up "good" linger through the
-    // downgrade debounce, so the first non-warming report is authoritative.
-    // (This also delivers that first non-provisional report to callback
-    // consumers, who would otherwise stay stuck on `warmingUp: true`.)
+    // Warm-up skips bandwidth scoring; when it ends, commit the fully-scored verdict
+    // immediately so the first non-warming report is authoritative, rather than
+    // holding the optimistic "good" through the downgrade debounce.
     const warmupJustEnded = this.prevWarmingUp && !warmingUp;
     this.prevWarmingUp = warmingUp;
 
@@ -302,8 +261,6 @@ export class ConnectionQualityEvaluator {
       changed = this.applyHysteresis(quality);
     }
 
-    // Capture the reason whenever the level (re)commits, so it stays in sync
-    // with the quality being reported between changes.
     if (changed || warmupJustEnded) {
       this.currentFactor = quality === "good" ? (limitingFactor === "cpu" ? "cpu" : "none") : limitingFactor;
     }
@@ -344,9 +301,8 @@ export class ConnectionQualityEvaluator {
 
   /** Returns true if the debounced level changed this tick. */
   private applyHysteresis(raw: ConnectionQuality): boolean {
-    // First verdict is emitted immediately so consumers get an initial state.
     if (this.currentLevel === null) {
-      this.currentLevel = raw;
+      this.currentLevel = raw; // first verdict — emit immediately
       this.candidateLevel = null;
       this.candidateCount = 0;
       return true;

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -133,7 +133,12 @@ export function scoreMetrics(
     if (signals.qualityLimitationReason === "bandwidth") bandwidth = worst(bandwidth, "fair");
   }
 
-  let stall = scoreHigherBetter(signals.fps, thresholds.stall.goodFps, thresholds.stall.fairFps, thresholds.stall.poorFps);
+  let stall = scoreHigherBetter(
+    signals.fps,
+    thresholds.stall.goodFps,
+    thresholds.stall.fairFps,
+    thresholds.stall.poorFps,
+  );
   if (signals.freezeCountDelta != null && signals.freezeCountDelta > 0) stall = worst(stall, "fair");
 
   const quality = worst(bandwidth, latency, loss, stall);

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -1,6 +1,7 @@
 import type { Room } from "livekit-client";
 import type { Logger } from "../../utils/logger";
 import { REALTIME_CONFIG } from "../config-realtime";
+import { ConnectionQualityEvaluator, type ConnectionQualityReport } from "./connection-quality";
 import type {
   ClientSessionConnectionBreakdownPhase,
   DiagnosticEvent,
@@ -19,6 +20,7 @@ export type RealtimeObservabilityOptions = {
   logger: Logger;
   onDiagnostic?: (event: DiagnosticEvent) => void;
   onStats?: (stats: WebRTCStats) => void;
+  onConnectionQuality?: (report: ConnectionQualityReport) => void;
 };
 
 type PendingTelemetryDiagnostic = {
@@ -51,6 +53,7 @@ export class RealtimeObservability {
   private videoStalled = false;
   private stallStartMs = 0;
   private connectionBreakdown: ConnectionBreakdownBuffer | null = null;
+  private readonly connectionQuality = new ConnectionQualityEvaluator();
 
   constructor(private readonly options: RealtimeObservabilityOptions) {}
 
@@ -160,7 +163,7 @@ export class RealtimeObservability {
     this.resetStallDetection();
     this.statsCollectorSource = source;
 
-    if (!this.options.telemetryEnabled && !this.options.onStats) {
+    if (!this.options.telemetryEnabled && !this.options.onStats && !this.options.onConnectionQuality) {
       return;
     }
 
@@ -200,10 +203,16 @@ export class RealtimeObservability {
     this.connectionBreakdown = null;
   }
 
+  getConnectionQuality(): ConnectionQualityReport | null {
+    return this.connectionQuality.current();
+  }
+
   private handleStats(stats: WebRTCStats): void {
     this.options.onStats?.(stats);
     this.telemetryReporter.addStats(stats);
     this.detectVideoStall(stats);
+    const report = this.connectionQuality.update(stats);
+    if (report) this.options.onConnectionQuality?.(report);
   }
 
   private detectVideoStall(stats: WebRTCStats): void {
@@ -240,5 +249,7 @@ export class RealtimeObservability {
   private resetStallDetection(): void {
     this.videoStalled = false;
     this.stallStartMs = 0;
+    // A reconnect re-enters warm-up; don't blend pre/post-reconnect networks.
+    this.connectionQuality.reset();
   }
 }

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -1,0 +1,210 @@
+import type { Logger } from "../utils/logger";
+import { REALTIME_CONFIG } from "./config-realtime";
+import type { ConnectionQuality } from "./observability/connection-quality";
+
+/**
+ * SDK-only connectivity preflight. Run this *before* `realtime.connect()` to
+ * decide whether to show/enable the integration. It does NOT start a session
+ * or consume any inference — it spins up a throwaway `RTCPeerConnection`
+ * against public STUN servers to answer two questions cheaply:
+ *
+ *  1. Can WebRTC even leave this network over UDP? (the dominant failure on
+ *     corporate / locked-down networks)
+ *  2. Roughly how laggy is the path? (time-to-first-reflexive-candidate)
+ *
+ * It deliberately does NOT measure upstream throughput — that can't be done
+ * accurately without a backend echo room or upload sink. Use the in-session
+ * `connectionQuality` signal (which sees real BWE a couple seconds after
+ * connect) for the throughput question.
+ */
+export type ConnectivityTransport = "udp" | "relay" | "failed";
+
+export type ConnectivityMetrics = {
+  /** "udp" = direct UDP works · "relay" = will need TURN (unverified SDK-only) · "failed" = no connectivity. */
+  transport: ConnectivityTransport;
+  /** Approximate network round-trip time (ms) from time-to-first STUN candidate, or null. */
+  rttMs: number | null;
+};
+
+export type ConnectivityReport = {
+  /**
+   * Pre-connect connection quality, on the same `good → critical` scale as the
+   * in-session signal. The SDK reports the state and leaves the decision to you
+   * — e.g. show on "good", warn on "fair"/"poor", hide on "critical".
+   */
+  quality: ConnectionQuality;
+  metrics: ConnectivityMetrics;
+  /** Human-readable explanations for any non-"good" verdict. */
+  reasons: string[];
+};
+
+export type CheckConnectivityOptions = {
+  /** Override the ICE servers used for the probe. Defaults to public STUN. */
+  iceServers?: RTCIceServer[];
+  /** Abort candidate gathering after this long. Defaults to config. */
+  iceGatherTimeoutMs?: number;
+  /** Abort the probe early. */
+  signal?: AbortSignal;
+};
+
+export type PreflightOptions = {
+  logger: Logger;
+};
+
+export type PreflightRttThresholds = { goodMs: number; marginalMs: number };
+
+/** Extract the candidate type ("host" | "srflx" | "prflx" | "relay") from an ICE candidate. */
+function candidateType(candidate: RTCIceCandidate): string {
+  if (candidate.type) return candidate.type;
+  const match = /\btyp (\w+)/.exec(candidate.candidate);
+  return match?.[1] ?? "";
+}
+
+type GatherResult = { transport: ConnectivityTransport; rttMs: number | null };
+
+async function gatherIceCandidates(
+  iceServers: RTCIceServer[],
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+  logger: Logger,
+): Promise<GatherResult> {
+  // Already-aborted signal: bail before allocating a peer connection or waiting.
+  if (signal?.aborted) {
+    return { transport: "failed", rttMs: null };
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: runtime capability detection
+  const PC = (globalThis as any)?.RTCPeerConnection as typeof RTCPeerConnection | undefined;
+  if (typeof PC !== "function") {
+    logger.warn("preflight: RTCPeerConnection unavailable in this environment");
+    return { transport: "failed", rttMs: null };
+  }
+
+  let pc: RTCPeerConnection | null = null;
+  try {
+    pc = new PC({ iceServers });
+    // A data channel gives us an m-section so ICE gathering actually runs,
+    // without needing camera permission or any media tracks.
+    pc.createDataChannel("decart-preflight");
+
+    let sawSrflx = false;
+    // host or relay candidate — proves we gathered *something* but not direct UDP egress.
+    let sawOtherCandidate = false;
+    let firstSrflxAt: number | null = null;
+    const start = performance.now();
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(finish, timeoutMs);
+      signal?.addEventListener("abort", finish, { once: true });
+
+      const peer = pc as RTCPeerConnection;
+      peer.onicecandidate = (event) => {
+        if (!event.candidate || event.candidate.candidate === "") {
+          finish(); // end-of-candidates
+          return;
+        }
+        if (candidateType(event.candidate) === "srflx") {
+          sawSrflx = true;
+          if (firstSrflxAt === null) firstSrflxAt = performance.now();
+        } else {
+          sawOtherCandidate = true;
+        }
+      };
+      peer.onicegatheringstatechange = () => {
+        if (peer.iceGatheringState === "complete") finish();
+      };
+
+      peer
+        .createOffer()
+        .then((offer) => peer.setLocalDescription(offer))
+        .catch((error) => {
+          logger.warn("preflight: failed to create offer", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+          finish();
+        });
+    });
+
+    const rttMs = firstSrflxAt !== null ? Math.round(firstSrflxAt - start) : null;
+
+    // srflx → confirmed UDP egress; any other candidate but no srflx → STUN
+    // unreachable over UDP, the session will need TURN; nothing at all → failed.
+    let transport: ConnectivityTransport;
+    if (sawSrflx) {
+      transport = "udp";
+    } else if (sawOtherCandidate) {
+      transport = "relay";
+    } else {
+      transport = "failed";
+    }
+    return { transport, rttMs };
+  } catch (error) {
+    logger.warn("preflight: connectivity probe threw", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { transport: "failed", rttMs: null };
+  } finally {
+    try {
+      pc?.close();
+    } catch {
+      // ignore teardown errors
+    }
+  }
+}
+
+/** Map probe metrics to a connectivity quality verdict. Pure. */
+export function classifyConnectivity(
+  metrics: { transport: ConnectivityTransport; rttMs: number | null },
+  thresholds: PreflightRttThresholds,
+): ConnectivityReport {
+  const reasons: string[] = [];
+  let quality: ConnectionQuality;
+
+  if (metrics.transport === "failed") {
+    quality = "critical";
+    reasons.push(
+      "Could not establish any WebRTC connectivity (no ICE candidates gathered). Real-time streaming is unlikely to work on this network.",
+    );
+  } else if (metrics.transport === "relay") {
+    quality = "poor";
+    reasons.push(
+      "Direct UDP connectivity could not be confirmed; the session will need a TURN relay, which adds latency and can't be verified without starting a session.",
+    );
+  } else if (metrics.rttMs != null && metrics.rttMs > thresholds.marginalMs) {
+    quality = "poor";
+    reasons.push(
+      `Network round-trip time is high (~${metrics.rttMs}ms > ${thresholds.marginalMs}ms); the real-time experience may feel laggy.`,
+    );
+  } else if (metrics.rttMs != null && metrics.rttMs > thresholds.goodMs) {
+    quality = "fair";
+    reasons.push(`Network round-trip time is elevated (~${metrics.rttMs}ms > ${thresholds.goodMs}ms).`);
+  } else {
+    quality = "good";
+  }
+
+  return {
+    quality,
+    metrics: { transport: metrics.transport, rttMs: metrics.rttMs },
+    reasons,
+  };
+}
+
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = REALTIME_CONFIG.preflight.defaultStunUrls.map((urls) => ({ urls }));
+
+export const createPreflight = ({ logger }: PreflightOptions) => {
+  const checkConnectivity = async (options: CheckConnectivityOptions = {}): Promise<ConnectivityReport> => {
+    const iceServers = options.iceServers ?? DEFAULT_ICE_SERVERS;
+    const timeoutMs = options.iceGatherTimeoutMs ?? REALTIME_CONFIG.preflight.iceGatherTimeoutMs;
+    const result = await gatherIceCandidates(iceServers, timeoutMs, options.signal, logger);
+    return classifyConnectivity(result, REALTIME_CONFIG.preflight.rtt);
+  };
+
+  return { checkConnectivity };
+};

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -3,19 +3,11 @@ import { REALTIME_CONFIG } from "./config-realtime";
 import type { ConnectionQuality } from "./observability/connection-quality";
 
 /**
- * SDK-only connectivity preflight. Run this *before* `realtime.connect()` to
- * decide whether to show/enable the integration. It does NOT start a session
- * or consume any inference — it spins up a throwaway `RTCPeerConnection`
- * against public STUN servers to answer two questions cheaply:
- *
- *  1. Can WebRTC even leave this network over UDP? (the dominant failure on
- *     corporate / locked-down networks)
- *  2. Roughly how laggy is the path? (time-to-first-reflexive-candidate)
- *
- * It deliberately does NOT measure upstream throughput — that can't be done
- * accurately without a backend echo room or upload sink. Use the in-session
- * `connectionQuality` signal (which sees real BWE a couple seconds after
- * connect) for the throughput question.
+ * SDK-only connectivity preflight — run before `realtime.connect()` to decide
+ * whether to show the integration. Spins up a throwaway `RTCPeerConnection`
+ * against public STUN (no session, no inference) to check whether WebRTC can
+ * leave the network over UDP and roughly how laggy the path is. It does not
+ * measure throughput — use the in-session `connectionQuality` signal for that.
  */
 export type ConnectivityTransport = "udp" | "relay" | "failed";
 
@@ -27,11 +19,7 @@ export type ConnectivityMetrics = {
 };
 
 export type ConnectivityReport = {
-  /**
-   * Pre-connect connection quality, on the same `good → critical` scale as the
-   * in-session signal. The SDK reports the state and leaves the decision to you
-   * — e.g. show on "good", warn on "fair"/"poor", hide on "critical".
-   */
+  /** Pre-connect quality on the same `good → critical` scale as the in-session signal — you decide what to do. */
   quality: ConnectionQuality;
   metrics: ConnectivityMetrics;
   /** Human-readable explanations for any non-"good" verdict. */

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -208,6 +208,17 @@ describe("ConnectionQualityEvaluator", () => {
     });
   });
 
+  it("refreshes the limiting factor when the cause shifts at the same held level", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    evaluator.update(makeStats()); // good
+    evaluator.update(makeStats({ rttSec: 0.6 }));
+    evaluator.update(makeStats({ rttSec: 0.6 }));
+    expect(evaluator.update(makeStats({ rttSec: 0.6 }))?.limitingFactor).toBe("latency"); // critical via latency
+    // Still critical, but latency recovered and bandwidth is now the culprit.
+    evaluator.update(makeStats({ availableOutgoingBitrate: 500_000 }));
+    expect(evaluator.current()).toMatchObject({ quality: "critical", limitingFactor: "bandwidth" });
+  });
+
   it("keeps the limiting factor of the held verdict during recovery", () => {
     const evaluator = new ConnectionQualityEvaluator(fastThresholds());
     evaluator.update(makeStats()); // good

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -50,7 +50,8 @@ function makeStats(o: StatsOverrides = {}): WebRTCStats {
     remoteInbound: o.remoteInboundNull
       ? null
       : {
-          fractionLost: o.fractionLost === undefined ? 0 : o.fractionLost,
+          // o.fractionLost is a 0–1 fraction; the real WebRTC stat is that × 256 (RFC 3550 8-bit).
+          fractionLost: o.fractionLost === undefined ? 0 : o.fractionLost * 256,
           jitter: 0,
           roundTripTime: rttSec,
         },
@@ -82,6 +83,11 @@ describe("scoreSnapshot", () => {
     const { quality, limitingFactor } = scoreSnapshot(makeStats({ fractionLost: 0.2 }));
     expect(quality).toBe("critical");
     expect(limitingFactor).toBe("loss");
+  });
+
+  it("normalizes the RFC 3550 fractionLost scale (a few % loss is not critical)", () => {
+    // 3% real loss (raw stat ≈ 7.7) must read "fair", not "critical".
+    expect(scoreSnapshot(makeStats({ fractionLost: 0.03 })).quality).toBe("fair");
   });
 
   it("does not penalize a low (server-controlled) downstream bitrate on its own", () => {

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -193,6 +193,21 @@ describe("ConnectionQualityEvaluator", () => {
     expect(evaluator.update(makeStats())).toBeNull(); // steady afterward → silent
   });
 
+  it("snaps to the real verdict when warm-up ends (no lingering optimistic good)", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds({ warmupSamples: 3 }));
+    const weakUplink = () => makeStats({ availableOutgoingBitrate: 800_000 }); // ~0.23 ratio → critical
+    // Bandwidth is skipped during warm-up, so the provisional verdict is good.
+    expect(evaluator.update(weakUplink())).toMatchObject({ quality: "good", warmingUp: true });
+    expect(evaluator.update(weakUplink())).toBeNull();
+    // When warm-up ends the first non-warming report must already reflect the
+    // weak uplink — not stay "good" until the downgrade debounce catches up.
+    expect(evaluator.update(weakUplink())).toMatchObject({
+      quality: "critical",
+      warmingUp: false,
+      limitingFactor: "bandwidth",
+    });
+  });
+
   it("keeps the limiting factor of the held verdict during recovery", () => {
     const evaluator = new ConnectionQualityEvaluator(fastThresholds());
     evaluator.update(makeStats()); // good

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
+import {
+  ConnectionQualityEvaluator,
+  type ConnectionQualityThresholds,
+  scoreSnapshot,
+} from "../src/realtime/observability/connection-quality.js";
+import type { WebRTCStats } from "../src/realtime/observability/webrtc-stats.js";
+
+const THRESHOLDS = REALTIME_CONFIG.observability.connectionQuality;
+
+type StatsOverrides = {
+  rttSec?: number | null;
+  fractionLost?: number | null;
+  availableOutgoingBitrate?: number | null;
+  targetBitrateKbps?: number | null;
+  outboundBitrate?: number;
+  qualityLimitationReason?: string;
+  downstreamBitrate?: number;
+  fps?: number;
+  freezeCountDelta?: number;
+  relayed?: boolean;
+  videoNull?: boolean;
+  outboundNull?: boolean;
+  remoteInboundNull?: boolean;
+};
+
+/** Build a WebRTCStats snapshot that scores "good" by default; override per test. */
+function makeStats(o: StatsOverrides = {}): WebRTCStats {
+  const rttSec = o.rttSec === undefined ? 0.05 : o.rttSec;
+  const relayCandidate = { candidateType: "relay", address: "", port: 0, protocol: "udp" };
+  const hostCandidate = { candidateType: "host", address: "", port: 0, protocol: "udp" };
+  const stats = {
+    timestamp: 1000,
+    video: o.videoNull
+      ? null
+      : {
+          framesPerSecond: o.fps ?? 30,
+          bitrate: o.downstreamBitrate ?? 3_000_000,
+          freezeCountDelta: o.freezeCountDelta ?? 0,
+        },
+    audio: null,
+    outboundVideo: o.outboundNull
+      ? null
+      : {
+          bitrate: o.outboundBitrate ?? 3_000_000,
+          targetBitrateKbps: o.targetBitrateKbps === undefined ? 3000 : o.targetBitrateKbps,
+          qualityLimitationReason: o.qualityLimitationReason ?? "none",
+        },
+    remoteInbound: o.remoteInboundNull
+      ? null
+      : {
+          fractionLost: o.fractionLost === undefined ? 0 : o.fractionLost,
+          jitter: 0,
+          roundTripTime: rttSec,
+        },
+    connection: {
+      currentRoundTripTime: rttSec,
+      availableOutgoingBitrate: o.availableOutgoingBitrate === undefined ? 4_000_000 : o.availableOutgoingBitrate,
+      selectedCandidatePairs: o.relayed
+        ? [{ local: relayCandidate, remote: relayCandidate }]
+        : [{ local: hostCandidate, remote: hostCandidate }],
+    },
+  };
+  return stats as unknown as WebRTCStats;
+}
+
+describe("scoreSnapshot", () => {
+  it("rates a healthy snapshot as good with no limiting factor", () => {
+    const { quality, limitingFactor } = scoreSnapshot(makeStats());
+    expect(quality).toBe("good");
+    expect(limitingFactor).toBe("none");
+  });
+
+  it("flags high RTT as a critical latency problem", () => {
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ rttSec: 0.6 }));
+    expect(quality).toBe("critical");
+    expect(limitingFactor).toBe("latency");
+  });
+
+  it("flags high packet loss as a critical loss problem", () => {
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ fractionLost: 0.2 }));
+    expect(quality).toBe("critical");
+    expect(limitingFactor).toBe("loss");
+  });
+
+  it("does not penalize a low (server-controlled) downstream bitrate on its own", () => {
+    // The return-stream bitrate is chosen by the server's encoder, not the
+    // network — a low-but-steady value must not read as a bad connection.
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ downstreamBitrate: 500_000 }));
+    expect(quality).toBe("good");
+    expect(limitingFactor).toBe("none");
+  });
+
+  it("flags insufficient upstream headroom as a bandwidth problem", () => {
+    // available 1 Mbps vs 3.5 Mbps intended → ratio 0.29 < 0.5 critical
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 }));
+    expect(quality).toBe("critical");
+    expect(limitingFactor).toBe("bandwidth");
+  });
+
+  it("flags throttled upstream even when the encoder target dropped to match it", () => {
+    // Congestion control cut the encoder target to ~1.2 Mbps to fit a weak uplink.
+    // Scoring against the intended 3.5 Mbps still flags it — the lowered target
+    // must not mask the throttle as "good".
+    const { quality, limitingFactor } = scoreSnapshot(
+      makeStats({ availableOutgoingBitrate: 1_200_000, targetBitrateKbps: 1200 }),
+    );
+    expect(quality).toBe("critical");
+    expect(limitingFactor).toBe("bandwidth");
+  });
+
+  it("caps upstream at fair when the encoder reports a bandwidth limitation, even with good BWE", () => {
+    const { quality, limitingFactor } = scoreSnapshot(
+      makeStats({ availableOutgoingBitrate: 6_000_000, qualityLimitationReason: "bandwidth" }),
+    );
+    expect(quality).toBe("fair");
+    expect(limitingFactor).toBe("bandwidth");
+  });
+
+  it("treats a CPU-limited encoder as informational, never dragging quality down", () => {
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ qualityLimitationReason: "cpu" }));
+    expect(quality).toBe("good");
+    expect(limitingFactor).toBe("cpu");
+  });
+
+  it("widens RTT bands on TURN-relayed paths", () => {
+    // 250ms: fair on a direct path (>300? no, <=300 → fair), good once relay adds +100ms headroom
+    expect(scoreSnapshot(makeStats({ rttSec: 0.25, relayed: false })).quality).toBe("fair");
+    expect(scoreSnapshot(makeStats({ rttSec: 0.25, relayed: true })).quality).toBe("good");
+  });
+
+  it("skips the bandwidth dimension when skipBitrate is set (warm-up)", () => {
+    const opts = { skipBitrate: true };
+    // low upstream headroom: 1 Mbps available vs 3 Mbps needed → critical, unless skipped
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 }), THRESHOLDS, opts).quality).toBe("good");
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 })).quality).toBe("critical");
+  });
+
+  it("treats missing metrics as good (absence of evidence is not evidence of badness)", () => {
+    const allNull = makeStats({
+      rttSec: null,
+      remoteInboundNull: true,
+      videoNull: true,
+      outboundNull: true,
+      availableOutgoingBitrate: null,
+    });
+    const { quality, limitingFactor } = scoreSnapshot(allNull);
+    expect(quality).toBe("good");
+    expect(limitingFactor).toBe("none");
+  });
+});
+
+function fastThresholds(overrides: Partial<ConnectionQualityThresholds> = {}): ConnectionQualityThresholds {
+  return {
+    ...THRESHOLDS,
+    windowSamples: 1,
+    warmupSamples: 1,
+    downgradeConsecutive: 3,
+    upgradeConsecutive: 3,
+    ...overrides,
+  };
+}
+
+describe("ConnectionQualityEvaluator", () => {
+  it("emits the first verdict immediately", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    const report = evaluator.update(makeStats());
+    expect(report?.quality).toBe("good");
+  });
+
+  it("requires consecutive samples before downgrading, then upgrading", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    expect(evaluator.update(makeStats())?.quality).toBe("good");
+
+    const bad = () => makeStats({ rttSec: 0.6 });
+    expect(evaluator.update(bad())).toBeNull(); // 1
+    expect(evaluator.update(bad())).toBeNull(); // 2
+    expect(evaluator.update(bad())?.quality).toBe("critical"); // 3 → downgrade
+    expect(evaluator.current()?.quality).toBe("critical");
+
+    expect(evaluator.update(makeStats())).toBeNull(); // 1
+    expect(evaluator.update(makeStats())).toBeNull(); // 2
+    expect(evaluator.update(makeStats())?.quality).toBe("good"); // 3 → upgrade
+  });
+
+  it("emits again when warm-up ends, even if the level stayed good", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds({ warmupSamples: 3 }));
+    expect(evaluator.update(makeStats())).toMatchObject({ quality: "good", warmingUp: true });
+    expect(evaluator.update(makeStats())).toBeNull(); // still warming, no change
+    // warm-up ends → emit the first non-provisional verdict even though quality held
+    expect(evaluator.update(makeStats())).toMatchObject({ quality: "good", warmingUp: false });
+    expect(evaluator.update(makeStats())).toBeNull(); // steady afterward → silent
+  });
+
+  it("keeps the limiting factor of the held verdict during recovery", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    evaluator.update(makeStats()); // good
+    const badLatency = () => makeStats({ rttSec: 0.6 });
+    evaluator.update(badLatency());
+    evaluator.update(badLatency());
+    expect(evaluator.update(badLatency())?.quality).toBe("critical"); // downgrade
+    expect(evaluator.current()?.limitingFactor).toBe("latency");
+
+    // One good recovery sample: still debounced at critical — the reason must
+    // stay "latency", not flip to "none" because the latest raw score recovered.
+    expect(evaluator.update(makeStats())).toBeNull();
+    expect(evaluator.current()).toMatchObject({ quality: "critical", limitingFactor: "latency" });
+  });
+
+  it("resets the debounce counter when a sample returns to the current level", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    evaluator.update(makeStats()); // good
+    const bad = () => makeStats({ rttSec: 0.6 });
+    expect(evaluator.update(bad())).toBeNull(); // 1 bad
+    expect(evaluator.update(bad())).toBeNull(); // 2 bad
+    expect(evaluator.update(makeStats())).toBeNull(); // good resets counter
+    expect(evaluator.update(bad())).toBeNull(); // 1 bad again
+    expect(evaluator.update(bad())).toBeNull(); // 2 bad
+    expect(evaluator.update(bad())?.quality).toBe("critical"); // 3 → downgrade
+  });
+
+  it("stays provisional and ignores bandwidth during warm-up, then scores it after", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds({ warmupSamples: 3, downgradeConsecutive: 1 }));
+    const lowUp = () => makeStats({ availableOutgoingBitrate: 1_000_000 });
+
+    const first = evaluator.update(lowUp());
+    expect(first?.quality).toBe("good");
+    expect(first?.warmingUp).toBe(true);
+
+    expect(evaluator.update(lowUp())).toBeNull(); // still warming, still good
+    expect(evaluator.current()?.warmingUp).toBe(true);
+
+    const afterWarmup = evaluator.update(lowUp()); // sample 3 → warm-up over, bandwidth counts
+    expect(afterWarmup?.warmingUp).toBe(false);
+    expect(afterWarmup?.quality).toBe("critical");
+  });
+
+  it("reset() clears all state", () => {
+    const evaluator = new ConnectionQualityEvaluator(fastThresholds());
+    evaluator.update(makeStats({ rttSec: 0.6 }));
+    evaluator.reset();
+    expect(evaluator.current()).toBeNull();
+    // first verdict after reset emits again
+    expect(evaluator.update(makeStats())?.quality).toBe("good");
+  });
+});

--- a/packages/sdk/tests/preflight.unit.test.ts
+++ b/packages/sdk/tests/preflight.unit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { classifyConnectivity, createPreflight, type PreflightRttThresholds } from "../src/realtime/preflight.js";
+
+const logger = { debug() {}, info() {}, warn() {}, error() {} };
+const RTT: PreflightRttThresholds = { goodMs: 150, marginalMs: 300 };
+
+describe("classifyConnectivity", () => {
+  it("treats no connectivity as critical", () => {
+    const report = classifyConnectivity({ transport: "failed", rttMs: null }, RTT);
+    expect(report.quality).toBe("critical");
+    expect(report.reasons.length).toBeGreaterThan(0);
+    expect(report.metrics).toEqual({ transport: "failed", rttMs: null });
+  });
+
+  it("treats relay-only (UDP unconfirmed) as poor", () => {
+    const report = classifyConnectivity({ transport: "relay", rttMs: 90 }, RTT);
+    expect(report.quality).toBe("poor");
+    expect(report.reasons.length).toBeGreaterThan(0);
+  });
+
+  it("treats direct UDP with low RTT as good", () => {
+    const report = classifyConnectivity({ transport: "udp", rttMs: 100 }, RTT);
+    expect(report.quality).toBe("good");
+    expect(report.reasons).toHaveLength(0);
+    expect(report.metrics.rttMs).toBe(100);
+  });
+
+  it("treats elevated RTT on direct UDP as fair", () => {
+    const report = classifyConnectivity({ transport: "udp", rttMs: 200 }, RTT);
+    expect(report.quality).toBe("fair");
+  });
+
+  it("treats very high RTT on direct UDP as poor", () => {
+    const report = classifyConnectivity({ transport: "udp", rttMs: 420 }, RTT);
+    expect(report.quality).toBe("poor");
+  });
+
+  it("treats direct UDP with unknown RTT as good", () => {
+    const report = classifyConnectivity({ transport: "udp", rttMs: null }, RTT);
+    expect(report.quality).toBe("good");
+  });
+});
+
+describe("checkConnectivity", () => {
+  it("reports critical/failed when WebRTC is unavailable in the environment", async () => {
+    // The vitest unit env has no RTCPeerConnection, so the probe degrades cleanly.
+    const { checkConnectivity } = createPreflight({ logger });
+    const report = await checkConnectivity();
+    expect(report.metrics.transport).toBe("failed");
+    expect(report.quality).toBe("critical");
+  });
+});


### PR DESCRIPTION
## Why

Apps embedding the realtime integration want to gate it on network adequacy — only show/enable it when the user's connection can sustain a live camera session, and warn or hide when it can't. Previously the SDK only emitted raw WebRTC stats, so every app re-implemented this coarsely and inconsistently. This adds two interpreted, SDK-only signals (no backend changes) that give a correct verdict out of the box; both report a *state* and leave the show/hide decision to the consumer.

## What

- **Pre-connect:** `client.realtime.checkConnectivity()` — a lightweight probe (WebRTC reachability + latency; no session, no inference) so you can decide *before* rendering the integration.
- **In-session:** a `connectionQuality` event / `onConnectionQuality` callback / `getConnectionQuality()` getter — a smoothed live verdict (with the limiting factor and key metrics) so you can warn or degrade if reception drops mid-session.

Both use the same `good | fair | poor | critical` scale and are covered by unit tests; `index.html` includes a live demo.

## Usage

```ts
// Before showing the integration
const { quality, reasons } = await client.realtime.checkConnectivity();
if (quality === "critical") showFallback(reasons); // you decide what counts as "adequate"

// During the session
const rt = await client.realtime.connect(stream, {
  model,
  onRemoteStream,
  onConnectionQuality: ({ quality, limitingFactor, metrics }) => {
    updateSignalBars(quality);                       // good | fair | poor | critical
    if (quality === "poor") warnUser(limitingFactor); // "bandwidth" | "latency" | "loss" | "stall" | ...
  },
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New optional realtime APIs and observability path; mis-tuned thresholds could cause false warnings, but connect/session behavior is unchanged and gating remains app-controlled.
> 
> **Overview**
> Adds **SDK-only network adequacy signals** for realtime embeds (no backend changes): a pre-connect probe and a smoothed in-session verdict on a shared `good | fair | poor | critical` scale.
> 
> **Pre-connect:** `client.realtime.checkConnectivity()` runs a throwaway `RTCPeerConnection` against public STUN (ICE reachability + rough RTT), classifies transport (`udp` / `relay` / `failed`), and returns `reasons` so apps can gate the UI before `connect()`.
> 
> **In-session:** New `connection-quality` scoring turns existing WebRTC stats into `ConnectionQualityReport` (limiting factor, key metrics, warm-up + hysteresis). Wired through `RealtimeObservability`, optional `onConnectionQuality`, `connectionQuality` event, and `getConnectionQuality()`. Tunable thresholds live in `config-realtime`.
> 
> The test page demos both flows (preflight panel + live quality badge). Unit tests cover scoring, evaluator behavior, and preflight classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36343eb2c0ffa9152fc97d2b9a3ca59242a63bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->