### PR TITLE
fix(sdk): flush telemetry on stop

### DIFF
--- a/packages/sdk/src/realtime/observability/telemetry-reporter.ts
+++ b/packages/sdk/src/realtime/observability/telemetry-reporter.ts
@@ -21,6 +21,8 @@ type TelemetryReport = {
   diagnostics: TelemetryDiagnostic[];
 };
 
+const KEEPALIVE_MAX_BODY_BYTES = 60 * 1024;
+
 export interface TelemetryReporterOptions {
   apiKey: string;
   sessionId: string;
@@ -87,14 +89,13 @@ export class TelemetryReporter implements ITelemetryReporter {
     this.sendReport();
   }
 
-  /** Stop the reporter and discard any buffered data. */
+  /** Stop the reporter and make one final best-effort flush. */
   stop(): void {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
     }
-    this.statsBuffer = [];
-    this.diagnosticsBuffer = [];
+    this.sendReport({ keepalive: true });
   }
 
   /**
@@ -124,7 +125,7 @@ export class TelemetryReporter implements ITelemetryReporter {
     };
   }
 
-  private sendReport(): void {
+  private sendReport(options: { keepalive?: boolean } = {}): void {
     if (this.statsBuffer.length === 0 && this.diagnosticsBuffer.length === 0) {
       return;
     }
@@ -136,18 +137,27 @@ export class TelemetryReporter implements ITelemetryReporter {
         "Content-Type": "application/json",
       };
 
-      // Send as many chunks as needed to drain both buffers.
-      let chunk = this.createReportChunk();
-      while (chunk !== null) {
+      const chunks: TelemetryReport[] = [];
+      let nextChunk = this.createReportChunk();
+      while (nextChunk !== null) {
+        chunks.push(nextChunk);
+        nextChunk = this.createReportChunk();
+      }
+
+      chunks.forEach((chunk, index) => {
+        const body = JSON.stringify(chunk);
+        const useKeepalive =
+          options.keepalive &&
+          index === chunks.length - 1 &&
+          new TextEncoder().encode(body).byteLength <= KEEPALIVE_MAX_BODY_BYTES;
+
         fetch(REALTIME_CONFIG.observability.telemetryUrl, {
           method: "POST",
           headers: commonHeaders,
-          body: JSON.stringify(chunk),
-          // Only set keepalive on the very last chunk (if the caller requested it).
+          body,
+          ...(useKeepalive ? { keepalive: true } : {}),
         }).catch(() => {});
-
-        chunk = this.createReportChunk();
-      }
+      });
     } catch {
       // Telemetry is best-effort and should never add console noise for SDK users.
     }

--- a/packages/sdk/tests/realtime-observability-unit.test.ts
+++ b/packages/sdk/tests/realtime-observability-unit.test.ts
@@ -204,6 +204,49 @@ describe("RealtimeObservability", () => {
     expect(body.diagnostics.map((event: NamedDiagnostic) => event.name)).toEqual(["videoStall", "videoStall"]);
   });
 
+  it("flushes buffered telemetry when stopped before the report interval", async () => {
+    const { RealtimeObservability } = await import("../src/realtime/observability/realtime-observability.js");
+
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    const source = {
+      getStats: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            "video",
+            {
+              type: "inbound-rtp",
+              kind: "video",
+              framesPerSecond: 30,
+              framesDecoded: 1,
+            },
+          ],
+        ]) as unknown as RTCStatsReport,
+      ),
+    };
+
+    const observability = new RealtimeObservability({
+      telemetryEnabled: true,
+      apiKey: "test-key",
+      logger,
+    });
+
+    observability.sessionStarted("session-stop");
+    observability.setStatsProvider(source);
+
+    await vi.advanceTimersByTimeAsync(REALTIME_CONFIG.observability.statsDefaultIntervalMs);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    observability.stop();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1].keepalive).toBe(true);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.sessionId).toBe("session-stop");
+    expect(body.stats).toHaveLength(1);
+  });
+
   it("replaces the stats provider without leaving the old polling loop running", async () => {
     const { RealtimeObservability } = await import("../src/realtime/observability/realtime-observability.js");
 

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1734,12 +1734,78 @@ describe("TelemetryReporter", () => {
 
       reporter.stop();
 
-      // stop() should NOT send any network request
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://platform.decart.ai/api/v1/telemetry");
+      expect(options.keepalive).toBe(true);
 
-      // flush() after stop() should be a no-op (buffers were cleared)
+      const body = JSON.parse(options.body);
+      expect(body.sessionId).toBe("sess-2");
+      expect(body.stats).toHaveLength(1);
+
+      // flush() after stop() should be a no-op because stop drained the buffers.
       reporter.flush();
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("only uses keepalive on the last stop chunk", async () => {
+    const { TelemetryReporter } = await import("../src/realtime/observability/telemetry-reporter.js");
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const reporter = new TelemetryReporter({
+        apiKey: "test-key",
+        sessionId: "sess-chunk-stop",
+        logger: { debug() {}, info() {}, warn() {}, error() {} },
+      });
+
+      for (let i = 0; i < 150; i++) {
+        reporter.addStats({
+          timestamp: i,
+          video: null,
+          audio: null,
+          connection: { currentRoundTripTime: null, availableOutgoingBitrate: null },
+        });
+      }
+
+      reporter.stop();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][1].keepalive).toBeUndefined();
+      expect(fetchMock.mock.calls[1][1].keepalive).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not use keepalive when the stop payload is too large", async () => {
+    const { TelemetryReporter } = await import("../src/realtime/observability/telemetry-reporter.js");
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const reporter = new TelemetryReporter({
+        apiKey: "test-key",
+        sessionId: "sess-large-stop",
+        logger: { debug() {}, info() {}, warn() {}, error() {} },
+      });
+
+      reporter.addDiagnostic({
+        name: "client-session-connection-breakdown",
+        data: { message: "x".repeat(70 * 1024) },
+        timestamp: 1000,
+      });
+
+      reporter.stop();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][1].keepalive).toBeUndefined();
     } finally {
       vi.unstubAllGlobals();
     }


### PR DESCRIPTION
## Summary

- Flush buffered SDK telemetry when `TelemetryReporter.stop()` runs, so `RealtimeObservability.stop()` during disconnect no longer drops final WebRTC stats/diagnostics before the 10s interval.
- Use `keepalive` only for the final stop-time chunk and only when the encoded body is small enough for browser keepalive limits; larger/chunked flushes still use normal best-effort `fetch`.
- Add focused reporter and observability tests for stop flushing, chunked stop flush behavior, oversized payload fallback, and disconnect-boundary flushing.

Requested by Roe in Slack ([#C0B09QY43V4](https://decart.slack.com/archives/C0B09QY43V4/p1781003269806359?thread_ts=1780996260.457779&cid=C0B09QY43V4)).

## Verification

- `pnpm exec vitest unit --run`
- `pnpm run typecheck`
- `pnpm exec biome check src/realtime/observability/telemetry-reporter.ts tests/unit.test.ts tests/realtime-observability-unit.test.ts`
- `git diff --check`
- Independent Codex review: clean after addressing keepalive byte/quota edge case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Best-effort observability-only behavior change; no auth or API contract changes, with edge cases covered by new unit tests.
> 
> **Overview**
> **`TelemetryReporter.stop()`** no longer clears buffered stats/diagnostics; it performs a **best-effort final flush** so disconnect-time `RealtimeObservability.stop()` can still ship WebRTC data that never reached the periodic report interval.
> 
> **`sendReport`** now drains buffers into an array of chunks before posting, and when flushing on stop it sets **`fetch` `keepalive: true` only on the last chunk** and only if the encoded JSON body is **≤ 60KB** (browser keepalive limits); larger or multi-chunk stop flushes use ordinary `fetch`.
> 
> Tests were updated and added for stop flushing, multi-chunk keepalive behavior, oversized-payload fallback, and observability stop before the telemetry interval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18027880e393c28415df839cb33602d6d142cbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->