### PR TITLE
feat(realtime): glass-to-glass latency signals + deep preflight probe

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -129,6 +129,70 @@ subscriber.on("connectionChange", (state) => {
 subscriber.disconnect();
 ```
 
+### Connection quality
+
+There are two layers: a **preflight** check before connecting, and an **in-session** quality
+signal while connected. Both report on a shared `"good" | "fair" | "poor" | "critical"` scale —
+the SDK reports, you decide what to do (gate the UI, warn the user, etc.).
+
+**Preflight (before connecting).** A fast, network-only reachability check — it spins up a
+throwaway peer connection against public STUN, so there's no session and no cost:
+
+```typescript
+const { quality, metrics, reasons } = await client.realtime.checkConnectivity();
+// metrics: { transport: "udp" | "relay" | "failed", rttMs }
+if (quality === "critical") showFallbackUI(reasons);
+```
+
+**In-session quality.** While connected, the SDK derives a smoothed verdict from WebRTC stats
+(latency, packet loss, bandwidth headroom, frame rate) and tells you which dimension is the
+bottleneck:
+
+```typescript
+const realtimeClient = await client.realtime.connect(stream, {
+  model,
+  onRemoteStream: (s) => { videoElement.srcObject = s; },
+  onConnectionQuality: ({ quality, limitingFactor, metrics }) => {
+    // limitingFactor: "bandwidth" | "latency" | "loss" | "stall" | "cpu" | "none"
+    // metrics: { rttMs, fps, packetLoss, upstreamJitterMs, availableUpstreamKbps, ... }
+    console.log(quality, limitingFactor);
+  },
+});
+
+// also available as an event and a getter:
+realtimeClient.on("connectionQuality", (report) => { /* ... */ });
+realtimeClient.getConnectionQuality(); // latest report, or null before the first sample
+```
+
+**Glass-to-glass latency (opt-in, diagnostic).** Network RTT hides the dominant cost in
+real-time video — model inference — so a session can read "good" while actually feeling laggy.
+Set `debugQuality: true` to measure the *real* camera→display latency: the SDK stamps a pixel
+marker into each outgoing frame and reads it back off the rendered output, surfacing **startup**
+(`ttffMs`) and **steady-state** (`g2gMs`) latency plus end-to-end frame drops (`g2gDropRatio`).
+When present, glass-to-glass drives the latency verdict instead of RTT.
+
+> ⚠️ Diagnostic only. The marker is **visible** (bottom-left of the published and rendered video)
+> and adds per-frame pixel work — don't enable it for production / end-user sessions.
+
+```typescript
+const realtimeClient = await client.realtime.connect(stream, {
+  model,
+  debugQuality: true,
+  onConnectionQuality: ({ quality, metrics }) => {
+    console.log(metrics.ttffMs, metrics.g2gMs, metrics.g2gDropRatio);
+  },
+});
+```
+
+For a *measured* verdict before connecting (instead of the network-only check), use the **deep
+probe**: it briefly opens a real session with a synthetic source, measures glass-to-glass, then
+tears it down. It requires a `model` and costs a short GPU session:
+
+```typescript
+const probe = await client.realtime.checkConnectivity({ deep: true, model });
+console.log(probe.quality, probe.metrics.g2gMs, probe.metrics.ttffMs);
+```
+
 ### Async Processing (Queue API)
 
 For video generation jobs, use the queue API to submit jobs and poll for results:

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -360,6 +360,12 @@
             </select>
         </div>
         <div class="control-group">
+            <label>
+                <input type="checkbox" id="measure-g2g" />
+                Measure glass-to-glass latency (pixel marker; visible bottom-left, opt-in)
+            </label>
+        </div>
+        <div class="control-group">
             <label for="initial-prompt">Initial Prompt (empty = passthrough):</label>
             <input type="text" id="initial-prompt" placeholder="e.g. Lego World">
         </div>
@@ -392,7 +398,8 @@
             SDK-only WebRTC reachability + latency probe — no session, no inference. Use it to decide whether to show the integration <em>before</em> connecting. Needs an API key above (the client factory requires one), but the probe itself only hits public STUN.
         </p>
         <div class="inline-controls">
-            <button id="check-connectivity-btn">Check Connectivity</button>
+            <button id="check-connectivity-btn">Check Connectivity (STUN)</button>
+            <button id="active-probe-btn">Active Probe (measure glass-to-glass)</button>
         </div>
         <div id="connectivity-result" style="margin-top: 10px; padding: 10px 12px; border-radius: 6px; display: none; background: #f8f9fa;">
             <div style="font-size: 15px; font-weight: bold;" id="connectivity-headline">-</div>
@@ -627,7 +634,9 @@
             connectionQualityBadge: document.getElementById('connection-quality-badge'),
             connectionQualityDetail: document.getElementById('connection-quality-detail'),
             // Connectivity preflight elements
+            measureG2g: document.getElementById('measure-g2g'),
             checkConnectivityBtn: document.getElementById('check-connectivity-btn'),
+            activeProbeBtn: document.getElementById('active-probe-btn'),
             connectivityResult: document.getElementById('connectivity-result'),
             connectivityHeadline: document.getElementById('connectivity-headline'),
             connectivityMetrics: document.getElementById('connectivity-metrics'),
@@ -770,9 +779,13 @@
             const m = report.metrics;
             const parts = [];
             if (report.limitingFactor && report.limitingFactor !== 'none') parts.push(`limited by ${report.limitingFactor}`);
+            if (m.ttffMs != null) parts.push(`ttff ${(m.ttffMs / 1000).toFixed(1)}s`);
+            if (m.g2gMs != null) parts.push(`g2g ${Math.round(m.g2gMs)}ms`);
             if (m.rttMs != null) parts.push(`rtt ${Math.round(m.rttMs)}ms`);
             if (m.fps != null) parts.push(`${Math.round(m.fps)}fps`);
             if (m.packetLoss != null) parts.push(`loss ${(m.packetLoss * 100).toFixed(1)}%`);
+            if (m.g2gDropRatio != null) parts.push(`drops ${(m.g2gDropRatio * 100).toFixed(1)}%`);
+            if (m.upstreamJitterMs != null) parts.push(`↑jitter ${Math.round(m.upstreamJitterMs)}ms`);
             if (m.availableUpstreamKbps != null) parts.push(`↑avail ${Math.round(m.availableUpstreamKbps)}kbps`);
             elements.connectionQualityDetail.textContent = parts.join('  ·  ');
         }
@@ -814,9 +827,7 @@
                 elements.connectivityHeadline.style.color = style.color;
                 elements.connectivityHeadline.textContent = style.label;
 
-                const m = report.metrics;
-                elements.connectivityMetrics.textContent =
-                    `quality=${report.quality}   transport=${m.transport}   rtt=${m.rttMs != null ? `${m.rttMs}ms` : 'n/a'}`;
+                renderConnectivityMetrics(report.metrics);
 
                 elements.connectivityReasons.innerHTML = '';
                 for (const reason of report.reasons) {
@@ -835,7 +846,59 @@
             }
         }
 
+        function renderConnectivityMetrics(m) {
+            const parts = [`transport=${m.transport}`, `rtt=${m.rttMs != null ? `${m.rttMs}ms` : 'n/a'}`];
+            if (m.ttffMs != null) parts.push(`ttff=${(m.ttffMs / 1000).toFixed(1)}s`);
+            if (m.g2gMs != null) parts.push(`g2g=${m.g2gMs}ms`);
+            if (m.g2gDropRatio != null) parts.push(`drops=${(m.g2gDropRatio * 100).toFixed(1)}%`);
+            if (m.upstreamJitterMs != null) parts.push(`↑jitter=${m.upstreamJitterMs}ms`);
+            if (m.packetLoss != null) parts.push(`↑loss=${(m.packetLoss * 100).toFixed(1)}%`);
+            if (m.sampleCount != null) parts.push(`samples=${m.sampleCount}`);
+            elements.connectivityMetrics.textContent = parts.join('   ');
+        }
+
+        // Active probe: briefly opens a real session to measure true glass-to-glass latency.
+        async function runActivePreflight() {
+            const client = ensureDecartClient();
+            if (!client) return;
+
+            try {
+                elements.activeProbeBtn.disabled = true;
+                elements.connectivityResult.style.display = 'block';
+                elements.connectivityResult.style.background = '#f8f9fa';
+                elements.connectivityHeadline.style.color = '#333';
+                elements.connectivityHeadline.textContent = '⏳ Running active probe (opening a short session)…';
+                elements.connectivityMetrics.textContent = '';
+                elements.connectivityReasons.innerHTML = '';
+                addLog(`Running active preflight probe for model "${model.name}"…`, 'info');
+
+                const report = await client.realtime.checkConnectivity({ active: true, model });
+
+                const style = CONNECTIVITY_STYLE[report.quality] ?? CONNECTIVITY_STYLE.fair;
+                elements.connectivityResult.style.background = style.bg;
+                elements.connectivityHeadline.style.color = style.color;
+                elements.connectivityHeadline.textContent = style.label;
+                renderConnectivityMetrics(report.metrics);
+
+                elements.connectivityReasons.innerHTML = '';
+                for (const reason of report.reasons) {
+                    const li = document.createElement('li');
+                    li.textContent = reason;
+                    elements.connectivityReasons.appendChild(li);
+                }
+
+                addLog(`checkConnectivity({ active: true }) →\n${JSON.stringify(report, null, 2)}`, style.log);
+            } catch (error) {
+                elements.connectivityHeadline.style.color = '#c62828';
+                elements.connectivityHeadline.textContent = `❌ Active probe failed: ${error.message ?? error}`;
+                addLog(`Active preflight failed: ${error.message ?? error}`, 'error');
+            } finally {
+                elements.activeProbeBtn.disabled = false;
+            }
+        }
+
         elements.checkConnectivityBtn.addEventListener('click', runConnectivityCheck);
+        elements.activeProbeBtn.addEventListener('click', runActivePreflight);
 
         function syncPublisherSubscribeToken() {
             if (activeConnectionMode !== 'publisher' || !decartRealtime?.getSubscribeToken) {
@@ -1019,10 +1082,16 @@
                     addLog(`Preferred video codec: ${preferredVideoCodec}`, 'info');
                 }
 
+                const measureGlassToGlass = elements.measureG2g.checked;
+                if (measureGlassToGlass) {
+                    addLog('Glass-to-glass measurement ON (marker visible bottom-left of output)', 'info');
+                }
+
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
+                    ...(measureGlassToGlass && { measureGlassToGlass: true }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -399,7 +399,7 @@
         </p>
         <div class="inline-controls">
             <button id="check-connectivity-btn">Check Connectivity (STUN)</button>
-            <button id="active-probe-btn">Active Probe (measure glass-to-glass)</button>
+            <button id="active-probe-btn">Deep Probe (measure glass-to-glass)</button>
         </div>
         <div id="connectivity-result" style="margin-top: 10px; padding: 10px 12px; border-radius: 6px; display: none; background: #f8f9fa;">
             <div style="font-size: 15px; font-weight: bold;" id="connectivity-headline">-</div>
@@ -867,12 +867,12 @@
                 elements.connectivityResult.style.display = 'block';
                 elements.connectivityResult.style.background = '#f8f9fa';
                 elements.connectivityHeadline.style.color = '#333';
-                elements.connectivityHeadline.textContent = '⏳ Running active probe (opening a short session)…';
+                elements.connectivityHeadline.textContent = '⏳ Running deep probe (opening a short session)…';
                 elements.connectivityMetrics.textContent = '';
                 elements.connectivityReasons.innerHTML = '';
-                addLog(`Running active preflight probe for model "${model.name}"…`, 'info');
+                addLog(`Running deep connectivity probe for model "${model.name}"…`, 'info');
 
-                const report = await client.realtime.checkConnectivity({ active: true, model });
+                const report = await client.realtime.checkConnectivity({ deep: true, model });
 
                 const style = CONNECTIVITY_STYLE[report.quality] ?? CONNECTIVITY_STYLE.fair;
                 elements.connectivityResult.style.background = style.bg;
@@ -887,11 +887,11 @@
                     elements.connectivityReasons.appendChild(li);
                 }
 
-                addLog(`checkConnectivity({ active: true }) →\n${JSON.stringify(report, null, 2)}`, style.log);
+                addLog(`checkConnectivity({ deep: true }) →\n${JSON.stringify(report, null, 2)}`, style.log);
             } catch (error) {
                 elements.connectivityHeadline.style.color = '#c62828';
-                elements.connectivityHeadline.textContent = `❌ Active probe failed: ${error.message ?? error}`;
-                addLog(`Active preflight failed: ${error.message ?? error}`, 'error');
+                elements.connectivityHeadline.textContent = `❌ Deep probe failed: ${error.message ?? error}`;
+                addLog(`Deep probe failed: ${error.message ?? error}`, 'error');
             } finally {
                 elements.activeProbeBtn.disabled = false;
             }
@@ -1082,16 +1082,16 @@
                     addLog(`Preferred video codec: ${preferredVideoCodec}`, 'info');
                 }
 
-                const measureGlassToGlass = elements.measureG2g.checked;
-                if (measureGlassToGlass) {
-                    addLog('Glass-to-glass measurement ON (marker visible bottom-left of output)', 'info');
+                const deep = elements.measureG2g.checked;
+                if (deep) {
+                    addLog('Deep (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
                 }
 
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
-                    ...(measureGlassToGlass && { measureGlassToGlass: true }),
+                    ...(deep && { deep: true }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -1082,16 +1082,16 @@
                     addLog(`Preferred video codec: ${preferredVideoCodec}`, 'info');
                 }
 
-                const deep = elements.measureG2g.checked;
-                if (deep) {
-                    addLog('Deep (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
+                const debugQuality = elements.measureG2g.checked;
+                if (debugQuality) {
+                    addLog('Debug-quality (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
                 }
 
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
-                    ...(deep && { deep: true }),
+                    ...(debugQuality && { debugQuality: true }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -45,6 +45,7 @@ export type {
   ReconnectEvent,
   VideoStallEvent,
 } from "./realtime/observability/diagnostics";
+export type { G2GMetrics } from "./realtime/observability/glass-to-glass";
 export type { WebRTCStats } from "./realtime/observability/webrtc-stats";
 export type {
   CheckConnectivityOptions,
@@ -223,7 +224,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
     integration,
     logger,
   });
-  const preflight = createPreflight({ logger });
+  const preflight = createPreflight({ logger, connect: realtimePublish.connect });
 
   const process = createProcessClient({
     baseUrl,
@@ -256,13 +257,23 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
       /**
        * Check whether the user's network can support a real-time session
        * *before* connecting — so you can gate showing the integration.
-       * SDK-only: validates WebRTC reachability (UDP egress / TURN need) and
-       * latency via a throwaway peer connection. Does not start a session.
+       *
+       * Default (STUN-only): validates WebRTC reachability (UDP egress / TURN
+       * need) and approximate latency via a throwaway peer connection — no
+       * session, instant. Opt-in active probe (`{ active: true, model }`):
+       * briefly opens a real session with a synthetic source and measures *true*
+       * glass-to-glass latency (and end-to-end drops / upstream loss+jitter),
+       * then tears it down — accurate, but costs a short GPU session.
        *
        * @example
        * ```ts
+       * // Fast, pre-session reachability check
        * const { quality, reasons } = await client.realtime.checkConnectivity();
-       * if (quality === "critical") showFallbackUI(reasons); // your call what counts as "adequate"
+       * if (quality === "critical") showFallbackUI(reasons);
+       *
+       * // Accurate, measured glass-to-glass verdict
+       * const probe = await client.realtime.checkConnectivity({ active: true, model: models.realtime("mirage") });
+       * console.log(probe.metrics.g2gMs);
        * ```
        */
       checkConnectivity: preflight.checkConnectivity,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -260,8 +260,8 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
        *
        * Default (STUN-only): validates WebRTC reachability (UDP egress / TURN
        * need) and approximate latency via a throwaway peer connection — no
-       * session, instant. Opt-in active probe (`{ active: true, model }`):
-       * briefly opens a real session with a synthetic source and measures *true*
+       * session, instant. Opt-in deep probe (`{ deep: true, model }`): briefly
+       * opens a real session with a synthetic source and measures *true*
        * glass-to-glass latency (and end-to-end drops / upstream loss+jitter),
        * then tears it down — accurate, but costs a short GPU session.
        *
@@ -272,7 +272,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
        * if (quality === "critical") showFallbackUI(reasons);
        *
        * // Accurate, measured glass-to-glass verdict
-       * const probe = await client.realtime.checkConnectivity({ active: true, model: models.realtime("mirage") });
+       * const probe = await client.realtime.checkConnectivity({ deep: true, model: models.realtime("mirage") });
        * console.log(probe.metrics.g2gMs);
        * ```
        */

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -64,14 +64,15 @@ const realTimeClientConnectOptionsSchema = z.object({
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
   /**
-   * Opt-in "deep" measurement: measure true glass-to-glass latency by stamping a
-   * pixel marker into every outgoing frame and reading it back off the rendered
-   * output (the server re-stamps it). Surfaces `g2gMs` / `ttffMs` / `g2gDropRatio`
-   * on the `stats` and `connectionQuality` signals. Note: the marker is visible
-   * (bottom-left of the output) and adds per-frame pixel work — keep it off for
-   * normal sessions.
+   * Opt-in DEBUG-quality measurement: stamps a pixel marker into every outgoing
+   * frame and reads it back off the rendered output (the server re-stamps it) to
+   * measure true glass-to-glass latency, surfaced as `g2gMs` / `ttffMs` /
+   * `g2gDropRatio` on the `stats` and `connectionQuality` signals. Diagnostic
+   * only: the marker is **visible** (bottom-left of the published + rendered
+   * video) and adds per-frame pixel work — do not enable it for production /
+   * end-user sessions.
    */
-  deep: z.boolean().optional(),
+  debugQuality: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -150,7 +151,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       }
     }
 
-    const deep = parsedOptions.data.deep ?? false;
+    const debugQuality = parsedOptions.data.debugQuality ?? false;
 
     let session: StreamSession | undefined;
     let observability: RealtimeObservability | undefined;
@@ -178,13 +179,13 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
           emitOrBuffer("connectionQuality", report);
           onConnectionQuality?.(report);
         },
-        deep,
+        debugQuality,
       });
 
       // Stamp the marker into the outgoing stream (after any mirror, so it isn't
       // flipped). The pump is owned by observability so it shares the tracker's
       // lifecycle with the marker reader and survives reconnects.
-      if (deep) {
+      if (debugQuality) {
         inputStream = observability.attachOutgoingStream(inputStream, resolveFpsNumber(options.model.fps));
       }
 
@@ -196,7 +197,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         ...(options.queryParams ?? {}),
         // Ask the server to re-stamp the pixel marker from input to output so the
         // client can read glass-to-glass latency back off the rendered frames.
-        ...(deep ? { pixel_latency: "1" } : {}),
+        ...(debugQuality ? { pixel_latency: "1" } : {}),
         api_key: apiKey,
         model: options.model.name,
         ...(resolution ? { resolution } : {}),

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -64,13 +64,14 @@ const realTimeClientConnectOptionsSchema = z.object({
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
   /**
-   * Opt-in: measure true glass-to-glass latency by stamping a pixel marker into
-   * every outgoing frame and reading it back off the rendered output (the server
-   * re-stamps it). Surfaces `g2gMs` / `g2gDropRatio` on the `stats` and
-   * `connectionQuality` signals. Note: the marker is visible (bottom-left of the
-   * output) and adds per-frame pixel work — keep it off for normal sessions.
+   * Opt-in "deep" measurement: measure true glass-to-glass latency by stamping a
+   * pixel marker into every outgoing frame and reading it back off the rendered
+   * output (the server re-stamps it). Surfaces `g2gMs` / `ttffMs` / `g2gDropRatio`
+   * on the `stats` and `connectionQuality` signals. Note: the marker is visible
+   * (bottom-left of the output) and adds per-frame pixel work — keep it off for
+   * normal sessions.
    */
-  measureGlassToGlass: z.boolean().optional(),
+  deep: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -149,7 +150,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       }
     }
 
-    const measureGlassToGlass = parsedOptions.data.measureGlassToGlass ?? false;
+    const deep = parsedOptions.data.deep ?? false;
 
     let session: StreamSession | undefined;
     let observability: RealtimeObservability | undefined;
@@ -177,13 +178,13 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
           emitOrBuffer("connectionQuality", report);
           onConnectionQuality?.(report);
         },
-        measureGlassToGlass,
+        deep,
       });
 
       // Stamp the marker into the outgoing stream (after any mirror, so it isn't
       // flipped). The pump is owned by observability so it shares the tracker's
       // lifecycle with the marker reader and survives reconnects.
-      if (measureGlassToGlass) {
+      if (deep) {
         inputStream = observability.attachOutgoingStream(inputStream, resolveFpsNumber(options.model.fps));
       }
 
@@ -195,7 +196,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         ...(options.queryParams ?? {}),
         // Ask the server to re-stamp the pixel marker from input to output so the
         // client can read glass-to-glass latency back off the rendered frames.
-        ...(measureGlassToGlass ? { pixel_latency: "1" } : {}),
+        ...(deep ? { pixel_latency: "1" } : {}),
         api_key: apiKey,
         model: options.model.name,
         ...(resolution ? { resolution } : {}),

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -63,6 +63,14 @@ const realTimeClientConnectOptionsSchema = z.object({
   resolution: z.enum(["720p", "1080p"]).optional(),
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp9"]).optional(),
+  /**
+   * Opt-in: measure true glass-to-glass latency by stamping a pixel marker into
+   * every outgoing frame and reading it back off the rendered output (the server
+   * re-stamps it). Surfaces `g2gMs` / `g2gDropRatio` on the `stats` and
+   * `connectionQuality` signals. Note: the marker is visible (bottom-left of the
+   * output) and adds per-frame pixel work — keep it off for normal sessions.
+   */
+  measureGlassToGlass: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -141,6 +149,8 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       }
     }
 
+    const measureGlassToGlass = parsedOptions.data.measureGlassToGlass ?? false;
+
     let session: StreamSession | undefined;
     let observability: RealtimeObservability | undefined;
 
@@ -167,7 +177,15 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
           emitOrBuffer("connectionQuality", report);
           onConnectionQuality?.(report);
         },
+        measureGlassToGlass,
       });
+
+      // Stamp the marker into the outgoing stream (after any mirror, so it isn't
+      // flipped). The pump is owned by observability so it shares the tracker's
+      // lifecycle with the marker reader and survives reconnects.
+      if (measureGlassToGlass) {
+        inputStream = observability.attachOutgoingStream(inputStream, resolveFpsNumber(options.model.fps));
+      }
 
       const safariCodec = isDesktopSafari() ? "vp8" : undefined;
       const publishCodec: VideoCodec | undefined = safariCodec ?? preferredVideoCodec;
@@ -175,6 +193,9 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       const queryParams = new URLSearchParams({
         ...(safariCodec ? { livekit_server_codec: safariCodec } : {}),
         ...(options.queryParams ?? {}),
+        // Ask the server to re-stamp the pixel marker from input to output so the
+        // client can read glass-to-glass latency back off the rendered frames.
+        ...(measureGlassToGlass ? { pixel_latency: "1" } : {}),
         api_key: apiKey,
         model: options.model.name,
         ...(resolution ? { resolution } : {}),

--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -105,12 +105,12 @@ export const REALTIME_CONFIG = {
     /** RTT bands (ms) for the preflight verdict. */
     rtt: { goodMs: 150, marginalMs: 300 },
     /**
-     * Opt-in active probe (`checkConnectivity({ active: true, model })`): briefly
-     * opens a real session with a synthetic source + pixel-marker measurement to
-     * get a true glass-to-glass verdict, then tears it down. Costs a short GPU
-     * session. The verdict reuses the in-session `connectionQuality` bands.
-     * Duration must cover TTFF (~4–5s) + mid-stream warm-up (~2s) before
-     * steady-state samples accrue; resolves early once `minSamples` exist.
+     * Deep probe (`checkConnectivity({ deep: true, model })`): briefly opens a
+     * real session with a synthetic source + pixel-marker measurement to get a
+     * true glass-to-glass verdict, then tears it down. Costs a short GPU session.
+     * The verdict reuses the in-session `connectionQuality` bands. Duration must
+     * cover TTFF (~4–5s) + mid-stream warm-up (~2s) before steady-state samples
+     * accrue; resolves early once `minSamples` exist.
      */
     active: { durationMs: 12_000, minSamples: 5 },
   },

--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -65,8 +65,27 @@ export const REALTIME_CONFIG = {
       upgradeConsecutive: 5,
       /** Round-trip time bands (ms). Bands widen by relayExtraMs on TURN-relayed paths. */
       rtt: { goodMs: 150, fairMs: 300, poorMs: 500, relayExtraMs: 100 },
+      /**
+       * Mid-stream (steady-state) true glass-to-glass latency bands (ms) — the
+       * real per-frame camera→display latency through the model, used for the
+       * latency dimension *instead of* RTT when pixel-marker measurement is on.
+       * Already includes both network legs, so relayExtraMs does not apply.
+       * Excludes startup (see `ttff`). Anchored to Datadog
+       * `rt.stream.pipeline_latency_ms` (server-side median ~285ms / p95 ~510ms)
+       * plus network + jitter-buffer + decode headroom. Tune with real data.
+       */
+      glassToGlass: { goodMs: 500, fairMs: 900, poorMs: 1500 },
+      /**
+       * Time-to-first-frame bands (ms) — startup latency from connect to the
+       * first rendered model frame. An order of magnitude larger than mid-stream
+       * and judged separately (a slow first frame is a different problem from a
+       * laggy steady state). ~4–5s is an acceptable ("fair") cold start today.
+       */
+      ttff: { goodMs: 4_000, fairMs: 6_000, poorMs: 10_000 },
       /** Fraction of outbound packets the server reports lost (0..1). */
       loss: { good: 0.02, fair: 0.05, poor: 0.1 },
+      /** End-to-end frame drop ratio (0..1) inferred from the pixel-marker seq stream (backpressure/overload). */
+      g2gDrop: { good: 0.02, fair: 0.05, poor: 0.1 },
       /** Upstream headroom = available BWE ÷ the intended publish bitrate (requiredUpstreamKbps). */
       upstream: { goodRatio: 1.0, fairRatio: 0.8, poorRatio: 0.5, requiredUpstreamKbps: 3500 },
       /** Rendered (inbound) frames-per-second. */
@@ -85,5 +104,14 @@ export const REALTIME_CONFIG = {
     iceGatherTimeoutMs: 5_000,
     /** RTT bands (ms) for the preflight verdict. */
     rtt: { goodMs: 150, marginalMs: 300 },
+    /**
+     * Opt-in active probe (`checkConnectivity({ active: true, model })`): briefly
+     * opens a real session with a synthetic source + pixel-marker measurement to
+     * get a true glass-to-glass verdict, then tears it down. Costs a short GPU
+     * session. The verdict reuses the in-session `connectionQuality` bands.
+     * Duration must cover TTFF (~4–5s) + mid-stream warm-up (~2s) before
+     * steady-state samples accrue; resolves early once `minSamples` exist.
+     */
+    active: { durationMs: 12_000, minSamples: 5 },
   },
 } as const;

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -82,6 +82,11 @@ export class MediaChannel {
 
       const mediaStreamTrack = track.mediaStreamTrack;
       if (mediaStreamTrack) {
+        // Feed the rendered remote video to the glass-to-glass marker reader
+        // (no-op unless g2g measurement is enabled).
+        if (track.kind === Track.Kind.Video) {
+          this.config.observability?.attachRemoteVideoTrack(mediaStreamTrack);
+        }
         // Emit a fresh MediaStream whenever the track set changes. Consumers
         // assign this to an element's `srcObject`; mutating the existing stream
         // in place would not work because assigning the same MediaStream

--- a/packages/sdk/src/realtime/mirror-stream.ts
+++ b/packages/sdk/src/realtime/mirror-stream.ts
@@ -6,17 +6,41 @@ interface MediaStreamTrackGeneratorCtor {
   new (init: { kind: "video" }): MediaStreamTrack & { writable: WritableStream<VideoFrame> };
 }
 
-type FlipImpl = "track-processor" | "canvas" | "noop";
+export type FramePumpImpl = "track-processor" | "canvas" | "noop";
+
+/**
+ * A per-frame canvas operation. Receives the pump's 2D context, the current
+ * source frame (a `VideoFrame` on the Insertable-Streams path, an
+ * `HTMLVideoElement` on the canvas-fallback path) and its dimensions. The
+ * implementation owns the `drawImage` call (so it can transform during the draw,
+ * e.g. flip) plus any overlay it wants to add.
+ */
+export type FrameTransform = (
+  ctx: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
+  source: CanvasImageSource,
+  width: number,
+  height: number,
+) => void;
+
+export interface FramePump {
+  /** The transformed stream to publish — video track plus any pass-through audio. */
+  stream: MediaStream;
+  dispose: () => void;
+  impl: FramePumpImpl;
+}
+
+export interface FramePumpOptions {
+  /** Publish frame rate; sets the canvas-fallback `captureStream` cadence. */
+  fps: number;
+  transform: FrameTransform;
+}
 
 export interface MirroredStreamOptions {
   fps: number;
 }
 
-export interface MirroredStream {
-  stream: MediaStream;
-  dispose: () => void;
-  impl: FlipImpl;
-}
+/** A mirrored stream is just a frame-transform pump whose op is a horizontal flip. */
+export type MirroredStream = FramePump;
 
 export function isMediaStreamTrackProcessorSupported(): boolean {
   return (
@@ -37,7 +61,13 @@ export function shouldMirrorTrack(track: MediaStreamTrack): boolean {
   return facingMode === "user";
 }
 
-export function createMirroredStream(input: MediaStream, opts: MirroredStreamOptions): MirroredStream {
+/**
+ * Wrap `input`'s video track so each published frame passes through `transform`.
+ * Uses Insertable Streams (frame-accurate) where supported, a canvas
+ * `captureStream` pump otherwise. No-ops (returns `input` unchanged) when there
+ * is no video track. Audio tracks pass through untouched.
+ */
+export function createFrameTransformPump(input: MediaStream, opts: FramePumpOptions): FramePump {
   const [sourceVideo] = input.getVideoTracks();
   const audioTracks = input.getAudioTracks();
 
@@ -46,21 +76,37 @@ export function createMirroredStream(input: MediaStream, opts: MirroredStreamOpt
   }
 
   if (isMediaStreamTrackProcessorSupported()) {
-    return createWithTrackProcessor(sourceVideo, audioTracks);
+    return createWithTrackProcessor(sourceVideo, audioTracks, opts.transform);
   }
-  return createWithCanvas(sourceVideo, audioTracks, opts.fps);
+  return createWithCanvas(sourceVideo, audioTracks, opts.fps, opts.transform);
 }
 
-function createWithTrackProcessor(sourceVideo: MediaStreamTrack, audioTracks: MediaStreamTrack[]): MirroredStream {
+export function createMirroredStream(input: MediaStream, opts: MirroredStreamOptions): MirroredStream {
+  return createFrameTransformPump(input, {
+    fps: opts.fps,
+    transform: (ctx, source, w, h) => {
+      ctx.save();
+      ctx.setTransform(-1, 0, 0, 1, w, 0);
+      ctx.drawImage(source, 0, 0, w, h);
+      ctx.restore();
+    },
+  });
+}
+
+function createWithTrackProcessor(
+  sourceVideo: MediaStreamTrack,
+  audioTracks: MediaStreamTrack[],
+  transform: FrameTransform,
+): FramePump {
   const Processor = (globalThis as unknown as { MediaStreamTrackProcessor: MediaStreamTrackProcessorCtor })
     .MediaStreamTrackProcessor;
   const Generator = (globalThis as unknown as { MediaStreamTrackGenerator: MediaStreamTrackGeneratorCtor })
     .MediaStreamTrackGenerator;
 
-  // Probe 2D context at setup so we fail loud here rather than silently
-  // passing un-flipped frames through the pipeline.
+  // Probe the 2D context at setup so we fail loud here rather than silently
+  // passing unprocessed frames through the pipeline.
   if (!new OffscreenCanvas(1, 1).getContext("2d")) {
-    throw new Error("createMirroredStream: OffscreenCanvas 2D context unavailable");
+    throw new Error("createFrameTransformPump: OffscreenCanvas 2D context unavailable");
   }
 
   const processor = new Processor({ track: sourceVideo });
@@ -69,7 +115,7 @@ function createWithTrackProcessor(sourceVideo: MediaStreamTrack, audioTracks: Me
   let canvas = new OffscreenCanvas(1, 1);
   let ctx = canvas.getContext("2d") as OffscreenCanvasRenderingContext2D;
 
-  const transform = new TransformStream<VideoFrame, VideoFrame>({
+  const pipeline = new TransformStream<VideoFrame, VideoFrame>({
     transform(frame, controller) {
       const w = frame.displayWidth;
       const h = frame.displayHeight;
@@ -80,32 +126,27 @@ function createWithTrackProcessor(sourceVideo: MediaStreamTrack, audioTracks: Me
 
       // VideoFrames hold GPU buffers; close them deterministically even if
       // VideoFrame construction or enqueue throws.
-      let flipped: VideoFrame | undefined;
+      let out: VideoFrame | undefined;
       try {
-        ctx.save();
-        ctx.setTransform(-1, 0, 0, 1, w, 0);
-        ctx.drawImage(frame, 0, 0, w, h);
-        ctx.restore();
-        flipped = new VideoFrame(canvas, { timestamp: frame.timestamp, alpha: "discard" });
-        controller.enqueue(flipped);
-        flipped = undefined;
+        transform(ctx, frame, w, h);
+        out = new VideoFrame(canvas, { timestamp: frame.timestamp, alpha: "discard" });
+        controller.enqueue(out);
+        out = undefined;
       } finally {
-        flipped?.close();
+        out?.close();
         frame.close();
       }
     },
   });
 
   processor.readable
-    .pipeThrough(transform)
+    .pipeThrough(pipeline)
     .pipeTo(generator.writable)
     .catch(() => {});
 
-  const stream = new MediaStream([generator, ...audioTracks]);
-
   let disposed = false;
   return {
-    stream,
+    stream: new MediaStream([generator, ...audioTracks]),
     impl: "track-processor",
     dispose: () => {
       if (disposed) return;
@@ -115,25 +156,30 @@ function createWithTrackProcessor(sourceVideo: MediaStreamTrack, audioTracks: Me
   };
 }
 
-function createWithCanvas(sourceVideo: MediaStreamTrack, audioTracks: MediaStreamTrack[], fps: number): MirroredStream {
+function createWithCanvas(
+  sourceVideo: MediaStreamTrack,
+  audioTracks: MediaStreamTrack[],
+  fps: number,
+  transform: FrameTransform,
+): FramePump {
   if (typeof document === "undefined") {
-    throw new Error("createMirroredStream requires a DOM environment (document is undefined)");
+    throw new Error("createFrameTransformPump requires a DOM environment (document is undefined)");
   }
 
   const canvas = document.createElement("canvas");
   const ctx = canvas.getContext("2d");
   if (!ctx) {
-    throw new Error("createMirroredStream: 2D canvas context unavailable");
+    throw new Error("createFrameTransformPump: 2D canvas context unavailable");
   }
 
   // Resolve the output track before kicking off playback / rAF, so a missing
   // captureStream API doesn't leave background work running.
   if (typeof canvas.captureStream !== "function") {
-    throw new Error("createMirroredStream: canvas.captureStream unavailable");
+    throw new Error("createFrameTransformPump: canvas.captureStream unavailable");
   }
-  const [flippedTrack] = canvas.captureStream(fps).getVideoTracks();
-  if (!flippedTrack) {
-    throw new Error("createMirroredStream: canvas.captureStream produced no video track");
+  const [outTrack] = canvas.captureStream(fps).getVideoTracks();
+  if (!outTrack) {
+    throw new Error("createFrameTransformPump: canvas.captureStream produced no video track");
   }
 
   const video = document.createElement("video");
@@ -152,10 +198,7 @@ function createWithCanvas(sourceVideo: MediaStreamTrack, audioTracks: MediaStrea
     if (w > 0 && h > 0) {
       if (canvas.width !== w) canvas.width = w;
       if (canvas.height !== h) canvas.height = h;
-      ctx.save();
-      ctx.setTransform(-1, 0, 0, 1, w, 0);
-      ctx.drawImage(video, 0, 0, w, h);
-      ctx.restore();
+      transform(ctx, video, w, h);
     }
     rafHandle = requestAnimationFrame(draw);
   };
@@ -164,13 +207,13 @@ function createWithCanvas(sourceVideo: MediaStreamTrack, audioTracks: MediaStrea
   rafHandle = requestAnimationFrame(draw);
 
   return {
-    stream: new MediaStream([flippedTrack, ...audioTracks]),
+    stream: new MediaStream([outTrack, ...audioTracks]),
     impl: "canvas",
     dispose: () => {
       if (disposed) return;
       disposed = true;
       if (rafHandle !== null) cancelAnimationFrame(rafHandle);
-      flippedTrack.stop();
+      outTrack.stop();
       video.srcObject = null;
     },
   };

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -21,7 +21,7 @@ export type ConnectionQualityMetrics = {
   /**
    * Mid-stream (steady-state) glass-to-glass latency (ms) — the real per-frame
    * camera→display latency through the model, excluding startup. Only populated
-   * when the opt-in pixel-marker measurement is on (`connect({ measureGlassToGlass: true })`)
+   * when the opt-in pixel-marker measurement is on (`connect({ deep: true })`)
    * and past warm-up; null otherwise. When present it drives the latency verdict
    * instead of `rttMs`.
    */

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -18,10 +18,32 @@ export type ConnectionQualityLimitingFactor = "bandwidth" | "latency" | "loss" |
 export type ConnectionQualityMetrics = {
   /** Round-trip time in ms, or null until measured. */
   rttMs: number | null;
+  /**
+   * Mid-stream (steady-state) glass-to-glass latency (ms) — the real per-frame
+   * camera→display latency through the model, excluding startup. Only populated
+   * when the opt-in pixel-marker measurement is on (`connect({ measureGlassToGlass: true })`)
+   * and past warm-up; null otherwise. When present it drives the latency verdict
+   * instead of `rttMs`.
+   */
+  g2gMs: number | null;
+  /**
+   * Time-to-first-frame (ms) — startup latency from connect to the first rendered
+   * model frame. One-shot; populated under g2g measurement once the first frame
+   * arrives. Surfaced for visibility; does not drive the live verdict (it's
+   * historical by the time a verdict exists).
+   */
+  ttffMs: number | null;
   /** Rendered (inbound) frames per second, or null until measured. */
   fps: number | null;
   /** Fraction (0–1) of our outbound packets the server reports lost, or null until measured. */
   packetLoss: number | null;
+  /** Server's view of upstream (client→server) jitter in ms, or null. Observational. */
+  upstreamJitterMs: number | null;
+  /**
+   * End-to-end frame drop ratio (0–1) inferred from the pixel-marker seq stream.
+   * Only populated under the opt-in g2g measurement; null otherwise.
+   */
+  g2gDropRatio: number | null;
   /** Estimated available upstream bandwidth in kbps. Chromium-only — null on Safari/Firefox. */
   availableUpstreamKbps: number | null;
 };
@@ -40,19 +62,22 @@ export type ConnectionQualityThresholds = {
   downgradeConsecutive: number;
   upgradeConsecutive: number;
   rtt: { goodMs: number; fairMs: number; poorMs: number; relayExtraMs: number };
+  glassToGlass: { goodMs: number; fairMs: number; poorMs: number };
+  ttff: { goodMs: number; fairMs: number; poorMs: number };
   loss: { good: number; fair: number; poor: number };
+  g2gDrop: { good: number; fair: number; poor: number };
   upstream: { goodRatio: number; fairRatio: number; poorRatio: number; requiredUpstreamKbps: number };
   stall: { goodFps: number; fairFps: number; poorFps: number };
 };
 
-const RANK: Record<ConnectionQuality, number> = { critical: 0, poor: 1, fair: 2, good: 3 };
+export const RANK: Record<ConnectionQuality, number> = { critical: 0, poor: 1, fair: 2, good: 3 };
 
-function worst(...qualities: ConnectionQuality[]): ConnectionQuality {
+export function worst(...qualities: ConnectionQuality[]): ConnectionQuality {
   return qualities.reduce((a, b) => (RANK[a] <= RANK[b] ? a : b));
 }
 
 // A null metric scores "good" — absence of evidence is not evidence of badness.
-function scoreLowerBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
+export function scoreLowerBetter(value: number | null, good: number, fair: number, poor: number): ConnectionQuality {
   if (value === null) return "good";
   if (value <= good) return "good";
   if (value <= fair) return "fair";
@@ -69,9 +94,13 @@ function scoreHigherBetter(value: number | null, good: number, fair: number, poo
 }
 
 /** Full set of raw signals the scorer needs; the public report exposes a subset. */
-type QualitySignals = {
+export type QualitySignals = {
   rttMs: number | null;
+  g2gMs: number | null;
+  ttffMs: number | null;
+  upstreamJitterMs: number | null;
   fractionLost: number | null;
+  g2gDropRatio: number | null;
   availableOutgoingKbps: number | null;
   fps: number | null;
   freezeCountDelta: number | null;
@@ -79,7 +108,7 @@ type QualitySignals = {
   isRelayed: boolean;
 };
 
-function extractSignals(stats: WebRTCStats): QualitySignals {
+export function extractSignals(stats: WebRTCStats): QualitySignals {
   const rttSec = stats.remoteInbound?.roundTripTime ?? stats.connection.currentRoundTripTime;
   const isRelayed = stats.connection.selectedCandidatePairs.some(
     (pair) => pair.local.candidateType === "relay" || pair.remote.candidateType === "relay",
@@ -87,8 +116,13 @@ function extractSignals(stats: WebRTCStats): QualitySignals {
 
   return {
     rttMs: rttSec != null ? rttSec * 1000 : null,
+    g2gMs: stats.glassToGlass?.medianMs ?? null,
+    ttffMs: stats.glassToGlass?.ttffMs ?? null,
+    // remote-inbound jitter is the server's view of our uplink; seconds → ms.
+    upstreamJitterMs: stats.remoteInbound?.jitter != null ? stats.remoteInbound.jitter * 1000 : null,
     // WebRTC reports fractionLost as the RFC 3550 8-bit value (loss × 256); normalize to a 0–1 fraction.
     fractionLost: stats.remoteInbound?.fractionLost != null ? stats.remoteInbound.fractionLost / 256 : null,
+    g2gDropRatio: stats.glassToGlass?.dropRatio ?? null,
     availableOutgoingKbps:
       stats.connection.availableOutgoingBitrate != null ? stats.connection.availableOutgoingBitrate / 1000 : null,
     fps: stats.video?.framesPerSecond ?? null,
@@ -109,13 +143,24 @@ export function scoreMetrics(
   thresholds: ConnectionQualityThresholds,
   options: ScoreOptions = {},
 ): { quality: ConnectionQuality; limitingFactor: ConnectionQualityLimitingFactor } {
+  // Prefer measured glass-to-glass — the real experienced latency — when the
+  // opt-in pixel-marker measurement is active. It already includes both network
+  // legs, so relay headroom doesn't apply. Fall back to RTT otherwise.
   const relayExtra = signals.isRelayed ? thresholds.rtt.relayExtraMs : 0;
-  const latency = scoreLowerBetter(
-    signals.rttMs,
-    thresholds.rtt.goodMs + relayExtra,
-    thresholds.rtt.fairMs + relayExtra,
-    thresholds.rtt.poorMs + relayExtra,
-  );
+  const latency =
+    signals.g2gMs != null
+      ? scoreLowerBetter(
+          signals.g2gMs,
+          thresholds.glassToGlass.goodMs,
+          thresholds.glassToGlass.fairMs,
+          thresholds.glassToGlass.poorMs,
+        )
+      : scoreLowerBetter(
+          signals.rttMs,
+          thresholds.rtt.goodMs + relayExtra,
+          thresholds.rtt.fairMs + relayExtra,
+          thresholds.rtt.poorMs + relayExtra,
+        );
 
   const loss = scoreLowerBetter(signals.fractionLost, thresholds.loss.good, thresholds.loss.fair, thresholds.loss.poor);
 
@@ -145,6 +190,15 @@ export function scoreMetrics(
     thresholds.stall.poorFps,
   );
   if (signals.freezeCountDelta != null && signals.freezeCountDelta > 0) stall = worst(stall, "fair");
+  // End-to-end frame drops (server backpressure / overload, or transit loss)
+  // surface as the same user-visible symptom as a low frame rate.
+  const drop = scoreLowerBetter(
+    signals.g2gDropRatio,
+    thresholds.g2gDrop.good,
+    thresholds.g2gDrop.fair,
+    thresholds.g2gDrop.poor,
+  );
+  stall = worst(stall, drop);
 
   const quality = worst(bandwidth, latency, loss, stall);
 
@@ -212,6 +266,7 @@ class RingBuffer {
  */
 export class ConnectionQualityEvaluator {
   private readonly rtt: RingBuffer;
+  private readonly glassToGlass: RingBuffer;
   private readonly loss: RingBuffer;
   private readonly availableOutgoing: RingBuffer;
   private readonly fps: RingBuffer;
@@ -230,6 +285,7 @@ export class ConnectionQualityEvaluator {
   ) {
     const w = thresholds.windowSamples;
     this.rtt = new RingBuffer(w);
+    this.glassToGlass = new RingBuffer(w);
     this.loss = new RingBuffer(w);
     this.availableOutgoing = new RingBuffer(w);
     this.fps = new RingBuffer(w);
@@ -241,13 +297,17 @@ export class ConnectionQualityEvaluator {
     const raw = extractSignals(stats);
 
     this.rtt.push(raw.rttMs);
+    this.glassToGlass.push(raw.g2gMs);
     this.loss.push(raw.fractionLost);
     this.availableOutgoing.push(raw.availableOutgoingKbps);
     this.fps.push(raw.fps);
 
+    // `upstreamJitterMs` (observational, unscored) and `g2gDropRatio` (already
+    // windowed by the SeqTracker) ride through from `raw` un-resmoothed.
     const smoothed: QualitySignals = {
       ...raw,
       rttMs: this.rtt.median(),
+      g2gMs: this.glassToGlass.median(),
       fractionLost: this.loss.median(),
       availableOutgoingKbps: this.availableOutgoing.median(),
       fps: this.fps.min(),
@@ -289,8 +349,14 @@ export class ConnectionQualityEvaluator {
       warmingUp,
       metrics: {
         rttMs: smoothed.rttMs,
+        g2gMs: smoothed.g2gMs,
+        // ttffMs (one-shot startup), upstreamJitterMs (observational), and
+        // g2gDropRatio (already windowed) are surfaced raw, not re-smoothed.
+        ttffMs: raw.ttffMs,
         fps: smoothed.fps,
         packetLoss: smoothed.fractionLost,
+        upstreamJitterMs: raw.upstreamJitterMs,
+        g2gDropRatio: raw.g2gDropRatio,
         availableUpstreamKbps: smoothed.availableOutgoingKbps,
       },
     };
@@ -304,6 +370,7 @@ export class ConnectionQualityEvaluator {
 
   reset(): void {
     this.rtt.clear();
+    this.glassToGlass.clear();
     this.loss.clear();
     this.availableOutgoing.clear();
     this.fps.clear();

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -21,7 +21,7 @@ export type ConnectionQualityMetrics = {
   /**
    * Mid-stream (steady-state) glass-to-glass latency (ms) — the real per-frame
    * camera→display latency through the model, excluding startup. Only populated
-   * when the opt-in pixel-marker measurement is on (`connect({ deep: true })`)
+   * when the opt-in pixel-marker measurement is on (`connect({ debugQuality: true })`)
    * and past warm-up; null otherwise. When present it drives the latency verdict
    * instead of `rttMs`.
    */

--- a/packages/sdk/src/realtime/observability/glass-to-glass.ts
+++ b/packages/sdk/src/realtime/observability/glass-to-glass.ts
@@ -143,14 +143,24 @@ export class SeqTracker {
 
   snapshot(): G2GMetrics {
     const sorted = [...this.latencies].sort((a, b) => a - b);
-    const pct = (p: number): number | null =>
-      sorted.length === 0 ? null : Math.round(sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))]);
+    const n = sorted.length;
+    // True median: average the two middle samples on an even count. Nearest-rank
+    // would bias high and can tip a verdict near a band threshold. p90 stays
+    // nearest-rank (the standard percentile convention).
+    const medianMs =
+      n === 0
+        ? null
+        : n % 2 === 0
+          ? Math.round((sorted[n / 2 - 1] + sorted[n / 2]) / 2)
+          : Math.round(sorted[(n - 1) / 2]);
+    const p90Ms = n === 0 ? null : Math.round(sorted[Math.min(n - 1, Math.floor(0.9 * n))]);
+
     let dropRatio: number | null = null;
     if (this.outcomes.length >= DROP_MIN_OUTCOMES) {
-      const dropped = this.outcomes.reduce((n, delivered) => n + (delivered ? 0 : 1), 0);
+      const dropped = this.outcomes.reduce((acc, delivered) => acc + (delivered ? 0 : 1), 0);
       dropRatio = dropped / this.outcomes.length;
     }
-    return { ttffMs: this.ttffMs, medianMs: pct(0.5), p90Ms: pct(0.9), sampleCount: sorted.length, dropRatio };
+    return { ttffMs: this.ttffMs, medianMs, p90Ms, sampleCount: n, dropRatio };
   }
 
   /** Clear measurement state. Keeps `nextSeq` monotonic to avoid stale collisions. */

--- a/packages/sdk/src/realtime/observability/glass-to-glass.ts
+++ b/packages/sdk/src/realtime/observability/glass-to-glass.ts
@@ -231,6 +231,7 @@ function createFrameScheduler(video: HTMLVideoElement, onFrame: () => void): { s
   let running = false;
 
   const schedule = () => {
+    if (!running) return; // never re-arm after stop(), even if a trailing tick calls us
     handle = supportsRvfc ? video.requestVideoFrameCallback(tick) : requestAnimationFrame(tick);
   };
   const tick = () => {

--- a/packages/sdk/src/realtime/observability/glass-to-glass.ts
+++ b/packages/sdk/src/realtime/observability/glass-to-glass.ts
@@ -1,0 +1,309 @@
+/**
+ * True glass-to-glass latency measurement for the realtime pipeline.
+ *
+ * Opt-in (the marker is visible in the output and pixel work has a cost). When
+ * enabled, the SDK stamps a monotonic sequence number into the bottom-left of
+ * every outgoing frame ({@link createStampPump}) and reads it back off the
+ * rendered remote frames ({@link createMarkerReader}); the server re-stamps the
+ * seq from input to matching output (its `pixel_latency` mode). The
+ * {@link SeqTracker} matches stamp time to render time to compute the real
+ * camera→display latency through the model, and infers end-to-end frame drops
+ * from seqs that are stamped but never rendered.
+ *
+ * The stamp pump is built on the shared `createFrameTransformPump` (Insertable
+ * Streams where available, canvas `captureStream` fallback). The reader is a
+ * passive offscreen-`<video>` tap so it never consumes or re-encodes the track
+ * the consumer displays.
+ */
+
+import { createFrameTransformPump, type FramePump } from "../mirror-stream";
+import {
+  MAX_MARKER_HEIGHT,
+  MIN_MARKER_HEIGHT,
+  MIN_MARKER_WIDTH,
+  type RGBAImageData,
+  read,
+  stamp,
+} from "./pixel-marker";
+
+/**
+ * Aggregated glass-to-glass metrics. TTFF (startup) and mid-stream (steady
+ * state) are measured separately — they differ by an order of magnitude and the
+ * cold-start frames must not pollute the steady-state numbers.
+ */
+export type G2GMetrics = {
+  /**
+   * Time-to-first-frame (ms): from the connect attempt start to the first
+   * rendered model output. A one-shot startup metric, ~seconds. Null until the
+   * first frame arrives.
+   */
+  ttffMs: number | null;
+  /**
+   * Median mid-stream (steady-state) glass-to-glass latency (ms), excluding the
+   * warm-up after the first frame. Null until past warm-up. This is the
+   * per-frame responsiveness, distinct from `ttffMs`.
+   */
+  medianMs: number | null;
+  /** p90 mid-stream glass-to-glass latency (ms), or null until past warm-up. */
+  p90Ms: number | null;
+  /** Mid-stream latency samples in the window (post-warm-up). */
+  sampleCount: number;
+  /**
+   * End-to-end frame drop ratio (0–1): seqs stamped but never rendered, over
+   * recent post-warm-up outcomes. Null until enough frames have completed the
+   * round trip — short sessions/probes may never produce it.
+   */
+  dropRatio: number | null;
+};
+
+/** Bound on in-flight seqs; a seq that ages out unmatched is an end-to-end drop. Cf. server `_MAX_PENDING`. */
+const MAX_PENDING = 256;
+/** Rolling window for the latency percentiles (≈10s at 30fps). */
+const LATENCY_WINDOW = 300;
+/** Rolling window of delivered/dropped outcomes for the drop ratio. */
+const OUTCOME_WINDOW = 300;
+/** Don't report a drop ratio until this many outcomes exist (head-of-stream frames are still in flight). */
+const DROP_MIN_OUTCOMES = 30;
+/** Discard implausible deltas (clock weirdness, seq wrap collisions). */
+const MAX_PLAUSIBLE_MS = 60_000;
+/**
+ * After the first frame, ignore this long before counting steady-state samples.
+ * The first frames after a cold start run slow while the pipeline warms; folding
+ * them into the mid-stream median would inflate it. (TTFF still captures the
+ * first frame.)
+ */
+const MID_STREAM_WARMUP_MS = 2_000;
+
+/**
+ * Matches outgoing stamp times to incoming render times. Shared by the stamp
+ * pump (writer) and the marker reader (matcher); owned by `RealtimeObservability`.
+ *
+ * Tracks two latencies: TTFF (start → first frame) and mid-stream median (steady
+ * state, after a warm-up). Call `markStart()` at the beginning of each connect
+ * attempt so TTFF measures the full setup→first-frame wait.
+ */
+export class SeqTracker {
+  private readonly stampTimes = new Map<number, number>();
+  private readonly latencies: number[] = [];
+  /** true = delivered (matched), false = dropped (aged out unmatched). */
+  private readonly outcomes: boolean[] = [];
+  private nextSeq = 0;
+  private startMs: number | null = null;
+  private firstMatchMs: number | null = null;
+  private ttffMs: number | null = null;
+
+  /** Mark the start of a connect attempt; resets measurement state. TTFF is measured from here. */
+  markStart(nowMs: number): void {
+    this.reset();
+    this.startMs = nowMs;
+  }
+
+  /** Allocate the next seq for an outgoing frame and record its stamp time. Returns the 16-bit seq. */
+  stampNext(nowMs: number): number {
+    const seq = this.nextSeq & 0xffff;
+    this.nextSeq = (this.nextSeq + 1) & 0xffff;
+    this.stampTimes.set(seq, nowMs);
+    if (this.stampTimes.size > MAX_PENDING) {
+      // Oldest insertion (Map preserves order) aged out without a match.
+      const oldest = this.stampTimes.keys().next();
+      if (!oldest.done) {
+        this.stampTimes.delete(oldest.value);
+        // Only a real drop once the stream is live and past warm-up; pre-publish
+        // and cold-start stamps that age out are not counted.
+        if (this.isPastWarmup(nowMs)) this.recordOutcome(false);
+      }
+    }
+    return seq;
+  }
+
+  /** Match a seq read off an inbound rendered frame. Ignores unknown/duplicate seqs. */
+  recordInbound(seq: number, nowMs: number): void {
+    const stampedAt = this.stampTimes.get(seq);
+    if (stampedAt === undefined) return; // unknown, already consumed, or evicted
+    this.stampTimes.delete(seq);
+    const g2g = nowMs - stampedAt;
+    if (g2g < 0 || g2g > MAX_PLAUSIBLE_MS) return;
+
+    if (this.firstMatchMs === null) {
+      // First rendered frame: capture TTFF and discard any older (pre-publish /
+      // pre-warm) pending stamps so they don't later age out as phantom drops.
+      this.firstMatchMs = nowMs;
+      if (this.startMs !== null) this.ttffMs = nowMs - this.startMs;
+      for (const [key, stampTime] of this.stampTimes) {
+        if (stampTime < stampedAt) this.stampTimes.delete(key);
+        else break; // insertion order == time order
+      }
+    }
+
+    if (!this.isPastWarmup(nowMs)) return; // first frame + warm-up don't pollute steady state
+    this.latencies.push(g2g);
+    if (this.latencies.length > LATENCY_WINDOW) this.latencies.shift();
+    this.recordOutcome(true);
+  }
+
+  snapshot(): G2GMetrics {
+    const sorted = [...this.latencies].sort((a, b) => a - b);
+    const pct = (p: number): number | null =>
+      sorted.length === 0 ? null : Math.round(sorted[Math.min(sorted.length - 1, Math.floor(p * sorted.length))]);
+    let dropRatio: number | null = null;
+    if (this.outcomes.length >= DROP_MIN_OUTCOMES) {
+      const dropped = this.outcomes.reduce((n, delivered) => n + (delivered ? 0 : 1), 0);
+      dropRatio = dropped / this.outcomes.length;
+    }
+    return { ttffMs: this.ttffMs, medianMs: pct(0.5), p90Ms: pct(0.9), sampleCount: sorted.length, dropRatio };
+  }
+
+  /** Clear measurement state. Keeps `nextSeq` monotonic to avoid stale collisions. */
+  reset(): void {
+    this.stampTimes.clear();
+    this.latencies.length = 0;
+    this.outcomes.length = 0;
+    this.startMs = null;
+    this.firstMatchMs = null;
+    this.ttffMs = null;
+  }
+
+  private isPastWarmup(nowMs: number): boolean {
+    return this.firstMatchMs !== null && nowMs >= this.firstMatchMs + MID_STREAM_WARMUP_MS;
+  }
+
+  private recordOutcome(delivered: boolean): void {
+    this.outcomes.push(delivered);
+    if (this.outcomes.length > OUTCOME_WINDOW) this.outcomes.shift();
+  }
+}
+
+export type StampPump = FramePump;
+
+export interface StampPumpOptions {
+  tracker: SeqTracker;
+  /** Publish frame rate; sets the canvas-fallback capture + stamp cadence. */
+  fps: number;
+}
+
+/**
+ * Wrap `input` so every published video frame carries a fresh marker (drawn into
+ * the bottom-left band). Built on the shared frame-transform pump; no-ops when
+ * there's no video track or the frame is too small to hold the marker.
+ */
+export function createStampPump(input: MediaStream, opts: StampPumpOptions): StampPump {
+  const { tracker, fps } = opts;
+  const stampIntervalMs = 1000 / fps;
+  let lastStampMs = 0;
+  let currentSeq: number | null = null;
+
+  return createFrameTransformPump(input, {
+    fps,
+    transform: (ctx, source, w, h) => {
+      ctx.drawImage(source, 0, 0, w, h);
+      if (w < MIN_MARKER_WIDTH || h < MIN_MARKER_HEIGHT) return;
+      // Allocate a new seq at ~fps cadence and hold it across faster (rAF) draws:
+      // captureStream only samples at fps, so minting a seq per draw would create
+      // seqs that never get encoded (phantom drops). On the frame-accurate path
+      // frames already arrive at ~fps, so this is effectively one seq per frame.
+      const now = performance.now();
+      if (currentSeq === null || now - lastStampMs >= stampIntervalMs - 1) {
+        currentSeq = tracker.stampNext(now);
+        lastStampMs = now;
+      }
+      const band = ctx.getImageData(0, h - MIN_MARKER_HEIGHT, w, MIN_MARKER_HEIGHT) as RGBAImageData;
+      stamp(band, currentSeq);
+      ctx.putImageData(band as unknown as ImageData, 0, h - MIN_MARKER_HEIGHT);
+    },
+  });
+}
+
+export interface MarkerReader {
+  /** Attach (or replace) the remote video track to read markers from. */
+  attach: (track: MediaStreamTrack) => void;
+  dispose: () => void;
+}
+
+/**
+ * Drives `onFrame` once per rendered video frame. Prefers
+ * `requestVideoFrameCallback` (fires per decoded frame) over `requestAnimationFrame`
+ * (fires at display refresh — ~2× the work on a 30fps stream shown at 60Hz).
+ * The `typeof` guard keeps the rAF fallback for browsers that lack rVFC.
+ */
+function createFrameScheduler(video: HTMLVideoElement, onFrame: () => void): { start: () => void; stop: () => void } {
+  const supportsRvfc = typeof video.requestVideoFrameCallback === "function";
+  let handle: number | null = null;
+  let running = false;
+
+  const schedule = () => {
+    handle = supportsRvfc ? video.requestVideoFrameCallback(tick) : requestAnimationFrame(tick);
+  };
+  const tick = () => {
+    if (!running) return;
+    onFrame();
+    schedule();
+  };
+
+  return {
+    start: () => {
+      if (running) return;
+      running = true;
+      schedule();
+    },
+    stop: () => {
+      running = false;
+      if (handle === null) return;
+      if (supportsRvfc) video.cancelVideoFrameCallback(handle);
+      else cancelAnimationFrame(handle);
+      handle = null;
+    },
+  };
+}
+
+/**
+ * Passively read markers off the rendered remote video. Uses a hidden `<video>`
+ * fed by the same track (a track can drive multiple sinks), reading only the
+ * bottom band per rendered frame — never consumes or re-encodes the displayed track.
+ */
+export function createMarkerReader(tracker: SeqTracker): MarkerReader {
+  if (typeof document === "undefined") {
+    // Non-DOM env: reading isn't possible; latency simply won't populate.
+    return { attach: () => {}, dispose: () => {} };
+  }
+
+  const video = document.createElement("video");
+  video.muted = true;
+  video.playsInline = true;
+  video.autoplay = true;
+
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+
+  let attachedTrack: MediaStreamTrack | null = null;
+
+  const readFrame = () => {
+    const w = video.videoWidth;
+    const h = video.videoHeight;
+    if (w === 0 || h === 0 || !ctx) return;
+    // The marker sits in the bottom rows; read only a band tall enough for it
+    // at the largest auto-detected block size.
+    const band = Math.min(h, MAX_MARKER_HEIGHT);
+    if (canvas.width !== w) canvas.width = w;
+    if (canvas.height !== band) canvas.height = band;
+    ctx.drawImage(video, 0, h - band, w, band, 0, 0, w, band);
+    const seq = read(ctx.getImageData(0, 0, w, band) as RGBAImageData);
+    if (seq !== null) tracker.recordInbound(seq, performance.now());
+  };
+
+  const scheduler = createFrameScheduler(video, readFrame);
+
+  return {
+    attach: (track: MediaStreamTrack) => {
+      if (track === attachedTrack) return;
+      attachedTrack = track;
+      video.srcObject = new MediaStream([track]);
+      void video.play().catch(() => {});
+      scheduler.start();
+    },
+    dispose: () => {
+      scheduler.stop();
+      attachedTrack = null;
+      video.srcObject = null;
+    },
+  };
+}

--- a/packages/sdk/src/realtime/observability/pixel-marker.ts
+++ b/packages/sdk/src/realtime/observability/pixel-marker.ts
@@ -1,0 +1,178 @@
+/**
+ * Browser port of the server's E2E pixel-latency marker protocol
+ * (`inference_server/rt/bench/pixel_marker.py`). Used to measure true
+ * glass-to-glass latency through the realtime model: the client stamps a
+ * monotonic sequence number into the bottom-left of every outgoing frame, the
+ * server (with `pixel_latency` enabled) reads it on input and re-stamps it onto
+ * the matching output frame, and the client reads it back on the rendered frame.
+ *
+ * The protocol works on the luma (Y) channel. The server writes Y∈{50,200};
+ * here we stamp grayscale RGB blocks (R=G=B=v) so the encoder's RGB→YUV
+ * conversion lands Y≈v, and we read by computing luma and thresholding at 128.
+ * The 75-unit margin either side of 128, the SYNC pattern, the per-row checksum,
+ * the 4 redundant rows, and the block-size auto-detect together survive VP8/VP9
+ * quantization and WebRTC transport scaling.
+ *
+ * This is intentionally a line-for-line port of `pixel_marker.py` so the two
+ * stay byte-compatible — keep the constants and bit layout in sync.
+ */
+
+/** Minimal structural shape of a canvas `ImageData` (RGBA, row-major). */
+export type RGBAImageData = {
+  readonly width: number;
+  readonly height: number;
+  readonly data: Uint8ClampedArray | Uint8Array;
+};
+
+const SYNC = [200, 50, 200, 50] as const;
+const SYNC_LEN = SYNC.length;
+const DATA_BITS = 16;
+const CHECKSUM_BITS = 4;
+/** 4 sync + 16 data + 4 checksum logical columns. */
+const TOTAL_LOGICAL = SYNC_LEN + DATA_BITS + CHECKSUM_BITS;
+/** Redundant logical rows, majority-voted on read. */
+const MARKER_ROWS = 4;
+/** Physical pixels per logical pixel when stamping (native resolution). */
+const BLOCK_SIZE = 8;
+
+/**
+ * Candidate received block sizes, ordered by likelihood (nominal 8, no transport
+ * scaling). Smaller values appear when WebRTC BWE downscales the stream; larger
+ * when the sender upscales pre-encode. Mirrors `_CANDIDATE_BLOCK_SIZES`.
+ */
+const CANDIDATE_BLOCK_SIZES = [8, 4, 6, 2, 12, 10, 16, 5, 7, 14, 3] as const;
+
+/** Smallest frame that can hold the marker at nominal block size. */
+export const MIN_MARKER_WIDTH = TOTAL_LOGICAL * BLOCK_SIZE;
+export const MIN_MARKER_HEIGHT = MARKER_ROWS * BLOCK_SIZE;
+/** Tallest the marker can be in a received frame (largest auto-detect block size). */
+export const MAX_MARKER_HEIGHT = MARKER_ROWS * Math.max(...CANDIDATE_BLOCK_SIZES);
+
+/** BT.601 luma approximation (integer, matches a >=128 threshold either way). */
+function luma(r: number, g: number, b: number): number {
+  return (77 * r + 150 * g + 29 * b) >> 8;
+}
+
+const isHigh = (v: number): boolean => v >= 128;
+
+/** XOR of the four 4-bit nibbles of the 16-bit seq (matches the server). */
+function checksumNibbles(seq: number): number {
+  let checksum = 0;
+  for (let i = 0; i < DATA_BITS; i += 4) checksum ^= (seq >> i) & 0xf;
+  return checksum;
+}
+
+/** The TOTAL_LOGICAL grayscale values for one logical row encoding `seq`. */
+function rowValues(seq: number): number[] {
+  const masked = seq & 0xffff;
+  const values: number[] = [...SYNC];
+  for (let i = 0; i < DATA_BITS; i++) {
+    values.push((masked >> (DATA_BITS - 1 - i)) & 1 ? 200 : 50);
+  }
+  const checksum = checksumNibbles(masked);
+  for (let i = 0; i < CHECKSUM_BITS; i++) {
+    values.push((checksum >> (CHECKSUM_BITS - 1 - i)) & 1 ? 200 : 50);
+  }
+  return values; // length === TOTAL_LOGICAL
+}
+
+/**
+ * Stamp `seq` into the bottom-left of `img` as grayscale blocks (mutates in
+ * place). Returns false (no-op) if the frame is too small to hold the marker.
+ * Always stamps at BLOCK_SIZE=8, matching the server's native-resolution stamp.
+ */
+export function stamp(img: RGBAImageData, seq: number): boolean {
+  const { width, height, data } = img;
+  if (width < MIN_MARKER_WIDTH || height < MIN_MARKER_HEIGHT) return false;
+
+  const values = rowValues(seq);
+  for (let logRow = 0; logRow < MARKER_ROWS; logRow++) {
+    const rowStart = height - (MARKER_ROWS - logRow) * BLOCK_SIZE;
+    for (let by = 0; by < BLOCK_SIZE; by++) {
+      const y = rowStart + by;
+      if (y < 0 || y >= height) continue;
+      for (let logCol = 0; logCol < TOTAL_LOGICAL; logCol++) {
+        const v = values[logCol];
+        const xStart = logCol * BLOCK_SIZE;
+        const xEnd = Math.min(xStart + BLOCK_SIZE, width);
+        for (let x = xStart; x < xEnd; x++) {
+          const o = (y * width + x) * 4;
+          data[o] = v;
+          data[o + 1] = v;
+          data[o + 2] = v;
+          data[o + 3] = 255;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+function syncMatches(rowValues: number[]): boolean {
+  for (let i = 0; i < SYNC_LEN; i++) {
+    if (isHigh(SYNC[i]) !== isHigh(rowValues[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Read the marker seq from the bottom of `img`, or null if absent/unreadable.
+ * Auto-detects the received block size so it works at any received resolution
+ * (the transport may uniformly scale the frame after the server stamped it).
+ */
+export function read(img: RGBAImageData): number | null {
+  const { width, height, data } = img;
+  const sample = (row: number, col: number): number => {
+    const o = (row * width + col) * 4;
+    return luma(data[o], data[o + 1], data[o + 2]);
+  };
+
+  for (const blockSize of CANDIDATE_BLOCK_SIZES) {
+    if (width < TOTAL_LOGICAL * blockSize || height < MARKER_ROWS * blockSize) continue;
+    const seq = decodeAtBlockSize(sample, width, height, blockSize);
+    if (seq !== null) return seq;
+  }
+  return null;
+}
+
+function decodeAtBlockSize(
+  sample: (row: number, col: number) => number,
+  width: number,
+  height: number,
+  blockSize: number,
+): number | null {
+  const half = blockSize >> 1;
+  const validRows: number[][] = [];
+
+  for (let logRow = 0; logRow < MARKER_ROWS; logRow++) {
+    let row = height - (MARKER_ROWS - logRow) * blockSize + half;
+    row = Math.max(0, Math.min(row, height - 1));
+    const rv: number[] = [];
+    for (let logCol = 0; logCol < TOTAL_LOGICAL; logCol++) {
+      let col = logCol * blockSize + half;
+      col = Math.max(0, Math.min(col, width - 1));
+      rv.push(sample(row, col));
+    }
+    if (syncMatches(rv)) validRows.push(rv);
+  }
+
+  if (validRows.length === 0) return null;
+  const threshold = validRows.length / 2;
+
+  let seq = 0;
+  for (let i = 0; i < DATA_BITS; i++) {
+    let votes = 0;
+    for (const rv of validRows) if (isHigh(rv[SYNC_LEN + i])) votes++;
+    if (votes > threshold) seq |= 1 << (DATA_BITS - 1 - i);
+  }
+
+  const expectedChecksum = checksumNibbles(seq);
+  let actualChecksum = 0;
+  for (let i = 0; i < CHECKSUM_BITS; i++) {
+    let votes = 0;
+    for (const rv of validRows) if (isHigh(rv[SYNC_LEN + DATA_BITS + i])) votes++;
+    if (votes > threshold) actualChecksum |= 1 << (CHECKSUM_BITS - 1 - i);
+  }
+
+  return expectedChecksum === actualChecksum ? seq : null;
+}

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -8,6 +8,7 @@ import type {
   DiagnosticEventName,
   DiagnosticEvents,
 } from "./diagnostics";
+import { createMarkerReader, createStampPump, type MarkerReader, SeqTracker, type StampPump } from "./glass-to-glass";
 import { createLiveKitStatsProvider } from "./livekit-stats-provider";
 import { type ITelemetryReporter, NullTelemetryReporter, TelemetryReporter } from "./telemetry-reporter";
 import { type StatsProvider, type WebRTCStats, WebRTCStatsCollector } from "./webrtc-stats";
@@ -21,6 +22,8 @@ export type RealtimeObservabilityOptions = {
   onDiagnostic?: (event: DiagnosticEvent) => void;
   onStats?: (stats: WebRTCStats) => void;
   onConnectionQuality?: (report: ConnectionQualityReport) => void;
+  /** Opt-in: measure true glass-to-glass latency via the pixel-marker pipeline. */
+  measureGlassToGlass?: boolean;
 };
 
 type PendingTelemetryDiagnostic = {
@@ -54,8 +57,49 @@ export class RealtimeObservability {
   private stallStartMs = 0;
   private connectionBreakdown: ConnectionBreakdownBuffer | null = null;
   private readonly connectionQuality = new ConnectionQualityEvaluator();
+  /** Glass-to-glass: shared tracker, outgoing stamp pump, and incoming reader. Null unless `measureGlassToGlass`. */
+  private readonly seqTracker: SeqTracker | null;
+  private readonly markerReader: MarkerReader | null;
+  private stampPump: StampPump | null = null;
 
-  constructor(private readonly options: RealtimeObservabilityOptions) {}
+  constructor(private readonly options: RealtimeObservabilityOptions) {
+    this.seqTracker = options.measureGlassToGlass ? new SeqTracker() : null;
+    this.markerReader = this.seqTracker ? createMarkerReader(this.seqTracker) : null;
+  }
+
+  /**
+   * Wrap the outgoing stream so each frame carries a marker, feeding the shared
+   * tracker that the reader matches against. Returns the stream to publish
+   * (unchanged when g2g is off or stamping can't start). Owned here so the
+   * writer and reader of the tracker share one lifecycle and survive reconnects.
+   */
+  attachOutgoingStream(stream: MediaStream, fps: number): MediaStream {
+    if (!this.seqTracker) return stream;
+    try {
+      this.stampPump = createStampPump(stream, { tracker: this.seqTracker, fps });
+      return this.stampPump.stream;
+    } catch (error) {
+      this.options.logger.warn("Failed to start glass-to-glass stamp pump; continuing without it", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return stream;
+    }
+  }
+
+  /** Feed the remote video track to the marker reader (called from the media channel). */
+  attachRemoteVideoTrack(track: MediaStreamTrack): void {
+    this.markerReader?.attach(track);
+  }
+
+  /**
+   * Mark the start of a connect attempt for glass-to-glass timing (resets the
+   * tracker and starts the TTFF clock). Called at the top of each connect/
+   * reconnect so TTFF measures the full setup→first-frame wait. No-op unless g2g
+   * measurement is on.
+   */
+  markGlassToGlassStart(): void {
+    this.seqTracker?.markStart(performance.now());
+  }
 
   diagnostic<K extends DiagnosticEventName>(name: K, data: DiagnosticEvents[K], timestamp: number = Date.now()): void {
     this.options.logger.debug(name, data as Record<string, unknown>);
@@ -196,6 +240,8 @@ export class RealtimeObservability {
 
   stop(): void {
     this.stopStats();
+    this.stampPump?.dispose();
+    this.markerReader?.dispose();
     this.telemetryReporter.stop();
     this.telemetryReporter = new NullTelemetryReporter();
     this.telemetryReporterReady = false;
@@ -208,6 +254,7 @@ export class RealtimeObservability {
   }
 
   private handleStats(stats: WebRTCStats): void {
+    if (this.seqTracker) stats.glassToGlass = this.seqTracker.snapshot();
     this.options.onStats?.(stats);
     this.telemetryReporter.addStats(stats);
     this.detectVideoStall(stats);
@@ -251,5 +298,8 @@ export class RealtimeObservability {
     this.stallStartMs = 0;
     // A reconnect re-enters warm-up; don't blend pre/post-reconnect networks.
     this.connectionQuality.reset();
+    // Note: the g2g tracker is reset via markGlassToGlassStart() at the start of
+    // each connect attempt, NOT here — this runs mid-connect (on room attach) and
+    // would otherwise wipe the TTFF start clock set moments earlier.
   }
 }

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -22,8 +22,8 @@ export type RealtimeObservabilityOptions = {
   onDiagnostic?: (event: DiagnosticEvent) => void;
   onStats?: (stats: WebRTCStats) => void;
   onConnectionQuality?: (report: ConnectionQualityReport) => void;
-  /** Opt-in: measure true glass-to-glass latency via the pixel-marker pipeline. */
-  deep?: boolean;
+  /** Opt-in diagnostic: measure true glass-to-glass latency via the pixel-marker pipeline (visible marker). */
+  debugQuality?: boolean;
 };
 
 type PendingTelemetryDiagnostic = {
@@ -57,13 +57,13 @@ export class RealtimeObservability {
   private stallStartMs = 0;
   private connectionBreakdown: ConnectionBreakdownBuffer | null = null;
   private readonly connectionQuality = new ConnectionQualityEvaluator();
-  /** Glass-to-glass: shared tracker, outgoing stamp pump, and incoming reader. Null unless `deep`. */
+  /** Glass-to-glass: shared tracker, outgoing stamp pump, and incoming reader. Null unless `debugQuality`. */
   private readonly seqTracker: SeqTracker | null;
   private readonly markerReader: MarkerReader | null;
   private stampPump: StampPump | null = null;
 
   constructor(private readonly options: RealtimeObservabilityOptions) {
-    this.seqTracker = options.deep ? new SeqTracker() : null;
+    this.seqTracker = options.debugQuality ? new SeqTracker() : null;
     this.markerReader = this.seqTracker ? createMarkerReader(this.seqTracker) : null;
   }
 

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -23,7 +23,7 @@ export type RealtimeObservabilityOptions = {
   onStats?: (stats: WebRTCStats) => void;
   onConnectionQuality?: (report: ConnectionQualityReport) => void;
   /** Opt-in: measure true glass-to-glass latency via the pixel-marker pipeline. */
-  measureGlassToGlass?: boolean;
+  deep?: boolean;
 };
 
 type PendingTelemetryDiagnostic = {
@@ -57,13 +57,13 @@ export class RealtimeObservability {
   private stallStartMs = 0;
   private connectionBreakdown: ConnectionBreakdownBuffer | null = null;
   private readonly connectionQuality = new ConnectionQualityEvaluator();
-  /** Glass-to-glass: shared tracker, outgoing stamp pump, and incoming reader. Null unless `measureGlassToGlass`. */
+  /** Glass-to-glass: shared tracker, outgoing stamp pump, and incoming reader. Null unless `deep`. */
   private readonly seqTracker: SeqTracker | null;
   private readonly markerReader: MarkerReader | null;
   private stampPump: StampPump | null = null;
 
   constructor(private readonly options: RealtimeObservabilityOptions) {
-    this.seqTracker = options.measureGlassToGlass ? new SeqTracker() : null;
+    this.seqTracker = options.deep ? new SeqTracker() : null;
     this.markerReader = this.seqTracker ? createMarkerReader(this.seqTracker) : null;
   }
 

--- a/packages/sdk/src/realtime/observability/webrtc-stats.ts
+++ b/packages/sdk/src/realtime/observability/webrtc-stats.ts
@@ -1,4 +1,5 @@
 import { REALTIME_CONFIG } from "../config-realtime";
+import type { G2GMetrics } from "./glass-to-glass";
 
 export type WebRTCStats = {
   timestamp: number;
@@ -130,6 +131,13 @@ export type WebRTCStats = {
      */
     selectedCandidatePairs: IceCandidatePair[];
   };
+  /**
+   * True glass-to-glass latency + end-to-end drop signal, merged in by
+   * `RealtimeObservability` when the opt-in pixel-marker measurement is active
+   * (see glass-to-glass.ts). Null otherwise — the stats collector does not
+   * populate it.
+   */
+  glassToGlass: G2GMetrics | null;
 };
 
 /** One side of an ICE candidate pair (sender or receiver). */
@@ -515,6 +523,8 @@ export class WebRTCStatsCollector {
       outboundVideo,
       connection,
       remoteInbound,
+      // Populated downstream by RealtimeObservability when g2g measurement is on.
+      glassToGlass: null,
     };
   }
 }

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -1,6 +1,9 @@
+import { type CustomModelDefinition, type ModelDefinition, resolveFpsNumber } from "../shared/model";
 import type { Logger } from "../utils/logger";
+import type { RealTimeClient, RealTimeClientConnectOptions } from "./client";
 import { REALTIME_CONFIG } from "./config-realtime";
-import type { ConnectionQuality } from "./observability/connection-quality";
+import { type ConnectionQuality, extractSignals, scoreLowerBetter, worst } from "./observability/connection-quality";
+import type { WebRTCStats } from "./observability/webrtc-stats";
 
 /**
  * SDK-only connectivity preflight — run before `realtime.connect()` to decide
@@ -14,8 +17,20 @@ export type ConnectivityTransport = "udp" | "relay" | "failed";
 export type ConnectivityMetrics = {
   /** "udp" = direct UDP works · "relay" = will need TURN (unverified SDK-only) · "failed" = no connectivity. */
   transport: ConnectivityTransport;
-  /** Approximate network round-trip time (ms) from time-to-first STUN candidate, or null. */
+  /** Approximate network round-trip time (ms) from time-to-first STUN candidate (or real RTT in active mode), or null. */
   rttMs: number | null;
+  /** Active-probe only: measured mid-stream (steady-state) glass-to-glass latency (ms), or null. */
+  g2gMs?: number | null;
+  /** Active-probe only: time-to-first-frame (ms) — startup latency to the first rendered model frame, or null. */
+  ttffMs?: number | null;
+  /** Active-probe only: end-to-end frame drop ratio (0–1), or null. */
+  g2gDropRatio?: number | null;
+  /** Active-probe only: server's view of upstream jitter (ms), or null. */
+  upstreamJitterMs?: number | null;
+  /** Active-probe only: server-reported upstream packet loss (0–1), or null. */
+  packetLoss?: number | null;
+  /** Active-probe only: number of glass-to-glass samples collected. */
+  sampleCount?: number;
 };
 
 export type ConnectivityReport = {
@@ -33,10 +48,25 @@ export type CheckConnectivityOptions = {
   iceGatherTimeoutMs?: number;
   /** Abort the probe early. */
   signal?: AbortSignal;
+  /**
+   * Run an active probe instead of the STUN-only check: briefly open a real
+   * session with a synthetic source and measure true glass-to-glass latency,
+   * then tear it down. Requires `model`. Costs a short GPU session.
+   */
+  active?: boolean;
+  /** Required when `active`: the realtime model to probe (latency is model-specific). */
+  model?: ModelDefinition | CustomModelDefinition;
+  /** Active-probe duration (ms). Defaults to config. */
+  durationMs?: number;
 };
+
+/** Realtime `connect` injected by the SDK root so the active probe can open a session. */
+type RealtimeConnect = (stream: MediaStream | null, options: RealTimeClientConnectOptions) => Promise<RealTimeClient>;
 
 export type PreflightOptions = {
   logger: Logger;
+  /** Injected by the SDK root; enables the opt-in active probe. */
+  connect?: RealtimeConnect;
 };
 
 export type PreflightRttThresholds = { goodMs: number; marginalMs: number };
@@ -184,10 +214,256 @@ export function classifyConnectivity(
   };
 }
 
+// --- Active probe (opt-in) ---------------------------------------------------
+
+/** Thresholds the active-probe verdict reuses from the in-session quality config. */
+type ActiveProbeThresholds = Pick<
+  typeof REALTIME_CONFIG.observability.connectionQuality,
+  "rtt" | "glassToGlass" | "ttff" | "loss" | "g2gDrop"
+>;
+
+/**
+ * Classify an active-probe result. Judges startup (TTFF) and steady-state
+ * (mid-stream glass-to-glass) latency separately — both are real experienced
+ * latency on different scales — and folds in drops + upstream loss. Falls back
+ * to RTT only when neither latency could be measured. Pure.
+ */
+export function classifyActiveProbe(
+  metrics: ConnectivityMetrics,
+  thresholds: ActiveProbeThresholds,
+): ConnectivityReport {
+  const reasons: string[] = [];
+
+  if (metrics.transport === "failed") {
+    return {
+      quality: "critical",
+      metrics,
+      reasons: ["Could not establish a realtime session for the active probe."],
+    };
+  }
+
+  const dims: ConnectionQuality[] = [];
+
+  if (metrics.ttffMs != null) {
+    const t = thresholds.ttff;
+    const q = scoreLowerBetter(metrics.ttffMs, t.goodMs, t.fairMs, t.poorMs);
+    dims.push(q);
+    if (q !== "good") {
+      reasons.push(
+        `Time to first frame is ~${(metrics.ttffMs / 1000).toFixed(1)}s (good ≤ ${(t.goodMs / 1000).toFixed(0)}s); the session is slow to start.`,
+      );
+    }
+  }
+
+  if (metrics.g2gMs != null) {
+    const g = thresholds.glassToGlass;
+    const q = scoreLowerBetter(metrics.g2gMs, g.goodMs, g.fairMs, g.poorMs);
+    dims.push(q);
+    if (q !== "good") {
+      reasons.push(
+        `Mid-stream glass-to-glass latency is ~${metrics.g2gMs}ms (good ≤ ${g.goodMs}ms); the real-time experience may feel laggy.`,
+      );
+    }
+  }
+
+  if (metrics.ttffMs == null && metrics.g2gMs == null) {
+    reasons.push(
+      "Could not measure glass-to-glass latency during the probe (no marker round-trip); falling back to network metrics.",
+    );
+    if (metrics.rttMs != null) {
+      dims.push(scoreLowerBetter(metrics.rttMs, thresholds.rtt.goodMs, thresholds.rtt.fairMs, thresholds.rtt.poorMs));
+    }
+  }
+
+  if (metrics.g2gDropRatio != null) {
+    const d = thresholds.g2gDrop;
+    const q = scoreLowerBetter(metrics.g2gDropRatio, d.good, d.fair, d.poor);
+    dims.push(q);
+    if (q !== "good") {
+      reasons.push(
+        `End-to-end frame drop ratio is ${(metrics.g2gDropRatio * 100).toFixed(1)}% (good ≤ ${d.good * 100}%).`,
+      );
+    }
+  }
+
+  if (metrics.packetLoss != null) {
+    const l = thresholds.loss;
+    const q = scoreLowerBetter(metrics.packetLoss, l.good, l.fair, l.poor);
+    dims.push(q);
+    if (q !== "good") {
+      reasons.push(`Upstream packet loss is ${(metrics.packetLoss * 100).toFixed(1)}% (good ≤ ${l.good * 100}%).`);
+    }
+  }
+
+  return { quality: dims.length ? worst(...dims) : "good", metrics, reasons };
+}
+
+/** Derive active-probe metrics from the latest in-session stats sample. */
+function activeMetricsFromStats(stats: WebRTCStats | null): ConnectivityMetrics {
+  if (!stats) {
+    // Connected but no stats arrived yet — connectivity works, just unmeasured.
+    return {
+      transport: "udp",
+      rttMs: null,
+      g2gMs: null,
+      ttffMs: null,
+      g2gDropRatio: null,
+      upstreamJitterMs: null,
+      packetLoss: null,
+      sampleCount: 0,
+    };
+  }
+  // Reuse the in-session signal extractor so the RTT fallback, RFC-3550 loss
+  // normalization, jitter conversion, and relay detection stay in one place.
+  const s = extractSignals(stats);
+  return {
+    transport: s.isRelayed ? "relay" : "udp",
+    rttMs: s.rttMs != null ? Math.round(s.rttMs) : null,
+    g2gMs: s.g2gMs,
+    ttffMs: s.ttffMs,
+    g2gDropRatio: s.g2gDropRatio,
+    upstreamJitterMs: s.upstreamJitterMs != null ? Math.round(s.upstreamJitterMs) : null,
+    packetLoss: s.fractionLost,
+    sampleCount: stats.glassToGlass?.sampleCount ?? 0,
+  };
+}
+
+/**
+ * Animated synthetic video source — no camera permission needed; content is
+ * irrelevant to the marker. Sized to the model's exact input dimensions so the
+ * server doesn't resize/crop the frame, which would move the bottom-left marker
+ * out of where the server reads it (breaking the round trip).
+ */
+function createSyntheticSource(
+  width: number,
+  height: number,
+  fps: number,
+): { stream: MediaStream; dispose: () => void } {
+  if (typeof document === "undefined") {
+    throw new Error("active preflight requires a DOM environment (document is undefined)");
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("active preflight: 2D canvas context unavailable");
+  if (typeof canvas.captureStream !== "function") {
+    throw new Error("active preflight: canvas.captureStream unavailable");
+  }
+
+  let rafHandle: number | null = null;
+  let frame = 0;
+  const draw = () => {
+    frame++;
+    // Animate so the encoder produces real frames at the target rate.
+    ctx.fillStyle = `hsl(${frame % 360}, 60%, 50%)`;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "white";
+    ctx.fillRect((frame * 7) % canvas.width, 48, 96, 96);
+    rafHandle = requestAnimationFrame(draw);
+  };
+  rafHandle = requestAnimationFrame(draw);
+
+  const stream = canvas.captureStream(fps);
+  return {
+    stream,
+    dispose: () => {
+      if (rafHandle !== null) cancelAnimationFrame(rafHandle);
+      for (const track of stream.getTracks()) track.stop();
+    },
+  };
+}
+
+/** Resolve once enough g2g samples exist or the probe window elapses (never rejects). */
+function waitForProbe(
+  getLatest: () => WebRTCStats | null,
+  minSamples: number,
+  durationMs: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const start = performance.now();
+    const tick = () => {
+      if (signal?.aborted) return resolve();
+      if ((getLatest()?.glassToGlass?.sampleCount ?? 0) >= minSamples) return resolve();
+      if (performance.now() - start >= durationMs) return resolve();
+      setTimeout(tick, 200);
+    };
+    setTimeout(tick, 200);
+  });
+}
+
+async function runActiveProbe(args: {
+  connect: RealtimeConnect;
+  logger: Logger;
+  model: ModelDefinition | CustomModelDefinition;
+  durationMs: number;
+  signal: AbortSignal | undefined;
+}): Promise<ConnectivityReport> {
+  const { connect, logger, model, durationMs, signal } = args;
+  const thresholds = REALTIME_CONFIG.observability.connectionQuality;
+
+  let source: { stream: MediaStream; dispose: () => void } | undefined;
+  let client: RealTimeClient | undefined;
+  let latest: WebRTCStats | null = null;
+
+  try {
+    // Match the model's exact input resolution so the server processes the frame
+    // without reshaping it (which would corrupt the bottom-left pixel marker).
+    source = createSyntheticSource(model.width, model.height, resolveFpsNumber(model.fps));
+    client = await connect(source.stream, {
+      model,
+      measureGlassToGlass: true,
+      onRemoteStream: () => {},
+    });
+    client.on("stats", (stats) => {
+      latest = stats;
+    });
+    await waitForProbe(() => latest, REALTIME_CONFIG.preflight.active.minSamples, durationMs, signal);
+  } catch (error) {
+    logger.warn("active preflight: probe failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return classifyActiveProbe(
+      {
+        transport: "failed",
+        rttMs: null,
+        g2gMs: null,
+        g2gDropRatio: null,
+        upstreamJitterMs: null,
+        packetLoss: null,
+        sampleCount: 0,
+      },
+      thresholds,
+    );
+  } finally {
+    client?.disconnect();
+    source?.dispose();
+  }
+
+  return classifyActiveProbe(activeMetricsFromStats(latest), thresholds);
+}
+
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = REALTIME_CONFIG.preflight.defaultStunUrls.map((urls) => ({ urls }));
 
-export const createPreflight = ({ logger }: PreflightOptions) => {
+export const createPreflight = ({ logger, connect }: PreflightOptions) => {
   const checkConnectivity = async (options: CheckConnectivityOptions = {}): Promise<ConnectivityReport> => {
+    if (options.active) {
+      if (!connect) {
+        throw new Error("active preflight is unavailable (realtime client not wired)");
+      }
+      if (!options.model) {
+        throw new Error("active preflight requires a `model` (latency is model-specific)");
+      }
+      return runActiveProbe({
+        connect,
+        logger,
+        model: options.model,
+        durationMs: options.durationMs ?? REALTIME_CONFIG.preflight.active.durationMs,
+        signal: options.signal,
+      });
+    }
+
     const iceServers = options.iceServers ?? DEFAULT_ICE_SERVERS;
     const timeoutMs = options.iceGatherTimeoutMs ?? REALTIME_CONFIG.preflight.iceGatherTimeoutMs;
     const result = await gatherIceCandidates(iceServers, timeoutMs, options.signal, logger);

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -267,11 +267,13 @@ export function classifyActiveProbe(
   }
 
   if (metrics.ttffMs == null && metrics.g2gMs == null) {
-    reasons.push(
-      "Could not measure glass-to-glass latency during the probe (no marker round-trip); falling back to network metrics.",
-    );
     if (metrics.rttMs != null) {
+      reasons.push(
+        "Could not measure glass-to-glass latency during the probe (no marker round-trip); using network RTT instead.",
+      );
       dims.push(scoreLowerBetter(metrics.rttMs, thresholds.rtt.goodMs, thresholds.rtt.fairMs, thresholds.rtt.poorMs));
+    } else {
+      reasons.push("The probe connected but could not measure latency (no marker round-trip and no RTT sample).");
     }
   }
 
@@ -295,7 +297,14 @@ export function classifyActiveProbe(
     }
   }
 
-  return { quality: dims.length ? worst(...dims) : "good", metrics, reasons };
+  // The session connected (transport !== "failed") but produced no usable
+  // quality signal — don't claim "good" we never verified. Report "fair" so the
+  // caller treats it as connected-but-unverified, with the reason explaining why.
+  if (dims.length === 0) {
+    return { quality: "fair", metrics, reasons };
+  }
+
+  return { quality: worst(...dims), metrics, reasons };
 }
 
 /** Derive active-probe metrics from the latest in-session stats sample. */

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -17,7 +17,7 @@ export type ConnectivityTransport = "udp" | "relay" | "failed";
 export type ConnectivityMetrics = {
   /** "udp" = direct UDP works · "relay" = will need TURN (unverified SDK-only) · "failed" = no connectivity. */
   transport: ConnectivityTransport;
-  /** Approximate network round-trip time (ms) from time-to-first STUN candidate (or real RTT in active mode), or null. */
+  /** Approximate network round-trip time (ms) from time-to-first STUN candidate (or real RTT in deep mode), or null. */
   rttMs: number | null;
   /** Active-probe only: measured mid-stream (steady-state) glass-to-glass latency (ms), or null. */
   g2gMs?: number | null;
@@ -49,14 +49,14 @@ export type CheckConnectivityOptions = {
   /** Abort the probe early. */
   signal?: AbortSignal;
   /**
-   * Run an active probe instead of the STUN-only check: briefly open a real
-   * session with a synthetic source and measure true glass-to-glass latency,
+   * Opt-in "deep" probe: instead of the STUN-only network check, briefly open a
+   * real session with a synthetic source, measure true glass-to-glass latency,
    * then tear it down. Requires `model`. Costs a short GPU session.
    */
-  active?: boolean;
-  /** Required when `active`: the realtime model to probe (latency is model-specific). */
+  deep?: boolean;
+  /** Required when `deep`: the realtime model to probe (latency is model-specific). */
   model?: ModelDefinition | CustomModelDefinition;
-  /** Active-probe duration (ms). Defaults to config. */
+  /** Deep-probe duration (ms). Defaults to config. */
   durationMs?: number;
 };
 
@@ -238,7 +238,7 @@ export function classifyActiveProbe(
     return {
       quality: "critical",
       metrics,
-      reasons: ["Could not establish a realtime session for the active probe."],
+      reasons: ["Could not establish a realtime session for the deep probe."],
     };
   }
 
@@ -340,15 +340,15 @@ function createSyntheticSource(
   fps: number,
 ): { stream: MediaStream; dispose: () => void } {
   if (typeof document === "undefined") {
-    throw new Error("active preflight requires a DOM environment (document is undefined)");
+    throw new Error("deep connectivity probe requires a DOM environment (document is undefined)");
   }
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;
   const ctx = canvas.getContext("2d");
-  if (!ctx) throw new Error("active preflight: 2D canvas context unavailable");
+  if (!ctx) throw new Error("deep connectivity probe: 2D canvas context unavailable");
   if (typeof canvas.captureStream !== "function") {
-    throw new Error("active preflight: canvas.captureStream unavailable");
+    throw new Error("deep connectivity probe: canvas.captureStream unavailable");
   }
 
   let rafHandle: number | null = null;
@@ -413,7 +413,7 @@ async function runActiveProbe(args: {
     source = createSyntheticSource(model.width, model.height, resolveFpsNumber(model.fps));
     client = await connect(source.stream, {
       model,
-      measureGlassToGlass: true,
+      deep: true,
       onRemoteStream: () => {},
     });
     client.on("stats", (stats) => {
@@ -421,7 +421,7 @@ async function runActiveProbe(args: {
     });
     await waitForProbe(() => latest, REALTIME_CONFIG.preflight.active.minSamples, durationMs, signal);
   } catch (error) {
-    logger.warn("active preflight: probe failed", {
+    logger.warn("deep connectivity probe failed", {
       error: error instanceof Error ? error.message : String(error),
     });
     return classifyActiveProbe(
@@ -448,12 +448,12 @@ const DEFAULT_ICE_SERVERS: RTCIceServer[] = REALTIME_CONFIG.preflight.defaultStu
 
 export const createPreflight = ({ logger, connect }: PreflightOptions) => {
   const checkConnectivity = async (options: CheckConnectivityOptions = {}): Promise<ConnectivityReport> => {
-    if (options.active) {
+    if (options.deep) {
       if (!connect) {
-        throw new Error("active preflight is unavailable (realtime client not wired)");
+        throw new Error("deep connectivity probe is unavailable (realtime client not wired)");
       }
       if (!options.model) {
-        throw new Error("active preflight requires a `model` (latency is model-specific)");
+        throw new Error("deep connectivity probe requires a `model` (latency is model-specific)");
       }
       return runActiveProbe({
         connect,

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -422,7 +422,7 @@ async function runActiveProbe(args: {
     source = createSyntheticSource(model.width, model.height, resolveFpsNumber(model.fps));
     client = await connect(source.stream, {
       model,
-      deep: true,
+      debugQuality: true,
       onRemoteStream: () => {},
     });
     client.on("stats", (stats) => {

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -169,6 +169,8 @@ export class StreamSession {
       this.resetHandshakeState();
       const initialState = this.getInitialState();
       this.config.observability?.beginConnectionBreakdown(attempt, getInitialImageSizeKb(initialState?.image));
+      // Start the glass-to-glass TTFF clock for this attempt (resets the tracker).
+      this.config.observability?.markGlassToGlassStart();
       const gateAttempt = this.initialStateGate.startAttempt(initialState);
 
       const { roomInfo, initialStateAck } = await this.signaling.openAndJoin({

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -23,6 +23,8 @@ type StatsOverrides = {
   videoNull?: boolean;
   outboundNull?: boolean;
   remoteInboundNull?: boolean;
+  g2gMs?: number;
+  g2gDropRatio?: number;
 };
 
 /** Build a WebRTCStats snapshot that scores "good" by default; override per test. */
@@ -62,6 +64,16 @@ function makeStats(o: StatsOverrides = {}): WebRTCStats {
         ? [{ local: relayCandidate, remote: relayCandidate }]
         : [{ local: hostCandidate, remote: hostCandidate }],
     },
+    glassToGlass:
+      o.g2gMs === undefined && o.g2gDropRatio === undefined
+        ? null
+        : {
+            ttffMs: null,
+            medianMs: o.g2gMs ?? null,
+            p90Ms: null,
+            sampleCount: 1,
+            dropRatio: o.g2gDropRatio ?? null,
+          },
   };
   return stats as unknown as WebRTCStats;
 }
@@ -141,6 +153,34 @@ describe("scoreSnapshot", () => {
     // low upstream headroom: 1 Mbps available vs 3 Mbps needed → critical, unless skipped
     expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 }), THRESHOLDS, opts).quality).toBe("good");
     expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 })).quality).toBe("critical");
+  });
+
+  it("drives the latency verdict off measured glass-to-glass when present (not RTT)", () => {
+    // Low RTT alone reads good, but a high measured g2g (slow model path) must
+    // pull latency down — this is the whole point of the feature.
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ rttSec: 0.05, g2gMs: 1800 }));
+    expect(quality).toBe("critical"); // 1800ms > poor band (1500)
+    expect(limitingFactor).toBe("latency");
+  });
+
+  it("rates a typical mid-stream glass-to-glass latency as good", () => {
+    // ~450ms steady-state (server pipeline ~285ms + network/jitter) is good.
+    expect(scoreSnapshot(makeStats({ g2gMs: 450 })).quality).toBe("good");
+  });
+
+  it("rates a good glass-to-glass latency as good even on a relayed path", () => {
+    // g2g already includes the network legs, so no relay headroom is applied.
+    expect(scoreSnapshot(makeStats({ g2gMs: 450, relayed: true })).quality).toBe("good");
+  });
+
+  it("falls back to RTT for latency when glass-to-glass is absent", () => {
+    expect(scoreSnapshot(makeStats({ rttSec: 0.6 })).quality).toBe("critical");
+  });
+
+  it("flags a high end-to-end frame drop ratio as a stall problem", () => {
+    const { quality, limitingFactor } = scoreSnapshot(makeStats({ g2gDropRatio: 0.2 }));
+    expect(quality).toBe("critical"); // 20% > poor band (10%)
+    expect(limitingFactor).toBe("stall");
   });
 
   it("treats missing metrics as good (absence of evidence is not evidence of badness)", () => {

--- a/packages/sdk/tests/glass-to-glass.unit.test.ts
+++ b/packages/sdk/tests/glass-to-glass.unit.test.ts
@@ -48,6 +48,21 @@ describe("SeqTracker", () => {
     expect(snap.p90Ms).toBe(300);
   });
 
+  it("averages the two middle samples for an even-count median (no high skew)", () => {
+    const t = new SeqTracker();
+    t.markStart(0);
+    const warm = t.stampNext(0);
+    t.recordInbound(warm, 10); // first frame (warm-up, excluded)
+
+    for (const latency of [100, 200, 150, 300]) {
+      const seq = t.stampNext(PAST_WARMUP);
+      t.recordInbound(seq, PAST_WARMUP + latency);
+    }
+    const snap = t.snapshot();
+    expect(snap.sampleCount).toBe(4);
+    expect(snap.medianMs).toBe(175); // sorted [100,150,200,300] -> (150 + 200) / 2
+  });
+
   it("ignores unknown, duplicate, and implausible inbound seqs", () => {
     const t = new SeqTracker();
     const warm = t.stampNext(0);

--- a/packages/sdk/tests/glass-to-glass.unit.test.ts
+++ b/packages/sdk/tests/glass-to-glass.unit.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { SeqTracker } from "../src/realtime/observability/glass-to-glass.js";
+
+// Mid-stream samples are only counted past a 2s warm-up after the first frame,
+// so tests establish a first frame, then feed steady-state samples well past it.
+const PAST_WARMUP = 5_000;
+
+describe("SeqTracker", () => {
+  it("allocates monotonic 16-bit seqs that wrap at 0xffff", () => {
+    const t = new SeqTracker();
+    expect(t.stampNext(0)).toBe(0);
+    expect(t.stampNext(0)).toBe(1);
+    expect(t.stampNext(0)).toBe(2);
+    const t2 = new SeqTracker();
+    let last = -1;
+    for (let i = 0; i < 0xffff; i++) last = t2.stampNext(0);
+    expect(last).toBe(0xffff - 1);
+    expect(t2.stampNext(0)).toBe(0xffff);
+    expect(t2.stampNext(0)).toBe(0); // wrap
+  });
+
+  it("measures time-to-first-frame from markStart to the first rendered frame", () => {
+    const t = new SeqTracker();
+    t.markStart(1_000);
+    const seq = t.stampNext(1_100);
+    t.recordInbound(seq, 6_000); // first frame at 6000 → TTFF = 6000 - 1000
+    const snap = t.snapshot();
+    expect(snap.ttffMs).toBe(5_000);
+    // The first frame is the cold-start frame; it does not count toward mid-stream.
+    expect(snap.sampleCount).toBe(0);
+    expect(snap.medianMs).toBeNull();
+  });
+
+  it("computes mid-stream latency percentiles, excluding the warm-up frames", () => {
+    const t = new SeqTracker();
+    t.markStart(0);
+    const warm = t.stampNext(0);
+    t.recordInbound(warm, 10); // first frame establishes warm-up window (not a sample)
+
+    const latencies = [100, 200, 150, 300, 250];
+    for (const latency of latencies) {
+      const seq = t.stampNext(PAST_WARMUP);
+      t.recordInbound(seq, PAST_WARMUP + latency); // matched well past warm-up
+    }
+    const snap = t.snapshot();
+    expect(snap.sampleCount).toBe(5);
+    expect(snap.medianMs).toBe(200); // sorted [100,150,200,250,300]
+    expect(snap.p90Ms).toBe(300);
+  });
+
+  it("ignores unknown, duplicate, and implausible inbound seqs", () => {
+    const t = new SeqTracker();
+    const warm = t.stampNext(0);
+    t.recordInbound(warm, 0); // first frame
+
+    const seq = t.stampNext(PAST_WARMUP);
+    t.recordInbound(9999, PAST_WARMUP + 10); // unknown seq
+    t.recordInbound(seq, PAST_WARMUP + 120); // valid -> 120ms
+    t.recordInbound(seq, PAST_WARMUP + 130); // duplicate (already consumed) -> ignored
+    const seq2 = t.stampNext(PAST_WARMUP + 1_000);
+    t.recordInbound(seq2, PAST_WARMUP + 500); // negative delta -> ignored
+    const snap = t.snapshot();
+    expect(snap.sampleCount).toBe(1);
+    expect(snap.medianMs).toBe(120);
+  });
+
+  it("reports null drop ratio until enough outcomes exist", () => {
+    const t = new SeqTracker();
+    const warm = t.stampNext(0);
+    t.recordInbound(warm, 0);
+    const seq = t.stampNext(PAST_WARMUP);
+    t.recordInbound(seq, PAST_WARMUP + 50);
+    expect(t.snapshot().dropRatio).toBeNull(); // 1 outcome < DROP_MIN_OUTCOMES
+  });
+
+  it("infers end-to-end drops from seqs that age out unmatched (post warm-up)", () => {
+    const t = new SeqTracker();
+    const warm = t.stampNext(0);
+    t.recordInbound(warm, 0); // first frame; subsequent stamps are post-warm-up
+
+    // Stamp 286 past warm-up: 30 oldest (beyond MAX_PENDING=256) age out unmatched -> 30 drops.
+    const seqs: number[] = [];
+    for (let i = 0; i < 286; i++) seqs.push(t.stampNext(PAST_WARMUP));
+    // Deliver 20 of the still-pending seqs.
+    for (let i = 100; i < 120; i++) t.recordInbound(seqs[i], PAST_WARMUP + 100);
+    const snap = t.snapshot();
+    // 30 dropped + 20 delivered = 50 outcomes -> 0.6 drop ratio.
+    expect(snap.dropRatio).toBeCloseTo(0.6, 5);
+    expect(snap.sampleCount).toBe(20);
+  });
+
+  it("does not count pre-first-frame stamps as drops (pre-publish frames)", () => {
+    const t = new SeqTracker();
+    t.markStart(0);
+    // 300 stamps before any frame ever renders (e.g. while still connecting).
+    for (let i = 0; i < 300; i++) t.stampNext(i);
+    // No match yet -> no outcomes recorded despite > MAX_PENDING evictions.
+    expect(t.snapshot().dropRatio).toBeNull();
+  });
+
+  it("reset clears measurement state but keeps seq monotonic", () => {
+    const t = new SeqTracker();
+    t.markStart(0);
+    const seq = t.stampNext(0);
+    t.recordInbound(seq, 100);
+    t.reset();
+    expect(t.snapshot()).toEqual({ ttffMs: null, medianMs: null, p90Ms: null, sampleCount: 0, dropRatio: null });
+    expect(t.stampNext(0)).toBe(1); // continues, not reset to 0
+  });
+});

--- a/packages/sdk/tests/pixel-marker.unit.test.ts
+++ b/packages/sdk/tests/pixel-marker.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  MIN_MARKER_HEIGHT,
+  MIN_MARKER_WIDTH,
+  type RGBAImageData,
+  read,
+  stamp,
+} from "../src/realtime/observability/pixel-marker.js";
+
+function makeImage(width: number, height: number, fill = 0): RGBAImageData {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < width * height; i++) {
+    data[i * 4] = fill;
+    data[i * 4 + 1] = fill;
+    data[i * 4 + 2] = fill;
+    data[i * 4 + 3] = 255;
+  }
+  return { width, height, data };
+}
+
+/** Uniform nearest-neighbor scale — stands in for WebRTC transport up/downscaling. */
+function scaleNearest(img: RGBAImageData, factor: number): RGBAImageData {
+  const width = Math.round(img.width * factor);
+  const height = Math.round(img.height * factor);
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const sx = Math.min(img.width - 1, Math.floor(x / factor));
+      const sy = Math.min(img.height - 1, Math.floor(y / factor));
+      const so = (sy * img.width + sx) * 4;
+      const o = (y * width + x) * 4;
+      data[o] = img.data[so];
+      data[o + 1] = img.data[so + 1];
+      data[o + 2] = img.data[so + 2];
+      data[o + 3] = 255;
+    }
+  }
+  return { width, height, data };
+}
+
+describe("pixel-marker stamp/read", () => {
+  it("round-trips a sweep of seqs at native resolution", () => {
+    for (const seq of [0, 1, 2, 42, 255, 256, 1000, 0x1234, 0x7fff, 0xabcd, 0xffff]) {
+      const img = makeImage(256, 256);
+      expect(stamp(img, seq)).toBe(true);
+      expect(read(img)).toBe(seq);
+    }
+  });
+
+  it("masks seq to 16 bits (matches server seq & 0xFFFF)", () => {
+    const img = makeImage(256, 256);
+    stamp(img, 70_000); // 70000 & 0xffff === 4464
+    expect(read(img)).toBe(70_000 & 0xffff);
+  });
+
+  it("no-ops and refuses to read on a frame too small for the marker", () => {
+    const tiny = makeImage(MIN_MARKER_WIDTH - 1, MIN_MARKER_HEIGHT - 1);
+    expect(stamp(tiny, 5)).toBe(false);
+    expect(read(tiny)).toBeNull();
+  });
+
+  it("recovers the seq after the frame is downscaled (BWE) — block-size auto-detect", () => {
+    const img = makeImage(256, 256);
+    stamp(img, 0x2bcd);
+    expect(read(scaleNearest(img, 0.5))).toBe(0x2bcd); // block 8 -> 4
+  });
+
+  it("recovers the seq after the frame is upscaled", () => {
+    const img = makeImage(256, 256);
+    stamp(img, 0x0777);
+    expect(read(scaleNearest(img, 2))).toBe(0x0777); // block 8 -> 16
+  });
+
+  it("returns null on an unstamped frame (no false positive)", () => {
+    expect(read(makeImage(256, 256, 0))).toBeNull();
+    expect(read(makeImage(256, 256, 128))).toBeNull();
+    expect(read(makeImage(256, 256, 255))).toBeNull();
+  });
+
+  it("rejects a corrupted marker via the checksum (no wrong seq)", () => {
+    const img = makeImage(256, 256);
+    stamp(img, 0x1234);
+    // Flip a single data column (the MSB) across every redundant row: majority
+    // vote decodes a seq one bit off, so its checksum no longer matches the
+    // stored one and the read is rejected rather than returning a wrong seq.
+    const { width, height, data } = img;
+    const logCol = 4; // first data bit
+    for (let logRow = 0; logRow < 4; logRow++) {
+      const row = height - (4 - logRow) * 8 + 4;
+      const sampleOffset = (row * width + (logCol * 8 + 4)) * 4;
+      const flipped = data[sampleOffset] >= 128 ? 50 : 200;
+      for (let bx = 0; bx < 8; bx++) {
+        const o = (row * width + (logCol * 8 + bx)) * 4;
+        data[o] = flipped;
+        data[o + 1] = flipped;
+        data[o + 2] = flipped;
+      }
+    }
+    expect(read(img)).toBeNull();
+  });
+
+  it("survives a single corrupted redundant row via majority vote", () => {
+    const img = makeImage(256, 256);
+    stamp(img, 0x5a5a);
+    // Destroy only the topmost redundant row (logRow 0); the other 3 still vote.
+    const { width, height, data } = img;
+    const row = height - 4 * 8 + 4;
+    for (let x = 0; x < width; x++) {
+      const o = (row * width + x) * 4;
+      data[o] = 123;
+      data[o + 1] = 123;
+      data[o + 2] = 123;
+    }
+    expect(read(img)).toBe(0x5a5a);
+  });
+});

--- a/packages/sdk/tests/preflight.unit.test.ts
+++ b/packages/sdk/tests/preflight.unit.test.ts
@@ -1,8 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { classifyConnectivity, createPreflight, type PreflightRttThresholds } from "../src/realtime/preflight.js";
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
+import {
+  type ConnectivityMetrics,
+  classifyActiveProbe,
+  classifyConnectivity,
+  createPreflight,
+  type PreflightRttThresholds,
+} from "../src/realtime/preflight.js";
 
 const logger = { debug() {}, info() {}, warn() {}, error() {} };
 const RTT: PreflightRttThresholds = { goodMs: 150, marginalMs: 300 };
+const PROBE_THRESHOLDS = REALTIME_CONFIG.observability.connectionQuality;
+
+function probeMetrics(overrides: Partial<ConnectivityMetrics> = {}): ConnectivityMetrics {
+  return {
+    transport: "udp",
+    rttMs: 50,
+    g2gMs: 450,
+    ttffMs: 2_000,
+    g2gDropRatio: 0,
+    upstreamJitterMs: 5,
+    packetLoss: 0,
+    sampleCount: 30,
+    ...overrides,
+  };
+}
 
 describe("classifyConnectivity", () => {
   it("treats no connectivity as critical", () => {
@@ -38,6 +60,57 @@ describe("classifyConnectivity", () => {
   it("treats direct UDP with unknown RTT as good", () => {
     const report = classifyConnectivity({ transport: "udp", rttMs: null }, RTT);
     expect(report.quality).toBe("good");
+  });
+});
+
+describe("classifyActiveProbe", () => {
+  it("rates a fast startup and low mid-stream latency as good with no reasons", () => {
+    const report = classifyActiveProbe(probeMetrics({ ttffMs: 2_000, g2gMs: 450 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("good");
+    expect(report.reasons).toHaveLength(0);
+  });
+
+  it("drives the verdict off mid-stream glass-to-glass even when RTT is low", () => {
+    const report = classifyActiveProbe(probeMetrics({ rttMs: 30, g2gMs: 1800 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("critical"); // 1800ms > poor band (1500)
+    expect(report.reasons.some((r) => r.includes("glass-to-glass"))).toBe(true);
+  });
+
+  it("scores time-to-first-frame separately from mid-stream latency", () => {
+    // Good steady state, but a very slow cold start (12s) must pull the verdict down.
+    const report = classifyActiveProbe(probeMetrics({ ttffMs: 12_000, g2gMs: 450 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("critical"); // 12s > poor band (10s)
+    expect(report.reasons.some((r) => r.includes("first frame"))).toBe(true);
+  });
+
+  it("treats a ~4-5s cold start as fair, not critical", () => {
+    const report = classifyActiveProbe(probeMetrics({ ttffMs: 4_500, g2gMs: 450 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("fair"); // 4.5s is within the fair band (≤6s)
+  });
+
+  it("falls back to RTT when neither latency could be measured", () => {
+    const report = classifyActiveProbe(
+      probeMetrics({ g2gMs: null, ttffMs: null, rttMs: 600, g2gDropRatio: null, packetLoss: null }),
+      PROBE_THRESHOLDS,
+    );
+    expect(report.quality).toBe("critical"); // RTT 600 > poor band (500)
+    expect(report.reasons.some((r) => r.includes("Could not measure"))).toBe(true);
+  });
+
+  it("flags a high end-to-end drop ratio even when latency is good", () => {
+    const report = classifyActiveProbe(probeMetrics({ g2gMs: 150, g2gDropRatio: 0.2 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("critical");
+  });
+
+  it("flags high upstream packet loss", () => {
+    const report = classifyActiveProbe(probeMetrics({ g2gMs: 150, packetLoss: 0.2 }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("critical");
+  });
+
+  it("treats a failed connection as critical", () => {
+    const report = classifyActiveProbe(probeMetrics({ transport: "failed" }), PROBE_THRESHOLDS);
+    expect(report.quality).toBe("critical");
+    expect(report.reasons.length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/sdk/tests/preflight.unit.test.ts
+++ b/packages/sdk/tests/preflight.unit.test.ts
@@ -112,6 +112,16 @@ describe("classifyActiveProbe", () => {
     expect(report.quality).toBe("critical");
     expect(report.reasons.length).toBeGreaterThan(0);
   });
+
+  it("returns fair (not good) when connected but nothing could be measured", () => {
+    // Session established (transport udp) but the probe produced no signal at all.
+    const report = classifyActiveProbe(
+      probeMetrics({ g2gMs: null, ttffMs: null, rttMs: null, g2gDropRatio: null, packetLoss: null }),
+      PROBE_THRESHOLDS,
+    );
+    expect(report.quality).toBe("fair");
+    expect(report.reasons.length).toBeGreaterThan(0);
+  });
 });
 
 describe("checkConnectivity", () => {


### PR DESCRIPTION
## What & why

PR #156 shipped connectivity signals, but they only measured **network RTT** — which hides the dominant cost in realtime video (model inference), so a session could report "good" while actually feeling laggy. This adds **opt-in true glass-to-glass latency**: the real camera→display latency, measured end-to-end by stamping a marker into each outgoing frame and reading it back off the rendered output. It reports **startup** (`ttffMs`) and **steady-state** (`g2gMs`) latency separately — a slow first frame is a different problem from a laggy steady state — plus end-to-end frame drops (`g2gDropRatio`) and the server's view of upstream jitter, and the measured latency drives the in-session quality verdict so apps can react to what users actually experience. The same measurement also powers an opt-in **deep preflight probe** that briefly opens a real session to return a *measured* verdict before committing a user to a full one. Measurement is off by default — it stamps a visible marker and adds per-frame work — so existing sessions are unaffected.

## Usage

```ts
// In-session: opt into diagnostic glass-to-glass measurement
// (visible marker + per-frame work — diagnostic only, not for production UX)
const rt = await client.realtime.connect(stream, {
  model: models.realtime("lucy-2.1"),
  debugQuality: true,
  onConnectionQuality: ({ quality, metrics }) => {
    // metrics.ttffMs (startup), metrics.g2gMs (steady-state), metrics.g2gDropRatio
    console.log(quality, metrics.g2gMs);
  },
});

// Pre-session: a measured verdict before you show the integration
const probe = await client.realtime.checkConnectivity({
  deep: true,
  model: models.realtime("lucy-2.1"),
});
console.log(probe.quality, probe.metrics.g2gMs, probe.metrics.ttffMs);
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime connect (query params, outgoing video pipeline) and quality scoring; opt-in only but deep probe opens billable GPU sessions and debug mode alters published video.
> 
> **Overview**
> Adds **opt-in true glass-to-glass latency** so connection quality can reflect model + pipeline delay, not just network RTT. With `connect({ debugQuality: true })`, the SDK stamps a server-compatible pixel marker on outgoing frames (`pixel_latency=1`), reads it from the rendered remote video, and exposes **TTFF**, steady-state **`g2gMs`**, **`g2gDropRatio`**, and upstream jitter on `stats` / `connectionQuality`. When measured g2g is present, it **replaces RTT** for the latency dimension and folds drops into stall scoring.
> 
> **Preflight** gains `checkConnectivity({ deep: true, model })`: a short real session on a synthetic canvas source (GPU cost) that reuses the same measurement and in-session thresholds for a pre-connect verdict. Default STUN-only preflight is unchanged.
> 
> Mirroring is refactored into a shared **frame-transform pump** (used for stamps and flip). README, demo page, config bands, and unit tests cover the new paths. Measurement stays **off by default** (visible marker + per-frame work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a63dc8ceaa3b260d42a6e7c6f14c1f7116ae0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->