### PR TITLE
fix(realtime): publish single camera layer + maintain-framerate to cut SFU ingress reorder

### DIFF
--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -35,6 +35,23 @@ export const REALTIME_CONFIG = {
     defaultMaxVideoBitrateBps: 3_500_000,
     vp9MaxVideoBitrateBps: 3_000_000,
     defaultPublishFps: 30,
+    /**
+     * Publish a single camera layer (no simulcast). The camera feeds exactly
+     * one subscriber — the inference server — and dynacast/adaptiveStream are
+     * off, so extra simulcast layers are never selected away; they are pure
+     * wasted uplink and extra packets-per-second that amplify packet reorder /
+     * inter-arrival jitter on the publisher->SFU ingress (the leg where the
+     * SFU measures the 18-34% out-of-order spikes). One layer = fewer packets
+     * and smaller bursts on the client's WiFi/cellular uplink.
+     */
+    publishSimulcast: false,
+    /**
+     * Under uplink pressure the encoder should shed RESOLUTION, not FRAMERATE.
+     * A steady cadence matters more than spatial detail for a real-time v2v
+     * model that resamples to the live edge; dropping fps instead would starve
+     * the model's input cadence and surface as stutter.
+     */
+    publishDegradationPreference: "maintain-framerate",
   },
   observability: {
     stallFpsThreshold: 0.5,

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -25,7 +25,8 @@ export function getDefaultVideoPublishOptions(videoCodec?: VideoCodec): TrackPub
   return {
     source: Track.Source.Camera,
     videoCodec: resolvedCodec,
-    simulcast: resolvedCodec !== "vp9",
+    simulcast: REALTIME_CONFIG.livekit.publishSimulcast,
+    degradationPreference: REALTIME_CONFIG.livekit.publishDegradationPreference,
     videoEncoding: {
       maxBitrate,
       maxFramerate: REALTIME_CONFIG.livekit.defaultPublishFps,

--- a/packages/sdk/tests/media-channel.unit.test.ts
+++ b/packages/sdk/tests/media-channel.unit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+// media-channel.ts imports value bindings (Room, RoomEvent, Track) from
+// livekit-client at module load. getDefaultVideoPublishOptions only reads
+// Track.Source.Camera, so a minimal stub is enough to import it in node.
+vi.mock("livekit-client", () => ({
+  Room: class {},
+  RoomEvent: { TrackSubscribed: "trackSubscribed", Disconnected: "disconnected" },
+  Track: {
+    Kind: { Video: "video", Audio: "audio" },
+    Source: { Camera: "camera" },
+  },
+}));
+
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
+import { getDefaultVideoPublishOptions, type VideoCodec } from "../src/realtime/media-channel.js";
+
+const CODECS: VideoCodec[] = ["h264", "vp8", "vp9", "av1"];
+
+describe("getDefaultVideoPublishOptions", () => {
+  it("publishes a single (non-simulcast) camera layer for every codec", () => {
+    // The camera publish feeds ONE subscriber (the inference server) and
+    // dynacast/adaptiveStream are off, so simulcast layers are wasted uplink
+    // and extra packets that amplify SFU ingress reorder/jitter.
+    for (const codec of CODECS) {
+      expect(getDefaultVideoPublishOptions(codec).simulcast).toBe(false);
+    }
+    expect(getDefaultVideoPublishOptions().simulcast).toBe(false);
+  });
+
+  it("prefers maintaining framerate (sheds resolution) under uplink pressure", () => {
+    for (const codec of CODECS) {
+      expect(getDefaultVideoPublishOptions(codec).degradationPreference).toBe("maintain-framerate");
+    }
+  });
+
+  it("targets the camera source and forwards the configured publish fps", () => {
+    const opts = getDefaultVideoPublishOptions("h264");
+    expect(opts.source).toBe("camera");
+    expect(opts.videoEncoding?.maxFramerate).toBe(REALTIME_CONFIG.livekit.defaultPublishFps);
+  });
+
+  it("caps bitrate with the vp9-specific limit for vp9 and the default otherwise", () => {
+    expect(getDefaultVideoPublishOptions("vp9").videoEncoding?.maxBitrate).toBe(
+      REALTIME_CONFIG.livekit.vp9MaxVideoBitrateBps,
+    );
+    expect(getDefaultVideoPublishOptions("h264").videoEncoding?.maxBitrate).toBe(
+      REALTIME_CONFIG.livekit.defaultMaxVideoBitrateBps,
+    );
+  });
+});


### PR DESCRIPTION
## What

In `getDefaultVideoPublishOptions` (`packages/sdk/src/realtime/media-channel.ts`):

1. **`simulcast: false`** for every codec (was `true` for everything but vp9).
2. **`degradationPreference: "maintain-framerate"`** so the encoder sheds resolution, not cadence, under uplink pressure.

Both are tunable in `REALTIME_CONFIG.livekit`. Adds a unit test pinning the publish options.

## Why

RT sessions show RTP **reorder / inter-arrival-jitter spikes** at the LiveKit SFU on the **publisher→SFU ingress** (camera uplink): 18–34% out-of-order, ~0 loss, low SFU CPU, bursting on parallel sessions.

A deep analysis (LiveKit v1.11 source + repo audit + WebRTC literature, adversarially verified) found the reorder is **created on the client uplink** (WiFi Block-Ack / cellular ARQ retransmit-out-of-order + multipath) — the SFU only measures and forwards it, and **no server `rtc.*` knob can un-reorder it.** The publisher is the only place that controls packet-rate/burstiness on that uplink.

- The camera publish feeds **one** subscriber (the inference server), and `dynacast`/`adaptiveStream` are off → simulcast layers are never selected away. They're pure wasted uplink + extra packets/sec that amplify ingress reorder/jitter. One layer = fewer packets, smaller bursts.
- `maintain-framerate`: a real-time v2v model resamples to the live edge, so steady fps matters more than spatial detail.

This reduces reorder **probability/magnitude**; it does not make a bad link stop reordering.

## Testing
- New unit test `tests/media-channel.unit.test.ts` (written test-first): green.
- `tsc --noEmit`: clean. `biome check`: clean.
- Full unit suite: 97 passed; one **pre-existing** failure in `tests/unit.test.ts` (`msw` / `localStorage.getItem` env issue, reproduces on clean `main`, unrelated to this change).

## Follow-ups (separate PRs)
- Adaptive publish downgrade wired to the existing `connection-quality` signal.
- Bouncer **server-side** per-IP/app session-concurrency cap (authoritative; clients can't be trusted to self-limit the parallel-session bursts).

---
**Platform team / Linear:** https://linear.app/decart/issue/PLA-311/sdk-publish-single-camera-layer-maintain-framerate-to-cut-sfu-ingress

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default LiveKit camera encoding for all codecs (less simulcast uplink, different degradation under congestion), which can affect video quality on poor networks but targets realtime inference stability.
> 
> **Overview**
> Camera publish defaults are tightened to cut uplink packet rate and protect frame cadence for real-time v2v.
> 
> **`getDefaultVideoPublishOptions`** now sets **`simulcast: false` for every codec** (previously simulcast was on for all codecs except vp9) and adds **`degradationPreference: "maintain-framerate"`** so constrained uplink drops resolution instead of fps. Both values live on **`REALTIME_CONFIG.livekit`** as **`publishSimulcast`** and **`publishDegradationPreference`** so they can be tuned without code changes.
> 
> A new **`media-channel.unit.test.ts`** pins simulcast off, maintain-framerate, camera source/fps, and vp9 vs default bitrate caps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d8853aefd57a6250a7de92d134dcb3903ac3a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

https://linear.app/decart/issue/API-1164/enable-udp-turn-for-regional-livekit-sfus