### PR TITLE
fix(realtime): honour abort signal during deep preflight connect

### DIFF
--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -383,6 +383,42 @@ function createSyntheticSource(
   };
 }
 
+function isAborted(signal: AbortSignal | undefined): boolean {
+  return signal?.aborted ?? false;
+}
+
+/** Reject when `signal` aborts (or immediately if already aborted). */
+function abortPromise(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    signal.addEventListener(
+      "abort",
+      () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
+      { once: true },
+    );
+  });
+}
+
+function abortedDeepProbeReport(): ConnectivityReport {
+  return {
+    quality: "fair",
+    metrics: {
+      transport: "failed",
+      rttMs: null,
+      g2gMs: null,
+      ttffMs: null,
+      g2gDropRatio: null,
+      upstreamJitterMs: null,
+      packetLoss: null,
+      sampleCount: 0,
+    },
+    reasons: ["Deep connectivity probe aborted."],
+  };
+}
+
 /** Resolve once enough g2g samples exist or the probe window elapses (never rejects). */
 function waitForProbe(
   getLatest: () => WebRTCStats | null,
@@ -416,20 +452,40 @@ async function runActiveProbe(args: {
   let client: RealTimeClient | undefined;
   let latest: WebRTCStats | null = null;
 
+  if (isAborted(signal)) return abortedDeepProbeReport();
+
   try {
     // Match the model's exact input resolution so the server processes the frame
     // without reshaping it (which would corrupt the bottom-left pixel marker).
     source = createSyntheticSource(model.width, model.height, resolveFpsNumber(model.fps));
-    client = await connect(source.stream, {
+
+    const connectTask = connect(source.stream, {
       model,
       debugQuality: true,
       onRemoteStream: () => {},
     });
+    const onAbortDuringConnect = () => {
+      connectTask.then((c) => c.disconnect()).catch(() => {});
+    };
+    signal?.addEventListener("abort", onAbortDuringConnect, { once: true });
+    try {
+      client = signal ? await Promise.race([connectTask, abortPromise(signal)]) : await connectTask;
+    } catch (error) {
+      if (isAborted(signal)) return abortedDeepProbeReport();
+      throw error;
+    } finally {
+      signal?.removeEventListener("abort", onAbortDuringConnect);
+    }
+
+    if (isAborted(signal)) return abortedDeepProbeReport();
+
     client.on("stats", (stats) => {
       latest = stats;
     });
     await waitForProbe(() => latest, REALTIME_CONFIG.preflight.active.minSamples, durationMs, signal);
+    if (isAborted(signal)) return abortedDeepProbeReport();
   } catch (error) {
+    if (isAborted(signal)) return abortedDeepProbeReport();
     logger.warn("deep connectivity probe failed", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -383,40 +383,35 @@ function createSyntheticSource(
   };
 }
 
-function isAborted(signal: AbortSignal | undefined): boolean {
-  return signal?.aborted ?? false;
-}
+const ABORTED_DEEP_PROBE: ConnectivityReport = {
+  quality: "fair",
+  metrics: {
+    transport: "failed",
+    rttMs: null,
+    g2gMs: null,
+    ttffMs: null,
+    g2gDropRatio: null,
+    upstreamJitterMs: null,
+    packetLoss: null,
+    sampleCount: 0,
+  },
+  reasons: ["Deep connectivity probe aborted."],
+};
 
-/** Reject when `signal` aborts (or immediately if already aborted). */
-function abortPromise(signal: AbortSignal): Promise<never> {
-  return new Promise((_, reject) => {
-    if (signal.aborted) {
-      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
-      return;
-    }
-    signal.addEventListener(
-      "abort",
-      () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
-      { once: true },
-    );
-  });
-}
-
-function abortedDeepProbeReport(): ConnectivityReport {
-  return {
-    quality: "fair",
-    metrics: {
-      transport: "failed",
-      rttMs: null,
-      g2gMs: null,
-      ttffMs: null,
-      g2gDropRatio: null,
-      upstreamJitterMs: null,
-      packetLoss: null,
-      sampleCount: 0,
-    },
-    reasons: ["Deep connectivity probe aborted."],
-  };
+/** Unblock `promise` early when `signal` aborts. */
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener(
+        "abort",
+        () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
+        { once: true },
+      );
+    }),
+  ]);
 }
 
 /** Resolve once enough g2g samples exist or the probe window elapses (never rejects). */
@@ -452,7 +447,7 @@ async function runActiveProbe(args: {
   let client: RealTimeClient | undefined;
   let latest: WebRTCStats | null = null;
 
-  if (isAborted(signal)) return abortedDeepProbeReport();
+  if (signal?.aborted) return ABORTED_DEEP_PROBE;
 
   try {
     // Match the model's exact input resolution so the server processes the frame
@@ -464,28 +459,18 @@ async function runActiveProbe(args: {
       debugQuality: true,
       onRemoteStream: () => {},
     });
-    const onAbortDuringConnect = () => {
-      connectTask.then((c) => c.disconnect()).catch(() => {});
-    };
-    signal?.addEventListener("abort", onAbortDuringConnect, { once: true });
-    try {
-      client = signal ? await Promise.race([connectTask, abortPromise(signal)]) : await connectTask;
-    } catch (error) {
-      if (isAborted(signal)) return abortedDeepProbeReport();
-      throw error;
-    } finally {
-      signal?.removeEventListener("abort", onAbortDuringConnect);
-    }
-
-    if (isAborted(signal)) return abortedDeepProbeReport();
+    signal?.addEventListener("abort", () => connectTask.then((c) => c.disconnect()).catch(() => {}), {
+      once: true,
+    });
+    client = await raceAbort(connectTask, signal);
 
     client.on("stats", (stats) => {
       latest = stats;
     });
     await waitForProbe(() => latest, REALTIME_CONFIG.preflight.active.minSamples, durationMs, signal);
-    if (isAborted(signal)) return abortedDeepProbeReport();
+    if (signal?.aborted) return ABORTED_DEEP_PROBE;
   } catch (error) {
-    if (isAborted(signal)) return abortedDeepProbeReport();
+    if (signal?.aborted) return ABORTED_DEEP_PROBE;
     logger.warn("deep connectivity probe failed", {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/packages/sdk/src/realtime/preflight.ts
+++ b/packages/sdk/src/realtime/preflight.ts
@@ -405,11 +405,9 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal | undefined): Pro
   return Promise.race([
     promise,
     new Promise<never>((_, reject) => {
-      signal.addEventListener(
-        "abort",
-        () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")),
-        { once: true },
-      );
+      signal.addEventListener("abort", () => reject(signal.reason ?? new DOMException("Aborted", "AbortError")), {
+        once: true,
+      });
     }),
   ]);
 }

--- a/packages/sdk/tests/preflight.unit.test.ts
+++ b/packages/sdk/tests/preflight.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
 import type { RealTimeClient } from "../src/realtime/client.js";
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
 import {
   type ConnectivityMetrics,
   classifyActiveProbe,
@@ -128,26 +128,21 @@ describe("classifyActiveProbe", () => {
 
 function stubDeepProbeDom() {
   const tracks = [{ stop: vi.fn() }];
-  vi.stubGlobal(
-    "document",
-    {
-      createElement: vi.fn(() => ({
-        width: 0,
-        height: 0,
-        getContext: vi.fn(() => ({
-          fillRect: vi.fn(),
-          set fillStyle(_: string) {},
-        })),
-        captureStream: vi.fn(() => ({
-          getTracks: () => tracks,
-          getVideoTracks: () => tracks,
-        })),
+  vi.stubGlobal("document", {
+    createElement: vi.fn(() => ({
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({
+        fillRect: vi.fn(),
+        set fillStyle(_: string) {},
       })),
-    } as unknown as Document,
-  );
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
-    setTimeout(() => cb(performance.now()), 0),
-  );
+      captureStream: vi.fn(() => ({
+        getTracks: () => tracks,
+        getVideoTracks: () => tracks,
+      })),
+    })),
+  } as unknown as Document);
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => setTimeout(() => cb(performance.now()), 0));
   vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
 }
 

--- a/packages/sdk/tests/preflight.unit.test.ts
+++ b/packages/sdk/tests/preflight.unit.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
+import type { RealTimeClient } from "../src/realtime/client.js";
 import {
   type ConnectivityMetrics,
   classifyActiveProbe,
@@ -7,6 +8,7 @@ import {
   createPreflight,
   type PreflightRttThresholds,
 } from "../src/realtime/preflight.js";
+import { models } from "../src/shared/model.js";
 
 const logger = { debug() {}, info() {}, warn() {}, error() {} };
 const RTT: PreflightRttThresholds = { goodMs: 150, marginalMs: 300 };
@@ -124,6 +126,31 @@ describe("classifyActiveProbe", () => {
   });
 });
 
+function stubDeepProbeDom() {
+  const tracks = [{ stop: vi.fn() }];
+  vi.stubGlobal(
+    "document",
+    {
+      createElement: vi.fn(() => ({
+        width: 0,
+        height: 0,
+        getContext: vi.fn(() => ({
+          fillRect: vi.fn(),
+          set fillStyle(_: string) {},
+        })),
+        captureStream: vi.fn(() => ({
+          getTracks: () => tracks,
+          getVideoTracks: () => tracks,
+        })),
+      })),
+    } as unknown as Document,
+  );
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 0),
+  );
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
+}
+
 describe("checkConnectivity", () => {
   it("reports critical/failed when WebRTC is unavailable in the environment", async () => {
     // The vitest unit env has no RTCPeerConnection, so the probe degrades cleanly.
@@ -131,5 +158,48 @@ describe("checkConnectivity", () => {
     const report = await checkConnectivity();
     expect(report.metrics.transport).toBe("failed");
     expect(report.quality).toBe("critical");
+  });
+
+  it("returns immediately when a deep probe signal is already aborted", async () => {
+    const connect = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+    const { checkConnectivity } = createPreflight({ logger, connect });
+    const report = await checkConnectivity({
+      deep: true,
+      model: models.realtime("lucy-restyle-2"),
+      signal: controller.signal,
+    });
+    expect(connect).not.toHaveBeenCalled();
+    expect(report.reasons).toContain("Deep connectivity probe aborted.");
+  });
+
+  it("cancels a deep probe while connect is still in flight", async () => {
+    vi.useFakeTimers();
+    stubDeepProbeDom();
+    const disconnect = vi.fn();
+    const connect = vi.fn(
+      () =>
+        new Promise<RealTimeClient>((resolve) => {
+          setTimeout(() => resolve({ on: vi.fn(), disconnect } as unknown as RealTimeClient), 60_000);
+        }),
+    );
+    const controller = new AbortController();
+    const { checkConnectivity } = createPreflight({ logger, connect });
+    const model = models.realtime("lucy-restyle-2");
+
+    const pending = checkConnectivity({ deep: true, model, signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(10);
+    controller.abort();
+    const report = await pending;
+
+    expect(report.reasons).toContain("Deep connectivity probe aborted.");
+    expect(connect).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(disconnect).toHaveBeenCalledOnce();
+
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary
- Addresses unresolved PR #158 review: `checkConnectivity({ deep: true, signal })` now respects `AbortSignal` while the realtime session is opening, not only during the post-connect sampling window.
- Races `connect()` against the abort signal and tears down any session that completes after cancellation.

## Test plan
- [x] `npm test -- --run preflight` (new tests: already-aborted + abort-during-connect)
- [ ] Manually abort a deep probe mid-connect in the demo page and confirm it returns promptly with "Deep connectivity probe aborted."


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to opt-in deep preflight probing and abort/cleanup paths; no changes to normal connect or STUN-only preflight.
> 
> **Overview**
> **Deep connectivity preflight** now honors `AbortSignal` for the whole probe, including while `connect()` is still opening a realtime session (not only during the post-connect sampling window).
> 
> `runActiveProbe` returns a fixed **"Deep connectivity probe aborted."** report when the signal is already aborted or fires mid-probe. `connect()` is raced via `raceAbort`, and an abort listener calls `disconnect()` on any session that finishes after cancellation. Unit tests cover an already-aborted signal and abort during an in-flight connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a3ed54262149d8ec27ba4a09c6a7f6c613279d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->