### PR TITLE
fix(realtime): tighten packet-loss and frame-drop quality thresholds

### DIFF
--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -100,9 +100,9 @@ export const REALTIME_CONFIG = {
        */
       ttff: { goodMs: 4_000, fairMs: 6_000, poorMs: 10_000 },
       /** Fraction of outbound packets the server reports lost (0..1). */
-      loss: { good: 0.02, fair: 0.05, poor: 0.1 },
+      loss: { good: 0.001, fair: 0.01, poor: 0.05 },
       /** End-to-end frame drop ratio (0..1) inferred from the pixel-marker seq stream (backpressure/overload). */
-      g2gDrop: { good: 0.02, fair: 0.05, poor: 0.1 },
+      g2gDrop: { good: 0.001, fair: 0.01, poor: 0.05 },
       /** Upstream headroom = available BWE ÷ the intended publish bitrate (requiredUpstreamKbps). */
       upstream: { goodRatio: 1.0, fairRatio: 0.8, poorRatio: 0.5, requiredUpstreamKbps: 3500 },
       /** Rendered (inbound) frames-per-second. */

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -98,8 +98,8 @@ describe("scoreSnapshot", () => {
   });
 
   it("normalizes the RFC 3550 fractionLost scale (a few % loss is not critical)", () => {
-    // 3% real loss (raw stat ≈ 7.7) must read "fair", not "critical".
-    expect(scoreSnapshot(makeStats({ fractionLost: 0.03 })).quality).toBe("fair");
+    // 3% real loss (raw stat ≈ 7.7) must read "poor", not "critical".
+    expect(scoreSnapshot(makeStats({ fractionLost: 0.03 })).quality).toBe("poor");
   });
 
   it("does not penalize a low (server-controlled) downstream bitrate on its own", () => {


### PR DESCRIPTION
The connection-quality bands for packet loss were too lenient for a real-time v2v pipeline — up to 2% loss read as "good" and only >10% as "critical", so genuinely degraded sessions were under-reported in both the in-session quality signal and the preflight check. The new bands are: good <0.1%, fair 0.1–1%, poor 1–5%, critical >5%. The end-to-end frame-drop ratio (g2gDrop) shares the same bands, since both measure delivery failures on the same scale. No API changes — `onConnectionQualityChange` and preflight consumers just get more honest ratings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only threshold tuning and test expectation change; no auth, APIs, or scoring algorithm changes—main effect is more frequent poor/critical quality signals for integrators.
> 
> **Overview**
> Tightens **connection-quality** bands for **packet loss** and **end-to-end frame drop** (`g2gDrop`) in `REALTIME_CONFIG.observability.connectionQuality`: good/fair/poor cutoffs move from roughly **2% / 5% / 10%** to **0.1% / 1% / 5%** (0.001 / 0.01 / 0.05 as fractions). Sessions with modest loss or drops will read **worse** in the in-session scorer and in **preflight** (which reuses the same bands)—no API or scoring logic changes, only thresholds.
> 
> The unit test for **~3% RFC-normalized loss** is updated to expect **poor** instead of **fair**, matching the stricter bands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c52adb9cc6dbb4729e02e2c93de2b2bab425b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->