### PR TITLE
[do not merge] eyal/observability-bouncer-ingest rebased onto main (snapshot trigger)

### DIFF
--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -109,13 +109,36 @@ export class MediaChannel {
       this.events.emit("disconnected", { reason });
     });
 
-    this.config.observability?.startPhase("webrtc-handshake");
-    await room.connect(opts.url, opts.token);
-    this.config.observability?.endPhase("webrtc-handshake", { success: true });
-    this.config.observability?.setLiveKitRoom(room);
+    // Attach instrumentation BEFORE connect so we catch the room-level events
+    // (Connected, SignalConnected, Reconnecting, etc.) and the PC-side ICE
+    // candidate / state-change firehose as they happen, not after the fact.
     if (this.config.observability) {
       this.detachInstrumentation = attachRoomInstrumentation(room, this.config.observability);
     }
+    this.config.observability?.startPhase("webrtc-handshake");
+    // Mark the moment we hand off to LiveKit's connect — useful to bracket
+    // any failure inside `room.connect()` against our own timing.
+    this.config.observability?.emitInstrumentationEvent("livekit-connect-start", {
+      url: opts.url,
+    });
+    try {
+      await room.connect(opts.url, opts.token);
+    } catch (error) {
+      // Emit the failure with whatever LiveKit gave us, then re-throw.
+      // Without this, a `room.connect()` rejection produces zero observability —
+      // the runOneConnect catch in stream-session.ts tears down before any
+      // failure signal can reach the WS forwarder.
+      const message = error instanceof Error ? error.message : String(error);
+      const name = error instanceof Error ? error.name : "Error";
+      this.config.observability?.emitInstrumentationEvent("livekit-connect-error", {
+        name,
+        message,
+      });
+      this.config.observability?.endPhase("webrtc-handshake", { success: false, error: message });
+      throw error;
+    }
+    this.config.observability?.endPhase("webrtc-handshake", { success: true });
+    this.config.observability?.setLiveKitRoom(room);
   }
 
   async publishLocalTracks(): Promise<void> {

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -11,6 +11,7 @@ import mitt, { type Emitter } from "mitt";
 
 import { createConsoleLogger, type Logger } from "../utils/logger";
 import { REALTIME_CONFIG } from "./config-realtime";
+import { attachRoomInstrumentation } from "./observability/network-instrumentation";
 import type { RealtimeObservability } from "./observability/realtime-observability";
 
 export type VideoCodec = "h264" | "vp8" | "vp9" | "av1";
@@ -55,6 +56,7 @@ export class MediaChannel {
   private remoteStream: MediaStream | null = null;
   private events: Emitter<MediaChannelEvents> = mitt();
   private readonly logger: Logger;
+  private detachInstrumentation: (() => void) | null = null;
 
   constructor(private readonly config: MediaChannelConfig) {
     this.logger = config.logger ?? createConsoleLogger("warn");
@@ -111,6 +113,9 @@ export class MediaChannel {
     await room.connect(opts.url, opts.token);
     this.config.observability?.endPhase("webrtc-handshake", { success: true });
     this.config.observability?.setLiveKitRoom(room);
+    if (this.config.observability) {
+      this.detachInstrumentation = attachRoomInstrumentation(room, this.config.observability);
+    }
   }
 
   async publishLocalTracks(): Promise<void> {
@@ -124,6 +129,10 @@ export class MediaChannel {
     const room = this.room;
     this.room = null;
     this.remoteStream = null;
+    if (this.detachInstrumentation) {
+      this.detachInstrumentation();
+      this.detachInstrumentation = null;
+    }
     this.config.observability?.setLiveKitRoom(null);
     if (room) {
       room.disconnect().catch(() => {});

--- a/packages/sdk/src/realtime/observability/network-instrumentation.ts
+++ b/packages/sdk/src/realtime/observability/network-instrumentation.ts
@@ -16,8 +16,32 @@
  * we never displace LiveKit's own handlers.
  */
 
-import { Room, RoomEvent, Track, type DisconnectReason } from "livekit-client";
+import { DisconnectReason, Room, RoomEvent, Track } from "livekit-client";
 import type { RealtimeObservability } from "./realtime-observability";
+
+const DISCONNECT_REASON_NAMES: Record<number, string> = {
+  [DisconnectReason.UNKNOWN_REASON]: "unknown",
+  [DisconnectReason.CLIENT_INITIATED]: "client_initiated",
+  [DisconnectReason.DUPLICATE_IDENTITY]: "duplicate_identity",
+  [DisconnectReason.SERVER_SHUTDOWN]: "server_shutdown",
+  [DisconnectReason.PARTICIPANT_REMOVED]: "participant_removed",
+  [DisconnectReason.ROOM_DELETED]: "room_deleted",
+  [DisconnectReason.STATE_MISMATCH]: "state_mismatch",
+  [DisconnectReason.JOIN_FAILURE]: "join_failure",
+  [DisconnectReason.MIGRATION]: "migration",
+  [DisconnectReason.SIGNAL_CLOSE]: "signal_close",
+  [DisconnectReason.ROOM_CLOSED]: "room_closed",
+  [DisconnectReason.USER_UNAVAILABLE]: "user_unavailable",
+  [DisconnectReason.USER_REJECTED]: "user_rejected",
+  [DisconnectReason.SIP_TRUNK_FAILURE]: "sip_trunk_failure",
+  [DisconnectReason.CONNECTION_TIMEOUT]: "connection_timeout",
+  [DisconnectReason.MEDIA_FAILURE]: "media_failure",
+};
+
+function disconnectReasonString(reason: number | undefined): string | undefined {
+  if (reason === undefined) return undefined;
+  return DISCONNECT_REASON_NAMES[reason] ?? `unknown(${reason})`;
+}
 
 type Side = "publisher" | "subscriber";
 
@@ -50,6 +74,10 @@ type ConnectionInfo = {
 
 function summarizeCandidate(candidate: RTCIceCandidate | null): Record<string, unknown> {
   if (!candidate) return { eof: true };
+  // Keep only the fields useful for ICE debugging. Dropped vs. raw RTCIceCandidate:
+  //   - candidate (raw SDP string — redundant with type/address/port/protocol)
+  //   - sdpMid / sdpMLineIndex (mux indexing, not network-debug)
+  //   - usernameFragment (ICE ufrag — auth, not network-debug)
   const c = candidate as RTCIceCandidate & {
     address?: string;
     relatedAddress?: string;
@@ -59,20 +87,16 @@ function summarizeCandidate(candidate: RTCIceCandidate | null): Record<string, u
     url?: string;
   };
   return {
-    candidate: c.candidate,
-    foundation: c.foundation,
-    component: c.component,
+    type: c.type,
     protocol: c.protocol,
     address: c.address ?? null,
     port: c.port,
     priority: c.priority,
-    type: c.type,
+    foundation: c.foundation,
+    component: c.component,
     tcpType: c.tcpType ?? null,
     relatedAddress: c.relatedAddress ?? null,
     relatedPort: c.relatedPort ?? null,
-    sdpMid: c.sdpMid,
-    sdpMLineIndex: c.sdpMLineIndex,
-    usernameFragment: c.usernameFragment,
     networkType: c.networkType ?? null,
     url: c.url ?? null,
   };
@@ -225,11 +249,11 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   // running, and the goal of this stream is to debug WHY connections fail
   // or take too long, not narrate a healthy session.
   const onConnected = () => emit("room-connected", { name: room.name, sid: room.localParticipant?.sid });
-  const onDisconnected = (reason?: DisconnectReason) => emit("room-disconnected", { reason });
+  const onDisconnected = (reason?: DisconnectReason) =>
+    emit("room-disconnected", { reason, reasonName: disconnectReasonString(reason) });
   const onReconnecting = () => emit("room-reconnecting");
   const onSignalReconnecting = () => emit("room-signal-reconnecting");
   const onReconnected = () => emit("room-reconnected");
-  const onConnectionStateChanged = (state: unknown) => emit("room-connection-state", { state });
   const onMediaDevicesError = (e: Error) => emit("media-devices-error", { name: e.name, message: e.message });
 
   room.on(RoomEvent.Connected, onConnected);
@@ -237,8 +261,9 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   room.on(RoomEvent.Reconnecting, onReconnecting);
   room.on(RoomEvent.SignalReconnecting, onSignalReconnecting);
   room.on(RoomEvent.Reconnected, onReconnected);
-  room.on(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
   room.on(RoomEvent.MediaDevicesError, onMediaDevicesError);
+  // RoomEvent.ConnectionStateChanged is intentionally not hooked — its
+  // states duplicate room-connected / -reconnecting / -disconnected.
 
   // Attach to the underlying RTCPeerConnections for ICE-level visibility.
   // Done lazily on next tick — LiveKit creates the PC transports during
@@ -279,7 +304,6 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
       room.off(RoomEvent.Reconnecting, onReconnecting);
       room.off(RoomEvent.SignalReconnecting, onSignalReconnecting);
       room.off(RoomEvent.Reconnected, onReconnected);
-      room.off(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
       room.off(RoomEvent.MediaDevicesError, onMediaDevicesError);
     } catch {
       // ignore detach errors during teardown
@@ -299,18 +323,36 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   };
 }
 
+function summarizeIceServers(pc: RTCPeerConnection): Array<Record<string, unknown>> {
+  try {
+    const cfg = pc.getConfiguration();
+    return (cfg.iceServers ?? []).map((s) => ({
+      urls: Array.isArray(s.urls) ? s.urls : [s.urls],
+      hasUsername: !!s.username,
+      hasCredential: !!s.credential,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 function attachPeerConnectionInstrumentation(
   pc: RTCPeerConnection,
   side: Side,
   emit: (name: string, data: Record<string, unknown>) => void,
-  pcManager?: PcManagerLike,
+  _pcManager?: PcManagerLike,
 ): () => void {
+  // pc-attached carries the PC's iceServers config — directly answers
+  // "did the SDK get STUN/TURN URLs from the JoinResponse?". Credentials
+  // are redacted (we only log whether they were present).
   emit("pc-attached", {
     side,
     iceConnectionState: pc.iceConnectionState,
     connectionState: pc.connectionState,
     iceGatheringState: pc.iceGatheringState,
     signalingState: pc.signalingState,
+    iceServers: summarizeIceServers(pc),
+    iceTransportPolicy: pc.getConfiguration().iceTransportPolicy ?? null,
   });
 
   // The PC may already have gathered all its candidates by the time we
@@ -323,14 +365,6 @@ function attachPeerConnectionInstrumentation(
     void (async () => {
       const pair = await snapshotSelectedPair(pc);
       if (pair) emit("selected-candidate-pair", { side, ...pair, snapshot: true });
-      if (pcManager?.getConnectedAddress) {
-        try {
-          const addr = await pcManager.getConnectedAddress();
-          if (addr) emit("connected-address", { side, address: addr, snapshot: true });
-        } catch {
-          // ignore
-        }
-      }
     })();
   }
 
@@ -342,19 +376,10 @@ function attachPeerConnectionInstrumentation(
   };
   const onIceConnectionStateChange = async () => {
     emit("ice-connection-state", { side, state: pc.iceConnectionState });
-    // Snapshot the winning candidate pair when ICE settles (connected/completed)
-    // or capture stats at the moment of failure for forensics.
+    // Snapshot the winning candidate pair when ICE settles.
     if (pc.iceConnectionState === "connected" || pc.iceConnectionState === "completed") {
       const pair = await snapshotSelectedPair(pc);
       if (pair) emit("selected-candidate-pair", { side, ...pair });
-      if (pcManager?.getConnectedAddress) {
-        try {
-          const addr = await pcManager.getConnectedAddress();
-          if (addr) emit("connected-address", { side, address: addr });
-        } catch {
-          // ignore
-        }
-      }
     }
   };
   const onConnectionStateChange = () => emit("pc-connection-state", { side, state: pc.connectionState });

--- a/packages/sdk/src/realtime/observability/network-instrumentation.ts
+++ b/packages/sdk/src/realtime/observability/network-instrumentation.ts
@@ -153,6 +153,46 @@ function getPc(transport: PcTransportLike | undefined): RTCPeerConnection | unde
 }
 
 /**
+ * Walk `pc.getStats()` once and emit one synthetic `ice-candidate-past`
+ * event per local-candidate (and `remote-candidate-past` per remote one)
+ * already known to the PC. Covers the very common case where ICE
+ * gathering finished before our `icecandidate` listener was attached.
+ */
+async function snapshotPastCandidates(
+  pc: RTCPeerConnection,
+  side: Side,
+  emit: (name: string, data: Record<string, unknown>) => void,
+): Promise<void> {
+  try {
+    const report = await pc.getStats();
+    report.forEach((stat) => {
+      if (stat.type === "local-candidate" || stat.type === "remote-candidate") {
+        const c = stat as RTCIceCandidateStats & {
+          address?: string;
+          networkType?: string;
+          relayProtocol?: string;
+          url?: string;
+        };
+        emit("ice-candidate-past", {
+          side,
+          source: stat.type, // local-candidate | remote-candidate
+          candidateType: c.candidateType,
+          protocol: c.protocol,
+          address: c.address ?? null,
+          port: c.port,
+          priority: c.priority,
+          networkType: c.networkType ?? null,
+          relayProtocol: c.relayProtocol ?? null,
+          url: c.url ?? null,
+        });
+      }
+    });
+  } catch {
+    // ignore
+  }
+}
+
+/**
  * Attach low-level instrumentation to a connected LiveKit `Room`. Safe to
  * call once per room. Returns a cleanup function that detaches all listeners.
  */
@@ -164,11 +204,11 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   // Initial browser network snapshot — gives a baseline to compare against.
   emit("network-state", snapshotConnection());
 
-  // Browser network events.
+  // Browser network events relevant to ICE failure debugging. Page
+  // visibility transitions are intentionally not forwarded — they're
+  // noise for connection diagnostics.
   const onOnline = () => emit("browser-online", { ...snapshotConnection() });
   const onOffline = () => emit("browser-offline", { ...snapshotConnection() });
-  const onVisibility = () =>
-    emit("page-visibility", { state: typeof document !== "undefined" ? document.visibilityState : null });
   const conn =
     typeof navigator !== "undefined" ? (navigator as Navigator & { connection?: EventTarget }).connection : undefined;
   const onConnChange = () => emit("network-change", snapshotConnection());
@@ -176,39 +216,21 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
     window.addEventListener("online", onOnline);
     window.addEventListener("offline", onOffline);
   }
-  if (typeof document !== "undefined") {
-    document.addEventListener("visibilitychange", onVisibility);
-  }
   conn?.addEventListener?.("change", onConnChange);
 
-  // LiveKit Room lifecycle events worth seeing in Datadog.
+  // LiveKit Room lifecycle events that matter for connection debugging.
+  // Steady-state events (connection-quality, track-subscribed/muted/unmuted,
+  // local-track-published, participant-connected, page-visibility) are
+  // intentionally not forwarded — they're noise once a session is up and
+  // running, and the goal of this stream is to debug WHY connections fail
+  // or take too long, not narrate a healthy session.
   const onConnected = () => emit("room-connected", { name: room.name, sid: room.localParticipant?.sid });
   const onDisconnected = (reason?: DisconnectReason) => emit("room-disconnected", { reason });
   const onReconnecting = () => emit("room-reconnecting");
   const onSignalReconnecting = () => emit("room-signal-reconnecting");
   const onReconnected = () => emit("room-reconnected");
   const onConnectionStateChanged = (state: unknown) => emit("room-connection-state", { state });
-  const onConnectionQualityChanged = (quality: unknown, participant: unknown) =>
-    emit("connection-quality", {
-      quality,
-      participantIdentity: (participant as { identity?: string } | undefined)?.identity,
-    });
   const onMediaDevicesError = (e: Error) => emit("media-devices-error", { name: e.name, message: e.message });
-  const onLocalTrackPublished = (pub: unknown) => {
-    const p = pub as { kind?: string; source?: string; trackSid?: string; mimeType?: string } | undefined;
-    emit("local-track-published", { kind: p?.kind, source: p?.source, trackSid: p?.trackSid, mimeType: p?.mimeType });
-  };
-  const onParticipantConnected = (participant: unknown) =>
-    emit("participant-connected", { identity: (participant as { identity?: string } | undefined)?.identity });
-  const onTrackSubscribed = (track: unknown, _pub: unknown, participant: unknown) => {
-    const t = track as { kind?: string; sid?: string } | undefined;
-    const p = participant as { identity?: string } | undefined;
-    emit("track-subscribed", { kind: t?.kind, trackSid: t?.sid, fromIdentity: p?.identity });
-  };
-  const onTrackMuted = (_pub: unknown, participant: unknown) =>
-    emit("track-muted", { identity: (participant as { identity?: string } | undefined)?.identity });
-  const onTrackUnmuted = (_pub: unknown, participant: unknown) =>
-    emit("track-unmuted", { identity: (participant as { identity?: string } | undefined)?.identity });
 
   room.on(RoomEvent.Connected, onConnected);
   room.on(RoomEvent.Disconnected, onDisconnected);
@@ -216,13 +238,7 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   room.on(RoomEvent.SignalReconnecting, onSignalReconnecting);
   room.on(RoomEvent.Reconnected, onReconnected);
   room.on(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
-  room.on(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
   room.on(RoomEvent.MediaDevicesError, onMediaDevicesError);
-  room.on(RoomEvent.LocalTrackPublished, onLocalTrackPublished);
-  room.on(RoomEvent.ParticipantConnected, onParticipantConnected);
-  room.on(RoomEvent.TrackSubscribed, onTrackSubscribed);
-  room.on(RoomEvent.TrackMuted, onTrackMuted);
-  room.on(RoomEvent.TrackUnmuted, onTrackUnmuted);
 
   // Attach to the underlying RTCPeerConnections for ICE-level visibility.
   // Done lazily on next tick — LiveKit creates the PC transports during
@@ -264,22 +280,13 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
       room.off(RoomEvent.SignalReconnecting, onSignalReconnecting);
       room.off(RoomEvent.Reconnected, onReconnected);
       room.off(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
-      room.off(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
       room.off(RoomEvent.MediaDevicesError, onMediaDevicesError);
-      room.off(RoomEvent.LocalTrackPublished, onLocalTrackPublished);
-      room.off(RoomEvent.ParticipantConnected, onParticipantConnected);
-      room.off(RoomEvent.TrackSubscribed, onTrackSubscribed);
-      room.off(RoomEvent.TrackMuted, onTrackMuted);
-      room.off(RoomEvent.TrackUnmuted, onTrackUnmuted);
     } catch {
       // ignore detach errors during teardown
     }
     if (typeof window !== "undefined") {
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
-    }
-    if (typeof document !== "undefined") {
-      document.removeEventListener("visibilitychange", onVisibility);
     }
     conn?.removeEventListener?.("change", onConnChange);
     for (const fn of pcCleanups) {
@@ -306,6 +313,27 @@ function attachPeerConnectionInstrumentation(
     signalingState: pc.signalingState,
   });
 
+  // The PC may already have gathered all its candidates by the time we
+  // attach. addEventListener('icecandidate', ...) only catches FUTURE
+  // events, so we walk getStats() once to surface what was already
+  // produced. This is the data we'd care about most for an ICE-failure
+  // post-mortem (srflx address, candidate types, the winning pair).
+  void snapshotPastCandidates(pc, side, emit);
+  if (pc.iceConnectionState === "connected" || pc.iceConnectionState === "completed") {
+    void (async () => {
+      const pair = await snapshotSelectedPair(pc);
+      if (pair) emit("selected-candidate-pair", { side, ...pair, snapshot: true });
+      if (pcManager?.getConnectedAddress) {
+        try {
+          const addr = await pcManager.getConnectedAddress();
+          if (addr) emit("connected-address", { side, address: addr, snapshot: true });
+        } catch {
+          // ignore
+        }
+      }
+    })();
+  }
+
   const onIceCandidate = (ev: RTCPeerConnectionIceEvent) => {
     emit("ice-candidate", { side, ...summarizeCandidate(ev.candidate) });
   };
@@ -331,27 +359,15 @@ function attachPeerConnectionInstrumentation(
   };
   const onConnectionStateChange = () => emit("pc-connection-state", { side, state: pc.connectionState });
   const onIceGatheringStateChange = () => emit("ice-gathering-state", { side, state: pc.iceGatheringState });
-  const onSignalingStateChange = () => emit("signaling-state", { side, state: pc.signalingState });
-  const onNegotiationNeeded = () => emit("negotiation-needed", { side });
-  const onDataChannel = (ev: RTCDataChannelEvent) =>
-    emit("data-channel-opened", {
-      side,
-      label: ev.channel.label,
-      ordered: ev.channel.ordered,
-      protocol: ev.channel.protocol,
-    });
-  const onTrack = (ev: RTCTrackEvent) =>
-    emit("track-received", { side, kind: ev.track.kind, id: ev.track.id, label: ev.track.label });
+  // signalingstatechange + negotiationneeded + track + datachannel are
+  // intentionally not hooked — they fire on every SDP renegotiation cycle
+  // (each prompt / set_image triggers one) and bury the ICE-level signal.
 
   pc.addEventListener("icecandidate", onIceCandidate);
   pc.addEventListener("icecandidateerror", onIceCandidateError);
   pc.addEventListener("iceconnectionstatechange", onIceConnectionStateChange);
   pc.addEventListener("connectionstatechange", onConnectionStateChange);
   pc.addEventListener("icegatheringstatechange", onIceGatheringStateChange);
-  pc.addEventListener("signalingstatechange", onSignalingStateChange);
-  pc.addEventListener("negotiationneeded", onNegotiationNeeded);
-  pc.addEventListener("datachannel", onDataChannel);
-  pc.addEventListener("track", onTrack);
 
   return () => {
     pc.removeEventListener("icecandidate", onIceCandidate);
@@ -359,10 +375,6 @@ function attachPeerConnectionInstrumentation(
     pc.removeEventListener("iceconnectionstatechange", onIceConnectionStateChange);
     pc.removeEventListener("connectionstatechange", onConnectionStateChange);
     pc.removeEventListener("icegatheringstatechange", onIceGatheringStateChange);
-    pc.removeEventListener("signalingstatechange", onSignalingStateChange);
-    pc.removeEventListener("negotiationneeded", onNegotiationNeeded);
-    pc.removeEventListener("datachannel", onDataChannel);
-    pc.removeEventListener("track", onTrack);
   };
 }
 

--- a/packages/sdk/src/realtime/observability/network-instrumentation.ts
+++ b/packages/sdk/src/realtime/observability/network-instrumentation.ts
@@ -72,6 +72,21 @@ type ConnectionInfo = {
   online?: boolean;
 };
 
+// Structural shape of an RTCIceCandidateStats entry. The DOM type isn't
+// in every TS lib build, so we redeclare what we read.
+type IceCandidateStat = {
+  id: string;
+  type: "local-candidate" | "remote-candidate";
+  candidateType?: string;
+  protocol?: string;
+  port?: number;
+  priority?: number;
+  address?: string;
+  networkType?: string;
+  relayProtocol?: string;
+  url?: string;
+};
+
 function summarizeCandidate(candidate: RTCIceCandidate | null): Record<string, unknown> {
   if (!candidate) return { eof: true };
   // Keep only the fields useful for ICE debugging. Dropped vs. raw RTCIceCandidate:
@@ -129,39 +144,56 @@ function snapshotConnection(): ConnectionInfo {
   return info;
 }
 
+// Structural shape of an RTCIceCandidatePairStats entry — same reason
+// as IceCandidateStat above (some TS lib builds don't expose this).
+type IceCandidatePairStat = {
+  type: "candidate-pair";
+  state: string;
+  nominated?: boolean;
+  localCandidateId?: string;
+  remoteCandidateId?: string;
+  currentRoundTripTime?: number;
+  availableOutgoingBitrate?: number;
+};
+
 async function snapshotSelectedPair(pc: RTCPeerConnection): Promise<Record<string, unknown> | null> {
   try {
     const report = await pc.getStats();
-    let pair: RTCIceCandidatePairStats | null = null;
-    const candidates = new Map<string, RTCIceCandidateStats>();
+    let pair: IceCandidatePairStat | null = null;
+    const candidates = new Map<string, IceCandidateStat>();
     report.forEach((stat) => {
-      if (stat.type === "candidate-pair" && stat.state === "succeeded" && stat.nominated) {
-        pair = stat as RTCIceCandidatePairStats;
+      const s = stat as unknown as { type: string; state?: string; nominated?: boolean; id: string };
+      if (s.type === "candidate-pair" && s.state === "succeeded" && s.nominated) {
+        pair = stat as unknown as IceCandidatePairStat;
       }
-      if (stat.type === "local-candidate" || stat.type === "remote-candidate") {
-        candidates.set(stat.id, stat as RTCIceCandidateStats);
+      if (s.type === "local-candidate" || s.type === "remote-candidate") {
+        candidates.set(s.id, stat as unknown as IceCandidateStat);
       }
     });
     if (!pair) return null;
-    const local = candidates.get(pair.localCandidateId);
-    const remote = candidates.get(pair.remoteCandidateId);
+    const localId = (pair as IceCandidatePairStat).localCandidateId;
+    const remoteId = (pair as IceCandidatePairStat).remoteCandidateId;
+    const local = localId ? candidates.get(localId) : undefined;
+    const remote = remoteId ? candidates.get(remoteId) : undefined;
+    const rtt = (pair as IceCandidatePairStat).currentRoundTripTime;
+    const aob = (pair as IceCandidatePairStat).availableOutgoingBitrate;
     return {
-      currentRoundTripTimeMs: pair.currentRoundTripTime != null ? pair.currentRoundTripTime * 1000 : null,
-      availableOutgoingBitrate: pair.availableOutgoingBitrate ?? null,
+      currentRoundTripTimeMs: rtt != null ? rtt * 1000 : null,
+      availableOutgoingBitrate: aob ?? null,
       local: local
         ? {
             type: local.candidateType,
             protocol: local.protocol,
-            address: (local as RTCIceCandidateStats & { address?: string }).address,
+            address: local.address,
             port: local.port,
-            networkType: (local as RTCIceCandidateStats & { networkType?: string }).networkType,
+            networkType: local.networkType,
           }
         : null,
       remote: remote
         ? {
             type: remote.candidateType,
             protocol: remote.protocol,
-            address: (remote as RTCIceCandidateStats & { address?: string }).address,
+            address: remote.address,
             port: remote.port,
           }
         : null,
@@ -190,16 +222,12 @@ async function snapshotPastCandidates(
   try {
     const report = await pc.getStats();
     report.forEach((stat) => {
-      if (stat.type === "local-candidate" || stat.type === "remote-candidate") {
-        const c = stat as RTCIceCandidateStats & {
-          address?: string;
-          networkType?: string;
-          relayProtocol?: string;
-          url?: string;
-        };
+      const s = stat as unknown as IceCandidateStat;
+      if (s.type === "local-candidate" || s.type === "remote-candidate") {
+        const c = s;
         emit("ice-candidate-past", {
           side,
-          source: stat.type, // local-candidate | remote-candidate
+          source: c.type, // local-candidate | remote-candidate
           candidateType: c.candidateType,
           protocol: c.protocol,
           address: c.address ?? null,

--- a/packages/sdk/src/realtime/observability/network-instrumentation.ts
+++ b/packages/sdk/src/realtime/observability/network-instrumentation.ts
@@ -1,0 +1,370 @@
+/**
+ * WebRTC / LiveKit / browser-network instrumentation that emits raw debug
+ * data over the SDK observability sink (which the realtime WS forwards to
+ * bouncer, where Datadog ingests it under the session's log context).
+ *
+ * Captures the kind of data that's actually useful when diagnosing an ICE
+ * failure — every candidate gathered (host/srflx/relay/prflx, address,
+ * port, priority, foundation), every state transition on both transports
+ * (publisher/subscriber: ice/peer/gathering/signaling), candidate errors,
+ * the selected pair on success, signaling traffic in/out, and the
+ * browser's view of its own network state.
+ *
+ * The browser-side `Room` doesn't publicly expose the underlying
+ * `RTCPeerConnection` objects, so we reach through `room.engine.pcManager`
+ * via a typed-cast access path. `addEventListener` is used everywhere so
+ * we never displace LiveKit's own handlers.
+ */
+
+import { Room, RoomEvent, Track, type DisconnectReason } from "livekit-client";
+import type { RealtimeObservability } from "./realtime-observability";
+
+type Side = "publisher" | "subscriber";
+
+// Loose typings for the parts of LiveKit's engine we touch. Everything is
+// optional / `unknown` because these are private APIs that have moved
+// across LiveKit versions; we degrade gracefully if a field is missing.
+type EngineLike = {
+  pcManager?: PcManagerLike;
+};
+type PcManagerLike = {
+  publisher?: PcTransportLike;
+  subscriber?: PcTransportLike;
+  getConnectedAddress?: (target?: unknown) => Promise<string | undefined>;
+};
+type PcTransportLike = {
+  pc?: RTCPeerConnection;
+  // some livekit builds expose it as `_pc`
+  _pc?: RTCPeerConnection;
+};
+type RoomWithEngine = Room & { engine?: EngineLike };
+
+type ConnectionInfo = {
+  effectiveType?: string;
+  downlinkMbps?: number;
+  rttMs?: number;
+  saveData?: boolean;
+  type?: string;
+  online?: boolean;
+};
+
+function summarizeCandidate(candidate: RTCIceCandidate | null): Record<string, unknown> {
+  if (!candidate) return { eof: true };
+  const c = candidate as RTCIceCandidate & {
+    address?: string;
+    relatedAddress?: string;
+    relatedPort?: number;
+    tcpType?: string;
+    networkType?: string;
+    url?: string;
+  };
+  return {
+    candidate: c.candidate,
+    foundation: c.foundation,
+    component: c.component,
+    protocol: c.protocol,
+    address: c.address ?? null,
+    port: c.port,
+    priority: c.priority,
+    type: c.type,
+    tcpType: c.tcpType ?? null,
+    relatedAddress: c.relatedAddress ?? null,
+    relatedPort: c.relatedPort ?? null,
+    sdpMid: c.sdpMid,
+    sdpMLineIndex: c.sdpMLineIndex,
+    usernameFragment: c.usernameFragment,
+    networkType: c.networkType ?? null,
+    url: c.url ?? null,
+  };
+}
+
+function summarizeCandidateError(ev: RTCPeerConnectionIceErrorEvent): Record<string, unknown> {
+  return {
+    address: ev.address ?? null,
+    port: ev.port ?? null,
+    url: ev.url ?? null,
+    errorCode: ev.errorCode,
+    errorText: ev.errorText,
+    hostCandidate: (ev as unknown as { hostCandidate?: string }).hostCandidate ?? null,
+  };
+}
+
+function snapshotConnection(): ConnectionInfo {
+  const info: ConnectionInfo = {};
+  if (typeof navigator !== "undefined") {
+    info.online = navigator.onLine;
+    const conn = (navigator as Navigator & { connection?: Record<string, unknown> }).connection;
+    if (conn) {
+      info.effectiveType = conn.effectiveType as string | undefined;
+      info.downlinkMbps = conn.downlink as number | undefined;
+      info.rttMs = conn.rtt as number | undefined;
+      info.saveData = conn.saveData as boolean | undefined;
+      info.type = conn.type as string | undefined;
+    }
+  }
+  return info;
+}
+
+async function snapshotSelectedPair(pc: RTCPeerConnection): Promise<Record<string, unknown> | null> {
+  try {
+    const report = await pc.getStats();
+    let pair: RTCIceCandidatePairStats | null = null;
+    const candidates = new Map<string, RTCIceCandidateStats>();
+    report.forEach((stat) => {
+      if (stat.type === "candidate-pair" && stat.state === "succeeded" && stat.nominated) {
+        pair = stat as RTCIceCandidatePairStats;
+      }
+      if (stat.type === "local-candidate" || stat.type === "remote-candidate") {
+        candidates.set(stat.id, stat as RTCIceCandidateStats);
+      }
+    });
+    if (!pair) return null;
+    const local = candidates.get(pair.localCandidateId);
+    const remote = candidates.get(pair.remoteCandidateId);
+    return {
+      currentRoundTripTimeMs: pair.currentRoundTripTime != null ? pair.currentRoundTripTime * 1000 : null,
+      availableOutgoingBitrate: pair.availableOutgoingBitrate ?? null,
+      local: local
+        ? {
+            type: local.candidateType,
+            protocol: local.protocol,
+            address: (local as RTCIceCandidateStats & { address?: string }).address,
+            port: local.port,
+            networkType: (local as RTCIceCandidateStats & { networkType?: string }).networkType,
+          }
+        : null,
+      remote: remote
+        ? {
+            type: remote.candidateType,
+            protocol: remote.protocol,
+            address: (remote as RTCIceCandidateStats & { address?: string }).address,
+            port: remote.port,
+          }
+        : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getPc(transport: PcTransportLike | undefined): RTCPeerConnection | undefined {
+  if (!transport) return undefined;
+  return transport.pc ?? transport._pc;
+}
+
+/**
+ * Attach low-level instrumentation to a connected LiveKit `Room`. Safe to
+ * call once per room. Returns a cleanup function that detaches all listeners.
+ */
+export function attachRoomInstrumentation(room: Room, observability: RealtimeObservability): () => void {
+  const emit = (name: string, data: Record<string, unknown> = {}): void => {
+    observability.emitInstrumentationEvent(name, data);
+  };
+
+  // Initial browser network snapshot — gives a baseline to compare against.
+  emit("network-state", snapshotConnection());
+
+  // Browser network events.
+  const onOnline = () => emit("browser-online", { ...snapshotConnection() });
+  const onOffline = () => emit("browser-offline", { ...snapshotConnection() });
+  const onVisibility = () =>
+    emit("page-visibility", { state: typeof document !== "undefined" ? document.visibilityState : null });
+  const conn =
+    typeof navigator !== "undefined" ? (navigator as Navigator & { connection?: EventTarget }).connection : undefined;
+  const onConnChange = () => emit("network-change", snapshotConnection());
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+  }
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", onVisibility);
+  }
+  conn?.addEventListener?.("change", onConnChange);
+
+  // LiveKit Room lifecycle events worth seeing in Datadog.
+  const onConnected = () => emit("room-connected", { name: room.name, sid: room.localParticipant?.sid });
+  const onDisconnected = (reason?: DisconnectReason) => emit("room-disconnected", { reason });
+  const onReconnecting = () => emit("room-reconnecting");
+  const onSignalReconnecting = () => emit("room-signal-reconnecting");
+  const onReconnected = () => emit("room-reconnected");
+  const onConnectionStateChanged = (state: unknown) => emit("room-connection-state", { state });
+  const onConnectionQualityChanged = (quality: unknown, participant: unknown) =>
+    emit("connection-quality", {
+      quality,
+      participantIdentity: (participant as { identity?: string } | undefined)?.identity,
+    });
+  const onMediaDevicesError = (e: Error) => emit("media-devices-error", { name: e.name, message: e.message });
+  const onLocalTrackPublished = (pub: unknown) => {
+    const p = pub as { kind?: string; source?: string; trackSid?: string; mimeType?: string } | undefined;
+    emit("local-track-published", { kind: p?.kind, source: p?.source, trackSid: p?.trackSid, mimeType: p?.mimeType });
+  };
+  const onParticipantConnected = (participant: unknown) =>
+    emit("participant-connected", { identity: (participant as { identity?: string } | undefined)?.identity });
+  const onTrackSubscribed = (track: unknown, _pub: unknown, participant: unknown) => {
+    const t = track as { kind?: string; sid?: string } | undefined;
+    const p = participant as { identity?: string } | undefined;
+    emit("track-subscribed", { kind: t?.kind, trackSid: t?.sid, fromIdentity: p?.identity });
+  };
+  const onTrackMuted = (_pub: unknown, participant: unknown) =>
+    emit("track-muted", { identity: (participant as { identity?: string } | undefined)?.identity });
+  const onTrackUnmuted = (_pub: unknown, participant: unknown) =>
+    emit("track-unmuted", { identity: (participant as { identity?: string } | undefined)?.identity });
+
+  room.on(RoomEvent.Connected, onConnected);
+  room.on(RoomEvent.Disconnected, onDisconnected);
+  room.on(RoomEvent.Reconnecting, onReconnecting);
+  room.on(RoomEvent.SignalReconnecting, onSignalReconnecting);
+  room.on(RoomEvent.Reconnected, onReconnected);
+  room.on(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
+  room.on(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+  room.on(RoomEvent.MediaDevicesError, onMediaDevicesError);
+  room.on(RoomEvent.LocalTrackPublished, onLocalTrackPublished);
+  room.on(RoomEvent.ParticipantConnected, onParticipantConnected);
+  room.on(RoomEvent.TrackSubscribed, onTrackSubscribed);
+  room.on(RoomEvent.TrackMuted, onTrackMuted);
+  room.on(RoomEvent.TrackUnmuted, onTrackUnmuted);
+
+  // Attach to the underlying RTCPeerConnections for ICE-level visibility.
+  // Done lazily on next tick — LiveKit creates the PC transports during
+  // `room.connect()`, and the engine may not be wired up yet at the
+  // moment we register Room events. Polling for a short window covers
+  // both early and late attach scenarios.
+  const pcCleanups: Array<() => void> = [];
+  const attachedSides = new Set<Side>();
+  const attachPcEventsIfReady = (): boolean => {
+    const engine = (room as RoomWithEngine).engine;
+    const mgr = engine?.pcManager;
+    if (!mgr) return false;
+    for (const side of ["publisher", "subscriber"] as Side[]) {
+      if (attachedSides.has(side)) continue;
+      const pc = getPc(side === "publisher" ? mgr.publisher : mgr.subscriber);
+      if (!pc) continue;
+      attachedSides.add(side);
+      pcCleanups.push(attachPeerConnectionInstrumentation(pc, side, emit, mgr));
+    }
+    return attachedSides.size === 2;
+  };
+  // Try immediately, then poll briefly for the late case.
+  if (!attachPcEventsIfReady()) {
+    let attempts = 0;
+    const poll = setInterval(() => {
+      attempts++;
+      if (attachPcEventsIfReady() || attempts > 50) {
+        clearInterval(poll);
+      }
+    }, 100);
+    pcCleanups.push(() => clearInterval(poll));
+  }
+
+  return () => {
+    try {
+      room.off(RoomEvent.Connected, onConnected);
+      room.off(RoomEvent.Disconnected, onDisconnected);
+      room.off(RoomEvent.Reconnecting, onReconnecting);
+      room.off(RoomEvent.SignalReconnecting, onSignalReconnecting);
+      room.off(RoomEvent.Reconnected, onReconnected);
+      room.off(RoomEvent.ConnectionStateChanged, onConnectionStateChanged);
+      room.off(RoomEvent.ConnectionQualityChanged, onConnectionQualityChanged);
+      room.off(RoomEvent.MediaDevicesError, onMediaDevicesError);
+      room.off(RoomEvent.LocalTrackPublished, onLocalTrackPublished);
+      room.off(RoomEvent.ParticipantConnected, onParticipantConnected);
+      room.off(RoomEvent.TrackSubscribed, onTrackSubscribed);
+      room.off(RoomEvent.TrackMuted, onTrackMuted);
+      room.off(RoomEvent.TrackUnmuted, onTrackUnmuted);
+    } catch {
+      // ignore detach errors during teardown
+    }
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+    }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", onVisibility);
+    }
+    conn?.removeEventListener?.("change", onConnChange);
+    for (const fn of pcCleanups) {
+      try {
+        fn();
+      } catch {
+        // ignore
+      }
+    }
+  };
+}
+
+function attachPeerConnectionInstrumentation(
+  pc: RTCPeerConnection,
+  side: Side,
+  emit: (name: string, data: Record<string, unknown>) => void,
+  pcManager?: PcManagerLike,
+): () => void {
+  emit("pc-attached", {
+    side,
+    iceConnectionState: pc.iceConnectionState,
+    connectionState: pc.connectionState,
+    iceGatheringState: pc.iceGatheringState,
+    signalingState: pc.signalingState,
+  });
+
+  const onIceCandidate = (ev: RTCPeerConnectionIceEvent) => {
+    emit("ice-candidate", { side, ...summarizeCandidate(ev.candidate) });
+  };
+  const onIceCandidateError = (ev: Event) => {
+    emit("ice-candidate-error", { side, ...summarizeCandidateError(ev as RTCPeerConnectionIceErrorEvent) });
+  };
+  const onIceConnectionStateChange = async () => {
+    emit("ice-connection-state", { side, state: pc.iceConnectionState });
+    // Snapshot the winning candidate pair when ICE settles (connected/completed)
+    // or capture stats at the moment of failure for forensics.
+    if (pc.iceConnectionState === "connected" || pc.iceConnectionState === "completed") {
+      const pair = await snapshotSelectedPair(pc);
+      if (pair) emit("selected-candidate-pair", { side, ...pair });
+      if (pcManager?.getConnectedAddress) {
+        try {
+          const addr = await pcManager.getConnectedAddress();
+          if (addr) emit("connected-address", { side, address: addr });
+        } catch {
+          // ignore
+        }
+      }
+    }
+  };
+  const onConnectionStateChange = () => emit("pc-connection-state", { side, state: pc.connectionState });
+  const onIceGatheringStateChange = () => emit("ice-gathering-state", { side, state: pc.iceGatheringState });
+  const onSignalingStateChange = () => emit("signaling-state", { side, state: pc.signalingState });
+  const onNegotiationNeeded = () => emit("negotiation-needed", { side });
+  const onDataChannel = (ev: RTCDataChannelEvent) =>
+    emit("data-channel-opened", {
+      side,
+      label: ev.channel.label,
+      ordered: ev.channel.ordered,
+      protocol: ev.channel.protocol,
+    });
+  const onTrack = (ev: RTCTrackEvent) =>
+    emit("track-received", { side, kind: ev.track.kind, id: ev.track.id, label: ev.track.label });
+
+  pc.addEventListener("icecandidate", onIceCandidate);
+  pc.addEventListener("icecandidateerror", onIceCandidateError);
+  pc.addEventListener("iceconnectionstatechange", onIceConnectionStateChange);
+  pc.addEventListener("connectionstatechange", onConnectionStateChange);
+  pc.addEventListener("icegatheringstatechange", onIceGatheringStateChange);
+  pc.addEventListener("signalingstatechange", onSignalingStateChange);
+  pc.addEventListener("negotiationneeded", onNegotiationNeeded);
+  pc.addEventListener("datachannel", onDataChannel);
+  pc.addEventListener("track", onTrack);
+
+  return () => {
+    pc.removeEventListener("icecandidate", onIceCandidate);
+    pc.removeEventListener("icecandidateerror", onIceCandidateError);
+    pc.removeEventListener("iceconnectionstatechange", onIceConnectionStateChange);
+    pc.removeEventListener("connectionstatechange", onConnectionStateChange);
+    pc.removeEventListener("icegatheringstatechange", onIceGatheringStateChange);
+    pc.removeEventListener("signalingstatechange", onSignalingStateChange);
+    pc.removeEventListener("negotiationneeded", onNegotiationNeeded);
+    pc.removeEventListener("datachannel", onDataChannel);
+    pc.removeEventListener("track", onTrack);
+  };
+}
+
+// Re-export for convenience so consumers know what's available.
+export { Track };

--- a/packages/sdk/src/realtime/observability/network-instrumentation.ts
+++ b/packages/sdk/src/realtime/observability/network-instrumentation.ts
@@ -50,6 +50,11 @@ type Side = "publisher" | "subscriber";
 // across LiveKit versions; we degrade gracefully if a field is missing.
 type EngineLike = {
   pcManager?: PcManagerLike;
+  // RTCEngine extends EventEmitter and emits 'transportsCreated' the
+  // moment publisher/subscriber RTCPeerConnections exist. Hook into that
+  // for deterministic attach (no polling, no early-window misses).
+  on?: (event: string, listener: (...args: unknown[]) => void) => unknown;
+  off?: (event: string, listener: (...args: unknown[]) => void) => unknown;
 };
 type PcManagerLike = {
   publisher?: PcTransportLike;
@@ -62,6 +67,11 @@ type PcTransportLike = {
   _pc?: RTCPeerConnection;
 };
 type RoomWithEngine = Room & { engine?: EngineLike };
+
+// LiveKit's EngineEvent.TransportsCreated string value. Kept as a literal
+// so we don't have to import the enum (which would couple us to the
+// livekit-client version at runtime).
+const TRANSPORTS_CREATED_EVENT = "transportsCreated";
 
 type ConnectionInfo = {
   effectiveType?: string;
@@ -294,10 +304,18 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
   // states duplicate room-connected / -reconnecting / -disconnected.
 
   // Attach to the underlying RTCPeerConnections for ICE-level visibility.
-  // Done lazily on next tick — LiveKit creates the PC transports during
-  // `room.connect()`, and the engine may not be wired up yet at the
-  // moment we register Room events. Polling for a short window covers
-  // both early and late attach scenarios.
+  //
+  // Two paths, in priority order:
+  //   1. Synchronous attach if the engine's PCs already exist (common when
+  //      called mid-reconnect or post-connect).
+  //   2. Subscribe to engine's 'transportsCreated' event so we attach the
+  //      moment LiveKit creates the publisher/subscriber PCs — which
+  //      happens INSIDE room.connect() before ICE gathering starts. This
+  //      is the deterministic path that catches every ICE candidate from
+  //      the very first one, including on failed connections where
+  //      room.connect() never resolves.
+  //   3. Polling fallback (short window) in case the LiveKit build doesn't
+  //      expose engine.on() as we expect.
   const pcCleanups: Array<() => void> = [];
   const attachedSides = new Set<Side>();
   const attachPcEventsIfReady = (): boolean => {
@@ -313,8 +331,41 @@ export function attachRoomInstrumentation(room: Room, observability: RealtimeObs
     }
     return attachedSides.size === 2;
   };
-  // Try immediately, then poll briefly for the late case.
-  if (!attachPcEventsIfReady()) {
+
+  // 1. Try synchronously.
+  const fullyAttached = attachPcEventsIfReady();
+
+  // 2. Subscribe to engine.on('transportsCreated') for the event-driven path.
+  //    This is the case that matters for failing connections: room.connect()
+  //    triggers PC creation, fires 'transportsCreated', then starts ICE
+  //    gathering. If ICE never converges, we still want every gathered
+  //    candidate event. Listening here guarantees we attach BEFORE the first
+  //    icecandidate fires.
+  const engine = (room as RoomWithEngine).engine;
+  let transportsCreatedHandler: ((...args: unknown[]) => void) | null = null;
+  if (engine?.on && engine?.off) {
+    transportsCreatedHandler = () => {
+      emit("engine-transports-created");
+      attachPcEventsIfReady();
+    };
+    try {
+      engine.on(TRANSPORTS_CREATED_EVENT, transportsCreatedHandler);
+      pcCleanups.push(() => {
+        try {
+          if (transportsCreatedHandler) engine.off?.(TRANSPORTS_CREATED_EVENT, transportsCreatedHandler);
+        } catch {
+          // ignore
+        }
+      });
+    } catch {
+      // engine doesn't accept the event subscription; fall through to polling.
+    }
+  }
+
+  // 3. Polling fallback: if engine.on isn't usable, or for engine builds where
+  //    PCs are created without firing transportsCreated, keep a short poll.
+  //    Stops as soon as both sides are attached or the window expires.
+  if (!fullyAttached) {
     let attempts = 0;
     const poll = setInterval(() => {
       attempts++;

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -113,6 +113,21 @@ export class RealtimeObservability {
     this.observabilityForwarder = fn;
   }
 
+  /**
+   * Emit a raw instrumentation event over the observability sink. Used by
+   * `network-instrumentation.ts` to forward per-ICE-candidate / signaling /
+   * peer-connection-state events that don't fit the strict `DiagnosticEvents`
+   * type union. Best-effort; silently dropped if the sink isn't attached.
+   */
+  emitInstrumentationEvent(name: string, data: unknown): void {
+    this.observabilityForwarder?.({
+      kind: "instrumentation",
+      name,
+      data,
+      timestamp: Date.now(),
+    });
+  }
+
   diagnostic<K extends DiagnosticEventName>(name: K, data: DiagnosticEvents[K], timestamp: number = Date.now()): void {
     this.options.logger.debug(name, data as Record<string, unknown>);
     this.options.onDiagnostic?.({ name, data } as DiagnosticEvent);

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -61,6 +61,13 @@ export class RealtimeObservability {
   private readonly seqTracker: SeqTracker | null;
   private readonly markerReader: MarkerReader | null;
   private stampPump: StampPump | null = null;
+  /**
+   * Sink for forwarding diagnostics and stats over the existing realtime
+   * WebSocket (bouncer logs them to Datadog under the session's context).
+   * Set by `StreamSession` after the signaling channel is created;
+   * cleared on tearDown.
+   */
+  private observabilityForwarder: ((payload: unknown) => void) | null = null;
 
   constructor(private readonly options: RealtimeObservabilityOptions) {
     this.seqTracker = options.debugQuality ? new SeqTracker() : null;
@@ -101,10 +108,16 @@ export class RealtimeObservability {
     this.seqTracker?.markStart(performance.now());
   }
 
+  /** Wire/unwire the WebSocket-side observability sink. Idempotent. */
+  setObservabilityForwarder(fn: ((payload: unknown) => void) | null): void {
+    this.observabilityForwarder = fn;
+  }
+
   diagnostic<K extends DiagnosticEventName>(name: K, data: DiagnosticEvents[K], timestamp: number = Date.now()): void {
     this.options.logger.debug(name, data as Record<string, unknown>);
     this.options.onDiagnostic?.({ name, data } as DiagnosticEvent);
     this.addTelemetryDiagnostic(name, data, timestamp);
+    this.observabilityForwarder?.({ kind: "diagnostic", name, data, timestamp });
   }
 
   beginConnectionBreakdown(attempt: number, initialImageSizeKb: number | null): void {
@@ -260,6 +273,7 @@ export class RealtimeObservability {
     this.detectVideoStall(stats);
     const report = this.connectionQuality.update(stats);
     if (report) this.options.onConnectionQuality?.(report);
+    this.observabilityForwarder?.({ kind: "stats", stats });
   }
 
   private detectVideoStall(stats: WebRTCStats): void {

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -288,7 +288,11 @@ export class RealtimeObservability {
     this.detectVideoStall(stats);
     const report = this.connectionQuality.update(stats);
     if (report) this.options.onConnectionQuality?.(report);
-    this.observabilityForwarder?.({ kind: "stats", stats });
+    // Stats intentionally not forwarded over the WS. They fire every 1s
+    // and would dominate Datadog's signal-to-noise ratio while not
+    // helping diagnose connection-establishment failures (which is what
+    // the WS-forwarded observability stream is for). They still flow to
+    // the local `onStats` callback and the platform telemetry POST.
   }
 
   private detectVideoStall(stats: WebRTCStats): void {

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -394,19 +394,16 @@ export class SignalingChannel {
   private writeMessage(message: OutgoingRealtimeMessage): boolean {
     if (this.ws?.readyState !== WebSocket.OPEN) return false;
     this.ws.send(JSON.stringify(message));
-    // Best-effort signaling-trace for non-self-referential messages
-    // (don't trace our own observability frames or we recurse).
-    if (message.type !== "observability") {
-      this.config.observability?.emitInstrumentationEvent("signaling-sent", {
-        type: message.type,
-        size: 0,
-      });
-    }
     return true;
   }
 
   private handleMessage(msg: IncomingRealtimeMessage): void {
-    this.config.observability?.emitInstrumentationEvent("signaling-received", { type: msg.type });
+    // Only trace connection-establishment-relevant signaling messages.
+    // Routine generation_tick / prompt_ack / set_image_ack chatter is
+    // suppressed to keep Datadog's signal-to-noise ratio usable.
+    if (msg.type === "livekit_room_info" || msg.type === "session_id") {
+      this.config.observability?.emitInstrumentationEvent("signaling-received", { type: msg.type });
+    }
     for (const ack of [...this.pendingAcks]) {
       if (ack.matches(msg)) {
         ack.onMatch(msg);

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -220,6 +220,21 @@ export class SignalingChannel {
     if (!ack.success) throw new Error(ack.error ?? "Failed to send prompt");
   }
 
+  /**
+   * Fire-and-forget client-side observability event. Goes out over the
+   * existing realtime WebSocket as `{type: "observability", data}` and is
+   * logged by bouncer under the current session's log context. Never
+   * throws; quietly drops if the socket isn't open.
+   */
+  sendObservability(data: unknown): void {
+    if (this.ws?.readyState !== WebSocket.OPEN) return;
+    try {
+      this.writeMessage({ type: "observability", data });
+    } catch {
+      // Best-effort; never disrupt the session for a telemetry hiccup.
+    }
+  }
+
   async setImage(payload: SetImagePayload, opts: ImageSetOptions = {}): Promise<void> {
     const message: OutgoingRealtimeMessage =
       payload.kind === "ref"

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -114,6 +114,15 @@ function buildInitialStateRequest(initialState?: InitialState): InitialStateRequ
   return null;
 }
 
+/**
+ * Hard upper bound on buffered observability events that arrive before the
+ * WebSocket is open. Bounded so an SDK consumer that misuses the API
+ * can't accumulate unbounded memory. 256 events covers the entire
+ * pre-WS observability window in practice (initial network-state,
+ * pc-attached, snapshot candidates, gathering-state transitions).
+ */
+const OBSERVABILITY_BUFFER_MAX = 256;
+
 export class SignalingChannel {
   private ws: WebSocket | null = null;
   private events: Emitter<SignalingChannelEvents> = mitt();
@@ -123,6 +132,13 @@ export class SignalingChannel {
   private connected = false;
   private closing = false;
   private readonly logger: Logger;
+  /**
+   * Observability events emitted before the WS is open. Flushed in order
+   * the moment readyState becomes OPEN. Dropped with a single `dropped`
+   * count event if the buffer overflows.
+   */
+  private observabilityBuffer: unknown[] = [];
+  private observabilityBufferDropped = 0;
 
   constructor(private readonly config: SignalingChannelConfig) {
     this.logger = config.logger ?? createConsoleLogger("warn");
@@ -206,6 +222,10 @@ export class SignalingChannel {
         // ignore
       }
     }
+    // Drop any buffered observability events that never made it out — the
+    // session is over and a future reconnect creates a fresh channel.
+    this.observabilityBuffer = [];
+    this.observabilityBufferDropped = 0;
     this.rejectPendingRoomInfo(new Error("Control channel closed"));
     this.rejectAllPending(new Error("Control channel closed"));
   }
@@ -223,15 +243,63 @@ export class SignalingChannel {
   /**
    * Fire-and-forget client-side observability event. Goes out over the
    * existing realtime WebSocket as `{type: "observability", data}` and is
-   * logged by bouncer under the current session's log context. Never
-   * throws; quietly drops if the socket isn't open.
+   * logged by bouncer under the current session's log context.
+   *
+   * If the WS isn't open yet, the event is buffered (bounded) and flushed
+   * the moment the WS becomes OPEN. This catches the small but important
+   * window between SDK init and WS-open during which network-state /
+   * pc-attached / early ICE events may fire — without buffering they'd
+   * silently disappear, exactly the failure mode we hit on `.251`-style
+   * networks where the connection never advances past the ICE phase and
+   * we never get a second chance to capture those events.
    */
   sendObservability(data: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      try {
+        this.writeMessage({ type: "observability", data });
+      } catch {
+        // Best-effort; never disrupt the session for a telemetry hiccup.
+      }
+      return;
+    }
+    // WS not open yet (or closed). Buffer up to the cap; drop the rest.
+    if (this.observabilityBuffer.length >= OBSERVABILITY_BUFFER_MAX) {
+      this.observabilityBufferDropped++;
+      return;
+    }
+    this.observabilityBuffer.push(data);
+  }
+
+  /**
+   * Flush any observability events that arrived before the WS was open.
+   * Called once from `openSocket` immediately after readyState becomes OPEN.
+   */
+  private flushObservabilityBuffer(): void {
     if (this.ws?.readyState !== WebSocket.OPEN) return;
-    try {
-      this.writeMessage({ type: "observability", data });
-    } catch {
-      // Best-effort; never disrupt the session for a telemetry hiccup.
+    const queued = this.observabilityBuffer;
+    this.observabilityBuffer = [];
+    for (const data of queued) {
+      try {
+        this.writeMessage({ type: "observability", data });
+      } catch {
+        // ignore — best-effort
+      }
+    }
+    if (this.observabilityBufferDropped > 0) {
+      try {
+        this.writeMessage({
+          type: "observability",
+          data: {
+            kind: "instrumentation",
+            name: "observability-buffer-overflow",
+            data: { droppedCount: this.observabilityBufferDropped },
+            timestamp: Date.now(),
+          },
+        });
+      } catch {
+        // ignore
+      }
+      this.observabilityBufferDropped = 0;
     }
   }
 
@@ -264,6 +332,12 @@ export class SignalingChannel {
       this.ws = ws;
       ws.onopen = () => {
         clearTimeout(timer);
+        // Flush any observability events that fired before the WS was
+        // ready. Otherwise pre-open instrumentation (network-state, early
+        // pc-attached, gathering-state transitions) would be silently
+        // dropped — which is exactly the case we hit on failed `.251`
+        // sessions where the connection times out at ICE.
+        this.flushObservabilityBuffer();
         resolve();
       };
       ws.onclose = (e) => {

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -401,7 +401,17 @@ export class SignalingChannel {
     // Only trace connection-establishment-relevant signaling messages.
     // Routine generation_tick / prompt_ack / set_image_ack chatter is
     // suppressed to keep Datadog's signal-to-noise ratio usable.
-    if (msg.type === "livekit_room_info" || msg.type === "session_id") {
+    if (msg.type === "livekit_room_info") {
+      // Capture which LiveKit SFU node the bouncer steered this session
+      // to — useful for "which node was bad?" debugging. Token is not
+      // logged (auth material).
+      this.config.observability?.emitInstrumentationEvent("signaling-received", {
+        type: msg.type,
+        livekitUrl: msg.livekit_url,
+        roomName: msg.room_name,
+        sessionId: msg.session_id,
+      });
+    } else if (msg.type === "session_id") {
       this.config.observability?.emitInstrumentationEvent("signaling-received", { type: msg.type });
     }
     for (const ack of [...this.pendingAcks]) {

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -394,10 +394,19 @@ export class SignalingChannel {
   private writeMessage(message: OutgoingRealtimeMessage): boolean {
     if (this.ws?.readyState !== WebSocket.OPEN) return false;
     this.ws.send(JSON.stringify(message));
+    // Best-effort signaling-trace for non-self-referential messages
+    // (don't trace our own observability frames or we recurse).
+    if (message.type !== "observability") {
+      this.config.observability?.emitInstrumentationEvent("signaling-sent", {
+        type: message.type,
+        size: 0,
+      });
+    }
     return true;
   }
 
   private handleMessage(msg: IncomingRealtimeMessage): void {
+    this.config.observability?.emitInstrumentationEvent("signaling-received", { type: msg.type });
     for (const ack of [...this.pendingAcks]) {
       if (ack.matches(msg)) {
         ack.onMatch(msg);

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -411,8 +411,10 @@ export class SignalingChannel {
         roomName: msg.room_name,
         sessionId: msg.session_id,
       });
-    } else if (msg.type === "session_id") {
-      this.config.observability?.emitInstrumentationEvent("signaling-received", { type: msg.type });
+    } else if ((msg as { type?: string }).type === "session_id") {
+      // `session_id` isn't in the typed IncomingRealtimeMessage union but is
+      // sent by the bouncer; trace it for the connection timeline.
+      this.config.observability?.emitInstrumentationEvent("signaling-received", { type: "session_id" });
     }
     for (const ack of [...this.pendingAcks]) {
       if (ack.matches(msg)) {

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -328,11 +328,18 @@ export class StreamSession {
       logger: this.logger,
       videoCodec: this.config.videoCodec,
     });
+    // Forward client-side diagnostics + WebRTC stats back over the
+    // realtime WS so bouncer can log them to Datadog under the
+    // session's existing log context.
+    this.config.observability?.setObservabilityForwarder((payload) => {
+      this.signaling.sendObservability(payload);
+    });
     this.wireSignalingEvents();
     this.wireMediaEvents();
   }
 
   private tearDown(): void {
+    this.config.observability?.setObservabilityForwarder(null);
     this.signaling.close();
     this.media.disconnect();
     this.initialStateGate.reset();

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -135,7 +135,19 @@ export type IncomingRealtimeMessage =
   | LiveKitRoomInfoMessage
   | QueuePositionMessage;
 
+// Client-side WebRTC / ICE / networking observability events. Free-form
+// payload; logged by bouncer under the session's existing log context and
+// not forwarded upstream.
+export type ObservabilityMessage = {
+  type: "observability";
+  data: unknown;
+};
+
 // Outgoing message types (to server)
-export type OutgoingRealtimeMessage = LiveKitJoinMessage | PromptMessage | SetImageMessage;
+export type OutgoingRealtimeMessage =
+  | LiveKitJoinMessage
+  | PromptMessage
+  | SetImageMessage
+  | ObservabilityMessage;
 
 export type OutgoingMessage = PromptMessage | SetImageMessage;

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -144,10 +144,6 @@ export type ObservabilityMessage = {
 };
 
 // Outgoing message types (to server)
-export type OutgoingRealtimeMessage =
-  | LiveKitJoinMessage
-  | PromptMessage
-  | SetImageMessage
-  | ObservabilityMessage;
+export type OutgoingRealtimeMessage = LiveKitJoinMessage | PromptMessage | SetImageMessage | ObservabilityMessage;
 
 export type OutgoingMessage = PromptMessage | SetImageMessage;

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -23,6 +23,27 @@ const liveKitMock = vi.hoisted(() => {
     SignalReconnecting: "signalReconnecting",
     Disconnected: "disconnected",
   } as const;
+  // Mirrors livekit-client's DisconnectReason enum well enough for our
+  // network-instrumentation lookup table. Real numeric values from the
+  // protocol; safe to extend without breaking tests.
+  const DisconnectReason = {
+    UNKNOWN_REASON: 0,
+    CLIENT_INITIATED: 1,
+    DUPLICATE_IDENTITY: 2,
+    SERVER_SHUTDOWN: 3,
+    PARTICIPANT_REMOVED: 4,
+    ROOM_DELETED: 5,
+    STATE_MISMATCH: 6,
+    JOIN_FAILURE: 7,
+    MIGRATION: 8,
+    SIGNAL_CLOSE: 9,
+    ROOM_CLOSED: 10,
+    USER_UNAVAILABLE: 11,
+    USER_REJECTED: 12,
+    SIP_TRUNK_FAILURE: 13,
+    CONNECTION_TIMEOUT: 14,
+    MEDIA_FAILURE: 15,
+  } as const;
 
   class MockRoom {
     handlers = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -49,7 +70,7 @@ const liveKitMock = vi.hoisted(() => {
     }
   }
 
-  return { roomInstances, RoomEvent, Track, TrackEvent, ConnectionState, MockRoom };
+  return { roomInstances, RoomEvent, Track, TrackEvent, ConnectionState, DisconnectReason, MockRoom };
 });
 
 vi.mock("livekit-client", () => ({
@@ -58,6 +79,7 @@ vi.mock("livekit-client", () => ({
   Track: liveKitMock.Track,
   TrackEvent: liveKitMock.TrackEvent,
   ConnectionState: liveKitMock.ConnectionState,
+  DisconnectReason: liveKitMock.DisconnectReason,
 }));
 
 class FakeMediaStream {


### PR DESCRIPTION
## Purpose

Triggers a `pkg.pr.new` snapshot for the observability-bouncer-ingest branch rebased onto current `main`.

**Do not merge.** The corresponding non-rebased branch is [#148](https://github.com/DecartAI/sdk/pull/148); this PR exists solely so the webrtc-ice-connection-tester can consume an `@decartai/sdk` build that has both:
- glass-to-glass canvas-fallback stamping (lands the iOS pixel-latency chip)
- the WS observability forwarding from #148

7 commits, rebased over `addac79` (`feat(realtime): bundle initial_state into livekit_join`).

## Conflict resolutions

| File | Resolution |
|------|------------|
| `realtime-observability.ts` class fields | Keep both (g2g fields + `observabilityForwarder`) |
| `realtime-observability.ts` `handleStats` | Keep `connectionQuality.update`, drop the WS stats forwarder (commit `4518087` later removed exactly this — 1Hz stats too noisy for the WS) |
| `signaling-channel.ts` top-level decls | Keep both (`InitialStateRequest` helper + `OBSERVABILITY_BUFFER_MAX`) |

Verified locally: `tsc --noEmit` clean, `pnpm test` → 276/276 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)