### PR TITLE
realtime: send livekit_join lean, initial-state image as its own frame

### DIFF
--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -147,16 +147,22 @@ export class SignalingChannel {
     this.config.observability?.startPhase("room-join");
     const roomInfoWait = this.waitForRoomInfo(handshakeTimeout);
 
-    // The initial state rides inside livekit_join so the inference server gets
-    // the reference image/prompt with the join, with no separate message sent
-    // after livekit_room_info arrives.
+    // Lean join first, then the initial state as its own frame. The server
+    // returns room_info off the small join frame without waiting for the
+    // (multi-MB) image to upload, so the upload overlaps the SFU connect rather
+    // than blocking room_info. Order matters: the join must be written first.
     const initialStateRequest = buildInitialStateRequest(opts.initialState);
     const joinMessage: LiveKitJoinMessage = {
       type: "livekit_join",
-      initial_state: initialStateRequest ? initialStateRequest.message : null,
+      initial_state: null,
     };
 
     if (!this.writeMessage(joinMessage)) {
+      roomInfoWait.cancel();
+      throw new Error("WebSocket is not open");
+    }
+
+    if (initialStateRequest && !this.writeMessage(initialStateRequest.message)) {
       roomInfoWait.cancel();
       throw new Error("WebSocket is not open");
     }
@@ -173,8 +179,8 @@ export class SignalingChannel {
     this.connected = true;
 
     // Arm the ack only now that room info arrived, so a long queue wait cannot
-    // trip the ack timeout. The message already rode out with the join, so this
-    // waits for the ack without writing again.
+    // trip the ack timeout. The message was already written as its own frame
+    // right after the join, so this waits for the ack without writing again.
     const initialStateAck = initialStateRequest ? this.flushInitialState(initialStateRequest) : Promise.resolve();
     initialStateAck.catch(() => {});
 


### PR DESCRIPTION
The reference image (often multi-MB) was bundled inside the livekit_join message, so the server couldn't return room_info until the whole image uploaded — blocking the SFU connect behind a ~1.4s upload on a far link.

Send the lean join first, then the set_image as a separate WS frame. The server emits room_info off the small join frame and the image upload overlaps the SFU connect. flushInitialState still waits for set_image_ack (write:false); the bouncer already handles standalone set_image, so no server change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime connection ordering and wire format for initial state; server must accept standalone `set_image` after join (PR notes bouncer already does). Unit tests in `realtime-signaling-unit.test.ts` still assert the old bundled `initial_state` shape and may need updates.
> 
> **Overview**
> **Join handshake no longer embeds the reference image or prompt inside `livekit_join`.** The join message is sent with `initial_state: null`, then `set_image` / `prompt` (when present) is written as a **second** WebSocket frame immediately after.
> 
> The goal is faster `livekit_room_info`: the server can respond off the small join frame while the large image upload continues in parallel with SFU connect, instead of serializing room info behind a ~1s+ upload on slow links.
> 
> **Ack behavior is unchanged in spirit:** `flushInitialState` still waits for `set_image_ack` / `prompt_ack` with `write: false` because the payload was already sent in that second frame. Early acks before `room_info` remain supported via the existing ack buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07af06565ad55aa7d393db41c67ec6c2d2f48cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->