### PR TITLE
feat(tokens): expose signed JWT on client token response

### DIFF
--- a/examples/sdk-core/tokens/create-client-token.ts
+++ b/examples/sdk-core/tokens/create-client-token.ts
@@ -15,6 +15,7 @@ run(async () => {
 
   console.log("Token created successfully:");
   console.log(`  API Key: ${token.apiKey.slice(0, 10)}...`);
+  console.log(`  JWT: ${token.token ? `${token.token.slice(0, 16)}...` : "(not issued)"}`);
   console.log(`  Expires At: ${token.expiresAt}`);
   console.log(`  Allowed Origins: ${token.permissions?.origins?.join(", ") ?? "(any)"}`);
 

--- a/packages/sdk/src/tokens/client.ts
+++ b/packages/sdk/src/tokens/client.ts
@@ -28,6 +28,8 @@ export type CreateTokenOptions = {
 
 export type CreateTokenResponse = {
   apiKey: string;
+  /** Signed JWT mirroring `apiKey`, verifiable offline via the public JWKS. */
+  token?: string;
   expiresAt: string;
   /** Present when `allowedModels` and/or `allowedOrigins` were set on the request. */
   permissions?: {
@@ -48,7 +50,7 @@ export type TokensClient = {
    * ```ts
    * const client = createDecartClient({ apiKey: process.env.DECART_API_KEY });
    * const token = await client.tokens.create();
-   * // Returns: { apiKey: "ek_...", expiresAt: "2024-12-15T12:10:00Z" }
+   * // Returns: { apiKey: "ek_...", token: "eyJhbGciOiJFZERTQS...", expiresAt: "2024-12-15T12:10:00Z" }
    *
    * // With metadata:
    * const token = await client.tokens.create({ metadata: { role: "viewer" } });

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1128,6 +1128,37 @@ describe("Tokens API", () => {
       });
       expect(result.constraints).toEqual({ realtime: { maxSessionDuration: 120 } });
     });
+
+    it("returns the signed JWT from response", async () => {
+      server.use(
+        http.post("http://localhost/v1/client/tokens", () => {
+          return HttpResponse.json({
+            apiKey: "ek_test123",
+            token: "eyJhbGciOiJFZERTQS.signed.jwt",
+            expiresAt: "2024-12-15T12:10:00Z",
+          });
+        }),
+      );
+
+      const result = await decart.tokens.create();
+
+      expect(result.token).toBe("eyJhbGciOiJFZERTQS.signed.jwt");
+    });
+
+    it("leaves token undefined when omitted from response", async () => {
+      server.use(
+        http.post("http://localhost/v1/client/tokens", () => {
+          return HttpResponse.json({
+            apiKey: "ek_test123",
+            expiresAt: "2024-12-15T12:10:00Z",
+          });
+        }),
+      );
+
+      const result = await decart.tokens.create();
+
+      expect(result.token).toBeUndefined();
+    });
   });
 });
 

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -1099,12 +1099,12 @@ describe("Tokens API", () => {
       });
     });
 
-    it("returns permissions and constraints from response", async () => {
+    it("returns all fields from response", async () => {
       server.use(
-        http.post("http://localhost/v1/client/tokens", async ({ request }) => {
-          lastRequest = request;
+        http.post("http://localhost/v1/client/tokens", () => {
           return HttpResponse.json({
             apiKey: "ek_test123",
+            token: "eyJhbGciOiJFZERTQS.signed.jwt",
             expiresAt: "2024-12-15T12:15:00Z",
             permissions: {
               models: ["lucy-pro-v2v", "lucy-restyle-v2v"],
@@ -1121,43 +1121,16 @@ describe("Tokens API", () => {
         constraints: { realtime: { maxSessionDuration: 120 } },
       });
 
-      expect(result.apiKey).toBe("ek_test123");
-      expect(result.permissions).toEqual({
-        models: ["lucy-pro-v2v", "lucy-restyle-v2v"],
-        origins: ["https://example.com"],
+      expect(result).toEqual({
+        apiKey: "ek_test123",
+        token: "eyJhbGciOiJFZERTQS.signed.jwt",
+        expiresAt: "2024-12-15T12:15:00Z",
+        permissions: {
+          models: ["lucy-pro-v2v", "lucy-restyle-v2v"],
+          origins: ["https://example.com"],
+        },
+        constraints: { realtime: { maxSessionDuration: 120 } },
       });
-      expect(result.constraints).toEqual({ realtime: { maxSessionDuration: 120 } });
-    });
-
-    it("returns the signed JWT from response", async () => {
-      server.use(
-        http.post("http://localhost/v1/client/tokens", () => {
-          return HttpResponse.json({
-            apiKey: "ek_test123",
-            token: "eyJhbGciOiJFZERTQS.signed.jwt",
-            expiresAt: "2024-12-15T12:10:00Z",
-          });
-        }),
-      );
-
-      const result = await decart.tokens.create();
-
-      expect(result.token).toBe("eyJhbGciOiJFZERTQS.signed.jwt");
-    });
-
-    it("leaves token undefined when omitted from response", async () => {
-      server.use(
-        http.post("http://localhost/v1/client/tokens", () => {
-          return HttpResponse.json({
-            apiKey: "ek_test123",
-            expiresAt: "2024-12-15T12:10:00Z",
-          });
-        }),
-      );
-
-      const result = await decart.tokens.create();
-
-      expect(result.token).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## What

`tokens.create()` now surfaces the server-issued signed JWT as `token`, alongside the existing opaque `apiKey`.

## Why

The JWT carries the same authorization context as the opaque key but can be verified offline against the public JWKS, so gateways can authenticate client tokens by signature instead of round-tripping to the verify endpoint on every connection. The opaque `apiKey` is unchanged and remains the default; `token` is optional and simply omitted when signing isn't available.

## Usage

```ts
const client = createDecartClient({ apiKey: process.env.DECART_API_KEY });
const { apiKey, token, expiresAt } = await client.tokens.create();
// apiKey: "ek_..."  — opaque key (online verify)
// token:  "eyJhbGciOiJFZERTQS..." — signed JWT (offline JWKS verify), may be undefined
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on a public type with no auth or request-path changes; existing callers ignoring `token` are unaffected.
> 
> **Overview**
> `tokens.create()` now types and documents an optional **`token`** field on the response: a signed JWT that mirrors the opaque **`apiKey`** and can be verified offline via JWKS (when the API issues it).
> 
> This is a **backward-compatible** SDK surface change only—the client still POSTs the same body and parses JSON unchanged; **`apiKey`** behavior is untouched. The example logs the JWT when present, and unit tests assert the full response shape including **`token`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61bdc2b2c595d13f68277de38dcba1bdbda50f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->