### PR TITLE
example(dev page): choose initial-state ref image instead of implicit default

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -370,6 +370,10 @@
             <input type="text" id="initial-prompt" placeholder="e.g. Lego World">
         </div>
         <div class="control-group">
+            <label for="initial-image">Initial Reference Image (optional):</label>
+            <input type="file" id="initial-image" accept="image/*">
+        </div>
+        <div class="control-group">
             <label for="camera-fps">Camera FPS:</label>
             <input type="number" id="camera-fps" min="1" max="120" step="1">
         </div>
@@ -603,6 +607,7 @@
             resolutionSelect: document.getElementById('resolution-select'),
             codecSelect: document.getElementById('codec-select'),
             initialPrompt: document.getElementById('initial-prompt'),
+            initialImage: document.getElementById('initial-image'),
             cameraFps: document.getElementById('camera-fps'),
             streamAudioToggle: document.getElementById('stream-audio-toggle'),
             startCamera: document.getElementById('start-camera'),
@@ -1067,11 +1072,10 @@
                     addLog('Initial prompt: passthrough (no prompt)', 'info');
                 }
 
-                // Load initial reference image only when there's an actual prompt
-                let initialImage;
-                if (promptValue && (model.name === 'lucy-2.1' || model.name === 'mirage_v2')) {
-                    const initialImageResponse = await fetch('./tests/fixtures/image.png');
-                    initialImage = await initialImageResponse.blob();
+                // Use the chosen reference image (if any) as the initial state image
+                const initialImage = elements.initialImage.files[0];
+                if (initialImage) {
+                    addLog(`Initial reference image: ${initialImage.name}`, 'info');
                 }
 
                 const resolution = elements.resolutionSelect.value;


### PR DESCRIPTION
## What

In the SDK dev/test page (`packages/sdk/index.html`):

- **Remove** the implicit behavior of sending a default image (`tests/fixtures/image.png`) as the initial state. Previously, whenever an initial prompt was set on `lucy-2.1`/`mirage_v2`, the page silently fetched the fixture image and passed it as `initialState.image`.
- **Add** an optional **Initial Reference Image** file input in the Configuration section, letting you explicitly pick which image is used for the initial state at connect time.

## Why

Sending a hidden default image as the initial state was surprising and undocumented behavior. The page already lets you set an initial *prompt*, and lets you choose a ref image *once a connection is ongoing* (via Image Reference / Files API). This adds the missing piece — choosing a ref image for the **initial state** — without any implicit magic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the local SDK demo HTML; no production SDK or API behavior is modified.
> 
> **Overview**
> The SDK **dev/test page** no longer auto-attaches `tests/fixtures/image.png` to `initialState.image` when you set an initial prompt on `lucy-2.1` / `mirage_v2`.
> 
> **Configuration** now includes an optional **Initial Reference Image** file input. On connect, only a file you pick there is sent as `initialState.image` (with logging of the filename); otherwise no initial image is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a8649515d6a21a9f01612dae34dde121e6212e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->