### PR TITLE
feat(realtime): H.264 SEI glass-to-glass latency (aiortc, Encoded Transform)

### DIFF
--- a/packages/sdk/sei-loopback.html
+++ b/packages/sdk/sei-loopback.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SEI Glass-to-Glass Loopback Proof</title>
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; max-width: 980px; margin: 0 auto; padding: 16px; background: #0f1115; color: #e6e6e6; }
+    h1 { font-size: 20px; }
+    p.lede { color: #9aa4b2; font-size: 13px; line-height: 1.5; }
+    .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 16px 0; }
+    .metric { background: #1a1d24; border: 1px solid #2a2f3a; border-radius: 10px; padding: 12px; }
+    .metric .label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #8a93a3; }
+    .metric .value { font-size: 28px; font-weight: 700; margin-top: 4px; font-variant-numeric: tabular-nums; }
+    .metric .value.ok { color: #4caf50; }
+    .videos { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .videos figure { margin: 0; }
+    .videos figcaption { font-size: 12px; color: #8a93a3; margin-bottom: 6px; }
+    canvas, video { width: 100%; background: #000; border-radius: 8px; aspect-ratio: 16/9; object-fit: contain; }
+    #status { font-family: ui-monospace, monospace; font-size: 12px; padding: 8px 10px; border-radius: 8px; background: #1a1d24; border: 1px solid #2a2f3a; margin-bottom: 12px; white-space: pre-wrap; }
+    .err { color: #ff6b6b; }
+    .ok { color: #4caf50; }
+    button { background:#2a2f3a; color:#e6e6e6; border:1px solid #3a4150; border-radius:8px; padding:6px 12px; font-size:13px; cursor:pointer; }
+    button:hover { background:#343a47; }
+  </style>
+</head>
+<body>
+  <h1>SEI Glass-to-Glass Loopback Proof</h1>
+  <p class="lede">
+    Pure browser proof that JavaScript can <strong>read and write H.264 SEI</strong>. A canvas (no camera) is
+    encoded to H.264 and sent over a local <code>RTCPeerConnection</code> loopback. On the sender,
+    a <code>RTCRtpScriptTransform</code> worker injects an SEI NAL stamped with <code>Date.now()</code>;
+    on the receiver, the worker parses it back and reports glass-to-glass latency. No server, no SDK signaling.
+  </p>
+
+  <div style="margin:12px 0; display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+    <button id="use-canvas">🎨 Canvas source</button>
+    <button id="use-camera">📷 Camera source</button>
+    <span style="font-size:12px; color:#8a93a3;">canvas runs headless; camera needs permission &amp; localhost/HTTPS</span>
+  </div>
+
+  <div id="status">initializing…</div>
+
+  <div class="metrics">
+    <div class="metric"><div class="label">SEI g2g latency</div><div class="value" id="m-latency">—</div></div>
+    <div class="metric"><div class="label">avg (last 30)</div><div class="value" id="m-avg">—</div></div>
+    <div class="metric"><div class="label">negotiated codec</div><div class="value" id="m-codec" style="font-size:18px">—</div></div>
+    <div class="metric"><div class="label">SEI frames matched</div><div class="value" id="m-count">0</div></div>
+  </div>
+
+  <div class="videos">
+    <figure><figcaption>📤 source (sent)</figcaption><canvas id="src" width="640" height="360"></canvas><video id="src-cam" autoplay muted playsinline style="display:none"></video></figure>
+    <figure><figcaption>📥 received (decoded)</figcaption><video id="dst" autoplay muted playsinline></video></figure>
+  </div>
+
+  <script type="module">
+    const $ = (id) => document.getElementById(id);
+    const status = (msg, cls = "") => { $("status").className = cls; $("status").textContent = msg; };
+
+    // ---- animated canvas source (so the encoder always has fresh frames) ----
+    const canvas = $("src");
+    const ctx = canvas.getContext("2d");
+    function draw() {
+      const t = Date.now() / 1000;
+      ctx.fillStyle = "#101826";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      const x = (Math.sin(t) * 0.5 + 0.5) * (canvas.width - 80);
+      const y = (Math.cos(t * 0.7) * 0.5 + 0.5) * (canvas.height - 80);
+      ctx.fillStyle = `hsl(${(t * 60) % 360}, 80%, 60%)`;
+      ctx.fillRect(x, y, 80, 80);
+      ctx.fillStyle = "#fff";
+      ctx.font = "20px monospace";
+      ctx.fillText(new Date().toISOString().slice(11, 23), 16, 32);
+    }
+    // setInterval (not rAF) so frames keep flowing even when the tab is backgrounded.
+    setInterval(draw, 33);
+    draw();
+
+    if (typeof RTCRtpScriptTransform === "undefined") {
+      status("❌ RTCRtpScriptTransform is not available in this browser. Use Chrome/Safari/recent Firefox.", "err");
+      throw new Error("no RTCRtpScriptTransform");
+    }
+
+    const worker = new Worker(new URL("./src/realtime/sei/sei-worker.ts", import.meta.url), { type: "module" });
+    const recent = [];
+    let matched = 0;
+    let sender = null, canvasTrack = null, cameraStream = null;
+    worker.onmessage = (e) => {
+      const msg = e.data;
+      if (msg.type === "sei-latency") {
+        matched++;
+        $("m-count").textContent = String(matched);
+        $("m-latency").textContent = `${msg.latencyMs} ms`;
+        $("m-latency").classList.add("ok");
+        recent.push(msg.latencyMs);
+        if (recent.length > 30) recent.shift();
+        const avg = recent.reduce((a, b) => a + b, 0) / recent.length;
+        $("m-avg").textContent = `${avg.toFixed(1)} ms`;
+        status(`✅ reading SEI off decoded H.264 frames — ${matched} frames matched`, "ok");
+      } else if (msg.type === "sei-error") {
+        status(`worker error: ${msg.message}`, "err");
+      }
+    };
+
+    function forceH264(pc, sender) {
+      const tr = pc.getTransceivers().find((t) => t.sender === sender);
+      const caps = RTCRtpSender.getCapabilities("video");
+      if (!tr || !caps) return;
+      const h264 = caps.codecs.filter((c) => c.mimeType.toLowerCase() === "video/h264");
+      const others = caps.codecs.filter((c) => c.mimeType.toLowerCase() !== "video/h264");
+      if (h264.length) tr.setCodecPreferences([...h264, ...others]);
+    }
+
+    async function main() {
+      status("setting up loopback…");
+      const stream = canvas.captureStream(30);
+
+      const pc1 = new RTCPeerConnection();
+      const pc2 = new RTCPeerConnection();
+      pc1.onicecandidate = (e) => e.candidate && pc2.addIceCandidate(e.candidate);
+      pc2.onicecandidate = (e) => e.candidate && pc1.addIceCandidate(e.candidate);
+
+      pc2.ontrack = (e) => {
+        e.receiver.transform = new RTCRtpScriptTransform(worker, { operation: "parse" });
+        $("dst").srcObject = e.streams[0] || new MediaStream([e.track]);
+      };
+
+      const [track] = stream.getVideoTracks();
+      canvasTrack = track;
+      sender = pc1.addTrack(track, stream);
+      forceH264(pc1, sender);
+      sender.transform = new RTCRtpScriptTransform(worker, { operation: "inject" });
+
+      const offer = await pc1.createOffer();
+      await pc1.setLocalDescription(offer);
+      await pc2.setRemoteDescription(offer);
+      const answer = await pc2.createAnswer();
+      await pc2.setLocalDescription(answer);
+      await pc1.setRemoteDescription(answer);
+
+      status("connecting…");
+      pc1.onconnectionstatechange = () => {
+        if (pc1.connectionState === "connected") status("connected — waiting for SEI frames…");
+      };
+
+      // Periodically surface the negotiated codec + decoded frame count from stats.
+      setInterval(async () => {
+        const stats = await pc2.getStats();
+        let codec = "?";
+        let frames = 0;
+        const codecs = new Map();
+        stats.forEach((r) => { if (r.type === "codec") codecs.set(r.id, r.mimeType); });
+        stats.forEach((r) => {
+          if (r.type === "inbound-rtp" && r.kind === "video") {
+            frames = r.framesDecoded || 0;
+            if (r.codecId && codecs.has(r.codecId)) codec = codecs.get(r.codecId);
+          }
+        });
+        $("m-codec").textContent = codec;
+      }, 1000);
+    }
+
+    async function useCamera() {
+      if (!sender) return;
+      try {
+        cameraStream = await navigator.mediaDevices.getUserMedia({ video: { width: 1280, height: 720 }, audio: false });
+        await sender.replaceTrack(cameraStream.getVideoTracks()[0]);
+        $("src-cam").srcObject = cameraStream;
+        $("src-cam").style.display = "block";
+        $("src").style.display = "none";
+        status("📷 camera → H.264 → SEI loopback");
+      } catch (e) {
+        status(`❌ camera: ${e}`, "err");
+      }
+    }
+    async function useCanvas() {
+      if (!sender || !canvasTrack) return;
+      await sender.replaceTrack(canvasTrack);
+      if (cameraStream) { cameraStream.getTracks().forEach((t) => t.stop()); cameraStream = null; }
+      $("src-cam").style.display = "none";
+      $("src").style.display = "block";
+    }
+    $("use-camera").onclick = useCamera;
+    $("use-canvas").onclick = useCanvas;
+
+    main().catch((e) => status(`❌ ${e}`, "err"));
+  </script>
+</body>
+</html>

--- a/packages/sdk/sei-server-demo.html
+++ b/packages/sdk/sei-server-demo.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SEI Glass-to-Glass — through-server demo</title>
+  <style>
+    body { font-family: system-ui, Arial, sans-serif; max-width: 1000px; margin: 0 auto; padding: 16px; background: #0f1115; color: #e6e6e6; }
+    h1 { font-size: 20px; } p.lede { color: #9aa4b2; font-size: 13px; line-height: 1.5; }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 8px 0; }
+    input, select { padding: 7px 9px; border: 1px solid #2a2f3a; border-radius: 7px; background: #1a1d24; color: #e6e6e6; font-size: 13px; }
+    input[type=text], input[type=password] { min-width: 240px; }
+    button { background: #2a2f3a; color: #e6e6e6; border: 1px solid #3a4150; border-radius: 8px; padding: 7px 13px; font-size: 13px; cursor: pointer; }
+    button:hover:not(:disabled) { background: #343a47; } button:disabled { opacity: .5; cursor: not-allowed; }
+    .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin: 14px 0; }
+    .metric { background: #1a1d24; border: 1px solid #2a2f3a; border-radius: 10px; padding: 12px; }
+    .metric .label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #8a93a3; }
+    .metric .value { font-size: 26px; font-weight: 700; margin-top: 4px; font-variant-numeric: tabular-nums; }
+    .videos { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    video { width: 100%; background: #000; border-radius: 8px; aspect-ratio: 16/9; object-fit: contain; }
+    figcaption { font-size: 12px; color: #8a93a3; margin-bottom: 6px; }
+    #status { font-family: ui-monospace, monospace; font-size: 12px; padding: 8px 10px; border-radius: 8px; background: #1a1d24; border: 1px solid #2a2f3a; margin: 10px 0; white-space: pre-wrap; }
+    .err { color: #ff6b6b; } .ok { color: #4caf50; }
+  </style>
+</head>
+<body>
+  <h1>SEI Glass-to-Glass — through-server demo</h1>
+  <p class="lede">
+    Camera → H.264 (forced) → <strong>your local bit-invert RT server</strong> → back. The SDK injects an SEI
+    marker on the uplink; the server's SEI bridge echoes it onto the output; this page parses it on the
+    downlink and reports true glass-to-glass latency. Prompts are sent over the data channel.
+  </p>
+
+  <div class="row">
+    <input type="password" id="api-key" placeholder="API key (local dev key)" />
+    <input type="text" id="base-url" placeholder="Realtime base URL (e.g. wss://api.decart.local)" value="wss://api.decart.local" />
+    <select id="model">
+      <option value="lucy-2.1" selected>lucy-2.1</option>
+      <option value="mirage_v2">mirage_v2</option>
+      <option value="lucy-restyle-2">lucy-restyle-2</option>
+    </select>
+  </div>
+  <div class="row">
+    <button id="start-camera">Start camera</button>
+    <button id="connect" disabled>Connect (SEI)</button>
+    <button id="disconnect" disabled>Disconnect</button>
+  </div>
+  <div class="row">
+    <input type="text" id="prompt" placeholder="prompt…" disabled />
+    <button id="send-prompt" disabled>Send prompt</button>
+  </div>
+
+  <div id="status">idle</div>
+  <div id="diag" style="font-size:12px; color:#8a93a3; margin:6px 0; font-family:ui-monospace,monospace;"></div>
+
+  <div class="metrics">
+    <div class="metric"><div class="label">SEI g2g latency</div><div class="value" id="m-latency">—</div></div>
+    <div class="metric"><div class="label">avg (last 30)</div><div class="value" id="m-avg">—</div></div>
+    <div class="metric"><div class="label">negotiated codec</div><div class="value" id="m-codec" style="font-size:18px">—</div></div>
+    <div class="metric"><div class="label">SEI frames matched</div><div class="value" id="m-count">0</div></div>
+  </div>
+
+  <div class="videos">
+    <figure style="margin:0"><figcaption>📷 camera (sent)</figcaption><video id="local" autoplay muted playsinline></video></figure>
+    <figure style="margin:0"><figcaption>🤖 server output (received)</figcaption><video id="remote" autoplay playsinline></video></figure>
+  </div>
+
+  <script type="module">
+    import { createDecartClient, models } from "./src/index.ts";
+
+    const $ = (id) => document.getElementById(id);
+    const status = (m, cls = "") => { $("status").className = cls; $("status").textContent = m; };
+
+    let localStream = null, rt = null, worker = null;
+    const recent = []; let matched = 0;
+
+    // URL params for headless/manual driving: ?canvas=1 (no camera), ?base=, ?key=
+    const params = new URLSearchParams(location.search);
+    if (params.get("base")) $("base-url").value = params.get("base");
+    if (params.get("key")) $("api-key").value = params.get("key");
+    const useCanvas = params.get("canvas") === "1";
+
+    async function makeSource() {
+      if (!useCanvas) return navigator.mediaDevices.getUserMedia({ video: { width: 1280, height: 720 }, audio: false });
+      const c = document.createElement("canvas");
+      c.width = 640; c.height = 360;
+      const ctx = c.getContext("2d");
+      const draw = () => {
+        const t = Date.now() / 1000;
+        ctx.fillStyle = "#101826"; ctx.fillRect(0, 0, 640, 360);
+        ctx.fillStyle = `hsl(${(t * 60) % 360},80%,60%)`;
+        ctx.fillRect((Math.sin(t) * 0.5 + 0.5) * 560, (Math.cos(t * 0.7) * 0.5 + 0.5) * 280, 80, 80);
+        ctx.fillStyle = "#fff"; ctx.font = "20px monospace"; ctx.fillText(new Date().toISOString().slice(11, 23), 16, 32);
+      };
+      setInterval(draw, 33); draw(); // setInterval survives a backgrounded tab
+      return c.captureStream(30);
+    }
+
+    $("start-camera").onclick = async () => {
+      try {
+        localStream = await makeSource();
+        $("local").srcObject = localStream;
+        $("connect").disabled = false;
+        status(useCanvas ? "canvas source ready" : "camera started", "ok");
+      } catch (e) { status(`❌ source: ${e}`, "err"); }
+    };
+
+    function ensureWorker() {
+      if (worker) return worker;
+      if (typeof RTCRtpScriptTransform === "undefined") { status("❌ no RTCRtpScriptTransform in this browser", "err"); return null; }
+      worker = new Worker(new URL("./src/realtime/sei/sei-worker.ts", import.meta.url), { type: "module" });
+      const diag = { inject: false, parse: false, injected: 0, parseSeen: 0, parseMatched: 0 };
+      const renderDiag = () => {
+        $("diag").textContent =
+          `uplink: transform=${diag.inject ? "✅" : "…"} injected=${diag.injected}  |  ` +
+          `downlink: transform=${diag.parse ? "✅" : "…"} framesSeen=${diag.parseSeen} seiFound=${diag.parseMatched}`;
+      };
+      worker.onmessage = (e) => {
+        const m = e.data;
+        if (m.type === "sei-latency") {
+          matched++; $("m-count").textContent = String(matched);
+          $("m-latency").textContent = `${m.latencyMs} ms`; $("m-latency").classList.add("ok");
+          recent.push(m.latencyMs); if (recent.length > 30) recent.shift();
+          $("m-avg").textContent = `${(recent.reduce((a, b) => a + b, 0) / recent.length).toFixed(1)} ms`;
+          status(`✅ SEI echoed through the server — ${matched} frames matched`, "ok");
+        } else if (m.type === "sei-attached") {
+          if (m.operation === "inject") diag.inject = true;
+          if (m.operation === "parse") diag.parse = true;
+          renderDiag();
+        } else if (m.type === "sei-stats") {
+          if (m.injected != null) diag.injected = m.injected;
+          if (m.parseSeen != null) { diag.parseSeen = m.parseSeen; diag.parseMatched = m.parseMatched; }
+          renderDiag();
+        } else if (m.type === "sei-error") status(`worker: ${m.message}`, "err");
+      };
+      return worker;
+    }
+
+    // Uplink: install BEFORE the offer (media not flowing yet) so frames route through the transform.
+    function installInject(pc) {
+      const w = ensureWorker(); if (!w) return;
+      const vs = pc.getSenders().find((s) => s.track?.kind === "video");
+      if (vs) vs.transform = new RTCRtpScriptTransform(w, { operation: "inject" });
+      setInterval(async () => {
+        const stats = await pc.getStats(); const codecs = new Map();
+        stats.forEach((r) => { if (r.type === "codec") codecs.set(r.id, r.mimeType); });
+        stats.forEach((r) => { if (r.type === "inbound-rtp" && r.kind === "video" && r.codecId) $("m-codec").textContent = codecs.get(r.codecId) || "?"; });
+      }, 1000);
+    }
+
+    // Downlink: install at ontrack (onRemoteStream), before the decoder consumes frames.
+    // Match the EXACT receiver for the delivered remote track — a sendrecv
+    // transceiver also exposes a recv-side video receiver that carries no media,
+    // so matching by kind alone can attach to the wrong (silent) receiver.
+    function installParse(pc, stream) {
+      const w = ensureWorker(); if (!w) return;
+      const vtrack = stream?.getVideoTracks?.()[0] ?? null;
+      const vr = (vtrack && pc.getReceivers().find((r) => r.track === vtrack))
+        || pc.getReceivers().find((r) => r.track?.kind === "video");
+      if (vr) vr.transform = new RTCRtpScriptTransform(w, { operation: "parse" });
+    }
+
+    $("connect").onclick = async () => {
+      const apiKey = $("api-key").value.trim();
+      const baseUrl = $("base-url").value.trim();
+      if (!localStream) return status("start camera first", "err");
+      try {
+        status("connecting…");
+        $("connect").disabled = true;
+        let seiPc = null;
+        const client = createDecartClient({ apiKey, ...(baseUrl && { realtimeBaseUrl: baseUrl }) });
+        rt = await client.realtime.connect(localStream, {
+          model: models.realtime($("model").value),
+          seiLatency: true,
+          // Both transforms attach BEFORE the offer. The client is the offerer, so
+          // its ontrack fires only at setRemoteDescription(answer) — too late to bind
+          // a receiver transform. aiortc reuses this sendrecv transceiver for its
+          // output, so the recv side exists pre-offer and catches the server's frames.
+          onPeerConnection: (pc) => { seiPc = pc; installInject(pc); installParse(pc); },
+          onRemoteStream: (s) => { $("remote").srcObject = s; },
+          onConnectionChange: (st) => status(`state: ${st}`),
+        });
+        $("disconnect").disabled = false; $("prompt").disabled = false; $("send-prompt").disabled = false;
+        status("connected — waiting for SEI frames…", "ok");
+      } catch (e) { status(`❌ connect: ${e?.message ?? e}`, "err"); $("connect").disabled = false; }
+    };
+
+    $("send-prompt").onclick = () => { const p = $("prompt").value.trim(); if (p && rt) { rt.setPrompt(p, { enhance: false }); status(`sent prompt: ${p}`, "ok"); } };
+    $("disconnect").onclick = () => { rt?.disconnect(); worker?.terminate(); status("disconnected"); $("disconnect").disabled = true; $("connect").disabled = false; };
+  </script>
+</body>
+</html>

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -91,6 +91,7 @@ const realTimeClientConnectOptionsSchema = z.object({
   onRemoteStream: z.custom<OnRemoteStreamFn>((val) => typeof val === "function", {
     message: "onRemoteStream must be a function",
   }),
+  onPeerConnection: z.custom<(pc: RTCPeerConnection) => void>((val) => typeof val === "function").optional(),
   initialState: realTimeClientInitialStateSchema.optional(),
   customizeOffer: createAsyncFunctionSchema(z.function()).optional(),
   /**
@@ -102,6 +103,13 @@ const realTimeClientConnectOptionsSchema = z.object({
   mirror: z.union([z.literal("auto"), z.boolean()]).optional(),
   /** Output resolution. Defaults to "720p". */
   resolution: z.enum(["720p", "1080p"]).optional(),
+  /**
+   * Opt-in SEI glass-to-glass latency. Forces H.264 and adds `?sei_latency=1`
+   * to signaling; the caller attaches encoded-frame transforms via
+   * getPeerConnection(). Requires a server that echoes the SEI marker (e.g.
+   * bit-invert with the SEI bridge).
+   */
+  seiLatency: z.boolean().optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -129,6 +137,9 @@ export type RealTimeClient = {
     image: Blob | File | string | null,
     options?: { prompt?: string; enhance?: boolean; timeout?: number },
   ) => Promise<void>;
+  /** The live RTCPeerConnection (or null) — lets callers attach encoded-frame
+   *  transforms, e.g. for SEI glass-to-glass latency. */
+  getPeerConnection: () => RTCPeerConnection | null;
 };
 
 export const createRealTimeClient = (opts: RealTimeClientOptions) => {
@@ -143,7 +154,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       throw parsedOptions.error;
     }
 
-    const { onRemoteStream, initialState, resolution } = parsedOptions.data;
+    const { onRemoteStream, onPeerConnection, initialState, resolution, seiLatency } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
 
     let inputStream: MediaStream = stream ?? new MediaStream();
@@ -199,6 +210,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         logger,
         observability,
         onRemoteStream,
+        onPeerConnection,
         onConnectionStateChange: (state) => {
           emitOrBuffer("connectionChange", state);
         },
@@ -211,6 +223,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         vp8StartBitrate: 600,
         initialImage,
         initialPrompt,
+        seiLatency,
       });
 
       const manager = webrtcManager;
@@ -263,6 +276,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
           const base64 = await imageToBase64(image);
           return manager.setImage(base64, options);
         },
+        getPeerConnection: () => manager.getPeerConnection(),
       };
 
       flush();

--- a/packages/sdk/src/realtime/sei/sei-nal.ts
+++ b/packages/sdk/src/realtime/sei/sei-nal.ts
@@ -1,0 +1,179 @@
+/**
+ * H.264 SEI latency-marker codec (browser/worker side).
+ *
+ * Mirror of the server's `inference_server/rt/bench/sei.py`: carries an opaque
+ * per-frame payload inside a `user_data_unregistered` SEI message (payloadType
+ * 5) tagged with the Decart UUID. Pure byte manipulation — no DOM/WebRTC deps —
+ * so it runs in a worker and unit-tests in isolation.
+ */
+
+// 16-byte UUID identifying a Decart latency marker among other SEI messages.
+// Must byte-match DECART_SEI_UUID in the Python codec.
+export const DECART_SEI_UUID = new Uint8Array([
+  0xde, 0xca, 0x27, 0x5e, 0x1a, 0x2b, 0x4c, 0x3d, 0x8e, 0x9f, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+]);
+
+const SEI_NAL_TYPE = 6;
+const USER_DATA_UNREGISTERED = 5;
+const RBSP_TRAILING = 0x80;
+const START_CODE = [0, 0, 1];
+
+function encodeFf(value: number): number[] {
+  const out: number[] = [];
+  while (value >= 0xff) {
+    out.push(0xff);
+    value -= 0xff;
+  }
+  out.push(value);
+  return out;
+}
+
+function readFf(buf: Uint8Array, pos: number): [number | null, number] {
+  let val = 0;
+  const n = buf.length;
+  while (pos < n && buf[pos] === 0xff) {
+    val += 0xff;
+    pos++;
+  }
+  if (pos >= n) return [null, pos];
+  val += buf[pos];
+  return [val, pos + 1];
+}
+
+/** Insert emulation_prevention_three_byte so no 00 00 0x start-code forms. */
+function emulationEscape(rbsp: Uint8Array): Uint8Array {
+  const out: number[] = [];
+  let zeros = 0;
+  for (const b of rbsp) {
+    if (zeros >= 2 && b <= 0x03) {
+      out.push(0x03);
+      zeros = 0;
+    }
+    out.push(b);
+    zeros = b === 0 ? zeros + 1 : 0;
+  }
+  return new Uint8Array(out);
+}
+
+/** Strip emulation_prevention_three_byte to recover the raw RBSP. */
+function emulationUnescape(ebsp: Uint8Array): Uint8Array {
+  const out: number[] = [];
+  let zeros = 0;
+  const n = ebsp.length;
+  let i = 0;
+  while (i < n) {
+    const b = ebsp[i];
+    if (zeros >= 2 && b === 0x03 && i + 1 < n && ebsp[i + 1] <= 0x03) {
+      zeros = 0;
+      i++;
+      continue;
+    }
+    out.push(b);
+    zeros = b === 0 ? zeros + 1 : 0;
+    i++;
+  }
+  return new Uint8Array(out);
+}
+
+/** Build a raw SEI NAL unit (no Annex-B start code) carrying `payload`. */
+export function buildSeiNal(payload: Uint8Array): Uint8Array {
+  const data = new Uint8Array(DECART_SEI_UUID.length + payload.length);
+  data.set(DECART_SEI_UUID, 0);
+  data.set(payload, DECART_SEI_UUID.length);
+
+  const rbsp: number[] = [];
+  rbsp.push(...encodeFf(USER_DATA_UNREGISTERED));
+  rbsp.push(...encodeFf(data.length));
+  for (const b of data) rbsp.push(b);
+  rbsp.push(RBSP_TRAILING);
+
+  const escaped = emulationEscape(new Uint8Array(rbsp));
+  const nal = new Uint8Array(1 + escaped.length);
+  nal[0] = SEI_NAL_TYPE;
+  nal.set(escaped, 1);
+  return nal;
+}
+
+function findSeq(buf: Uint8Array, seq: number[], from: number): number {
+  outer: for (let i = from; i <= buf.length - seq.length; i++) {
+    for (let j = 0; j < seq.length; j++) if (buf[i + j] !== seq[j]) continue outer;
+    return i;
+  }
+  return -1;
+}
+
+/** Yield NAL units (without start codes) from an Annex-B bitstream. */
+export function iterNalUnits(annexb: Uint8Array): Uint8Array[] {
+  const nals: Uint8Array[] = [];
+  let i = findSeq(annexb, START_CODE, 0);
+  while (i !== -1) {
+    i += START_CODE.length;
+    const start = i;
+    const nxt = findSeq(annexb, START_CODE, i);
+    if (nxt === -1) {
+      nals.push(annexb.subarray(start));
+      break;
+    }
+    // A 4-byte start code (00 00 00 01) leaves a trailing 0x00 on the prior NAL.
+    const end = annexb[nxt - 1] === 0 ? nxt - 1 : nxt;
+    nals.push(annexb.subarray(start, end));
+    i = nxt;
+  }
+  return nals;
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function parseDecartSeiRbsp(rbsp: Uint8Array): Uint8Array | null {
+  let pos = 0;
+  const n = rbsp.length;
+  while (pos < n && rbsp[pos] !== RBSP_TRAILING) {
+    let ptype: number | null;
+    [ptype, pos] = readFf(rbsp, pos);
+    if (ptype === null) return null;
+    let psize: number | null;
+    [psize, pos] = readFf(rbsp, pos);
+    if (psize === null || pos + psize > n) return null;
+    const chunk = rbsp.subarray(pos, pos + psize);
+    pos += psize;
+    if (
+      ptype === USER_DATA_UNREGISTERED &&
+      chunk.length >= 16 &&
+      bytesEqual(chunk.subarray(0, 16), DECART_SEI_UUID)
+    ) {
+      return chunk.slice(16); // copy out of the view
+    }
+  }
+  return null;
+}
+
+/** Return the Decart latency payload from an Annex-B access unit, or null. */
+export function extractSeiPayload(annexb: Uint8Array): Uint8Array | null {
+  for (const nal of iterNalUnits(annexb)) {
+    if (nal.length && (nal[0] & 0x1f) === SEI_NAL_TYPE) {
+      const payload = parseDecartSeiRbsp(emulationUnescape(nal.subarray(1)));
+      if (payload !== null) return payload;
+    }
+  }
+  return null;
+}
+
+/**
+ * Return `nals` with a Decart SEI NAL inserted before the first VCL slice.
+ * NAL units are start-code-free; SEI precedes the first VCL NAL (types 1–5),
+ * or is prepended if the access unit has none.
+ */
+export function injectSeiIntoNals(nals: Uint8Array[], payload: Uint8Array): Uint8Array[] {
+  const seiNal = buildSeiNal(payload);
+  for (let idx = 0; idx < nals.length; idx++) {
+    const t = nals[idx][0] & 0x1f;
+    if (nals[idx].length && t >= 1 && t <= 5) {
+      return [...nals.slice(0, idx), seiNal, ...nals.slice(idx)];
+    }
+  }
+  return [seiNal, ...nals];
+}

--- a/packages/sdk/src/realtime/sei/sei-worker.ts
+++ b/packages/sdk/src/realtime/sei/sei-worker.ts
@@ -1,0 +1,82 @@
+/**
+ * WebRTC Encoded Transform worker for H.264 SEI glass-to-glass latency.
+ *
+ * Runs as an `RTCRtpScriptTransform` worker. Two operations, selected via the
+ * transform's options:
+ *   - "inject"  (sender side):  prepend a Decart SEI NAL carrying Date.now()
+ *                               onto each encoded frame's bitstream.
+ *   - "parse"   (receiver side): read the SEI off each encoded frame and post
+ *                               the measured latency (now - stamped) to the page.
+ *
+ * `RTCEncodedVideoFrame.data` is the raw encoded H.264 bitstream (Annex-B NAL
+ * units) — this is the browser API that gives JS access to where SEI lives.
+ * Date.now() is wall-clock, so it is comparable across the page's realms (and,
+ * in the real flow, across the same client that both sends and receives).
+ */
+
+import { buildSeiNal, extractSeiPayload } from "./sei-nal.js";
+
+const START_CODE_4 = [0, 0, 0, 1];
+
+function prependSei(data: Uint8Array, payload: Uint8Array): Uint8Array {
+  const sei = buildSeiNal(payload);
+  const out = new Uint8Array(START_CODE_4.length + sei.length + data.length);
+  out.set(START_CODE_4, 0);
+  out.set(sei, START_CODE_4.length);
+  out.set(data, START_CODE_4.length + sei.length);
+  return out;
+}
+
+type EncodedFrame = { data: ArrayBuffer };
+
+interface RtcTransformEvent extends Event {
+  transformer: {
+    readable: ReadableStream<EncodedFrame>;
+    writable: WritableStream<EncodedFrame>;
+    options?: { operation?: "inject" | "parse" };
+  };
+}
+
+const scope = self as unknown as {
+  onrtctransform: ((event: RtcTransformEvent) => void) | null;
+  postMessage: (message: unknown) => void;
+};
+
+let injected = 0;
+let parseSeen = 0;
+let parseMatched = 0;
+
+scope.onrtctransform = (event: RtcTransformEvent) => {
+  const { readable, writable, options } = event.transformer;
+  const operation = options?.operation;
+  scope.postMessage({ type: "sei-attached", operation });
+
+  const pipe = new TransformStream<EncodedFrame, EncodedFrame>({
+    transform(frame, controller) {
+      try {
+        if (operation === "inject") {
+          const stamp = new TextEncoder().encode(String(Date.now()));
+          frame.data = prependSei(new Uint8Array(frame.data), stamp).buffer;
+          injected++;
+          if (injected % 30 === 0) scope.postMessage({ type: "sei-stats", injected });
+        } else if (operation === "parse") {
+          parseSeen++;
+          const payload = extractSeiPayload(new Uint8Array(frame.data));
+          if (payload) {
+            parseMatched++;
+            const sentMs = Number(new TextDecoder().decode(payload));
+            if (Number.isFinite(sentMs)) {
+              scope.postMessage({ type: "sei-latency", latencyMs: Date.now() - sentMs });
+            }
+          }
+          if (parseSeen % 30 === 0) scope.postMessage({ type: "sei-stats", parseSeen, parseMatched });
+        }
+      } catch (err) {
+        scope.postMessage({ type: "sei-error", message: String(err) });
+      }
+      controller.enqueue(frame);
+    },
+  });
+
+  readable.pipeThrough(pipe).pipeTo(writable).catch(() => {});
+};

--- a/packages/sdk/src/realtime/webrtc-connection.ts
+++ b/packages/sdk/src/realtime/webrtc-connection.ts
@@ -19,6 +19,9 @@ const SETUP_TIMEOUT_MS = 30_000; // 30 seconds
 
 interface ConnectionCallbacks {
   onRemoteStream?: (stream: MediaStream) => void;
+  // Fired right after the RTCPeerConnection + local tracks are set up, before
+  // the offer/media — early enough to attach encoded-frame transforms.
+  onPeerConnection?: (pc: RTCPeerConnection) => void;
   onStateChange?: (state: ConnectionState) => void;
   onError?: (error: Error) => void;
   customizeOffer?: (offer: RTCSessionDescriptionInit) => Promise<void>;
@@ -26,6 +29,7 @@ interface ConnectionCallbacks {
   vp8StartBitrate?: number;
   initialImage?: string;
   initialPrompt?: { text: string; enhance?: boolean };
+  seiLatency?: boolean;
   logger?: Logger;
   observability: RealtimeObservability;
 }
@@ -62,7 +66,8 @@ export class WebRTCConnection {
     // Add user agent as query parameter (browsers don't support WS headers)
     const userAgent = encodeURIComponent(buildUserAgent(integration));
     const separator = url.includes("?") ? "&" : "?";
-    const wsUrl = `${url}${separator}user_agent=${userAgent}`;
+    let wsUrl = `${url}${separator}user_agent=${userAgent}`;
+    if (this.callbacks.seiLatency) wsUrl += "&sei_latency=1";
 
     // Shared abort mechanism: any phase failure aborts the entire connect flow.
     // connectionReject is set once and stays active across all phases so that
@@ -257,9 +262,10 @@ export class WebRTCConnection {
 
       switch (msg.type) {
         case "ready": {
-          await this.applyCodecPreference("video/VP8");
+          // SEI g2g requires H.264 (SEI is an H.264/H.265 NAL); otherwise VP8.
+          await this.applyCodecPreference(this.callbacks.seiLatency ? "video/H264" : "video/VP8");
           const offer = await this.pc.createOffer();
-          this.modifyVP8Bitrate(offer);
+          if (!this.callbacks.seiLatency) this.modifyVP8Bitrate(offer);
           await this.callbacks.customizeOffer?.(offer);
           await this.pc.setLocalDescription(offer);
           this.send({ type: "offer", sdp: offer.sdp || "" });
@@ -434,6 +440,10 @@ export class WebRTCConnection {
         this.callbacks.onRemoteStream?.(fallbackStream);
       }
     };
+
+    // Hand the PC to the caller before the offer (media not flowing yet) so it
+    // can install RTCRtpScriptTransform on the sender in time to catch frames.
+    this.callbacks.onPeerConnection?.(this.pc);
 
     this.pc.onicecandidate = (e) => {
       this.send({ type: "ice-candidate", candidate: e.candidate });

--- a/packages/sdk/src/realtime/webrtc-manager.ts
+++ b/packages/sdk/src/realtime/webrtc-manager.ts
@@ -11,6 +11,7 @@ export interface WebRTCConfig {
   logger?: Logger;
   observability: RealtimeObservability;
   onRemoteStream: (stream: MediaStream) => void;
+  onPeerConnection?: (pc: RTCPeerConnection) => void;
   onConnectionStateChange?: (state: ConnectionState) => void;
   onError?: (error: Error) => void;
   customizeOffer?: (offer: RTCSessionDescriptionInit) => Promise<void>;
@@ -18,6 +19,7 @@ export interface WebRTCConfig {
   vp8StartBitrate?: number;
   initialImage?: string;
   initialPrompt?: { text: string; enhance?: boolean };
+  seiLatency?: boolean;
 }
 
 const PERMANENT_ERRORS = [
@@ -58,6 +60,7 @@ export class WebRTCManager {
     this.observability = config.observability;
     this.connection = new WebRTCConnection({
       onRemoteStream: config.onRemoteStream,
+      onPeerConnection: config.onPeerConnection,
       onStateChange: (state) => this.handleConnectionStateChange(state),
       onError: config.onError,
       customizeOffer: config.customizeOffer,
@@ -65,6 +68,7 @@ export class WebRTCManager {
       vp8StartBitrate: config.vp8StartBitrate,
       initialImage: config.initialImage,
       initialPrompt: config.initialPrompt,
+      seiLatency: config.seiLatency,
       logger: this.logger,
       observability: this.observability,
     });

--- a/packages/sdk/tests/sei-nal.unit.test.ts
+++ b/packages/sdk/tests/sei-nal.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildSeiNal, extractSeiPayload, injectSeiIntoNals } from "../src/realtime/sei/sei-nal.js";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const arr = (u: Uint8Array | null) => (u === null ? null : Array.from(u));
+
+function annexb(nals: Uint8Array[]): Uint8Array {
+  const out: number[] = [];
+  for (const n of nals) out.push(0, 0, 0, 1, ...n);
+  return new Uint8Array(out);
+}
+
+function contains(buf: Uint8Array, seq: number[]): boolean {
+  outer: for (let i = 0; i <= buf.length - seq.length; i++) {
+    for (let j = 0; j < seq.length; j++) if (buf[i + j] !== seq[j]) continue outer;
+    return true;
+  }
+  return false;
+}
+
+describe("sei-nal codec", () => {
+  it("round-trips build -> extract", () => {
+    const payload = enc("hello-g2g-12345");
+    const stream = new Uint8Array([0, 0, 0, 1, ...buildSeiNal(payload)]);
+    expect(arr(extractSeiPayload(stream))).toEqual(arr(payload));
+  });
+
+  it("returns null when no Decart SEI is present", () => {
+    const stream = new Uint8Array([0, 0, 0, 1, 0x41, 0, 1, 2]); // fake non-IDR slice
+    expect(extractSeiPayload(stream)).toBeNull();
+  });
+
+  it("built NAL has no start-code emulation (00 00 00/01/02)", () => {
+    const payload = new Uint8Array([0, 0, 0, 1, 0, 0, 1, 0, 0, 2, 0, 0, 3]);
+    const nal = buildSeiNal(payload);
+    expect(contains(nal, [0, 0, 0])).toBe(false);
+    expect(contains(nal, [0, 0, 1])).toBe(false);
+    expect(contains(nal, [0, 0, 2])).toBe(false);
+  });
+
+  it("round-trips a payload containing emulation sequences", () => {
+    const payload = new Uint8Array([0, 0, 0, 1, 0, 0, 1, 0, 0, 2, 0, 0, 3, 255, 0, 0]);
+    const stream = new Uint8Array([0, 0, 0, 1, ...buildSeiNal(payload)]);
+    expect(arr(extractSeiPayload(stream))).toEqual(arr(payload));
+  });
+
+  it("round-trips a large payload (multi-byte ff size)", () => {
+    const payload = new Uint8Array(600).fill(0x78);
+    const stream = new Uint8Array([0, 0, 0, 1, ...buildSeiNal(payload)]);
+    expect(arr(extractSeiPayload(stream))).toEqual(arr(payload));
+  });
+
+  it("injects SEI before the first VCL slice", () => {
+    const nals = [new Uint8Array([0x67, 1, 2]), new Uint8Array([0x68, 3, 4]), new Uint8Array([0x65, 9, 9, 9])];
+    const types = injectSeiIntoNals(nals, enc("ts=42")).map((n) => n[0] & 0x1f);
+    expect(types).toContain(6);
+    expect(types.indexOf(6)).toBeLessThan(types.indexOf(5));
+  });
+
+  it("injected payload is extractable", () => {
+    const out = injectSeiIntoNals([new Uint8Array([0x65, 9, 9, 9])], enc("ts=42"));
+    expect(arr(extractSeiPayload(annexb(out)))).toEqual(arr(enc("ts=42")));
+  });
+});


### PR DESCRIPTION
## What

Browser **read/write of H.264 SEI** via the WebRTC Encoded Transform API (`RTCRtpScriptTransform`) to measure true glass-to-glass latency over the **aiortc** transport. Pairs with the server-side SEI bridge in DecartAI/api (separate PR).

> **Base note:** this targets `aiortc-v0.0.68` (the aiortc release line consumed as `@decartai/sdk-old`), **not `main`** — `main` has since migrated to LiveKit, so a diff against it would be the entire aiortc↔livekit divergence. This base keeps the diff to the SEI work only.

## How
- `realtime/sei/sei-nal.ts` — pure SEI NAL codec (build/parse/inject, emulation-prevention, ff-size). Byte-compatible with the Python codec in the api PR.
- `realtime/sei/sei-worker.ts` — Encoded Transform worker: injects an SEI marker on the sender, parses it on the receiver.
- `seiLatency` connect option — forces H.264 and appends `?sei_latency=1` to signaling.
- `onPeerConnection(pc)` hook + `getPeerConnection()` — lets callers attach encoded-frame transforms **before the offer**. This is required: the client is the offerer, so its `ontrack` fires only at `setRemoteDescription(answer)`, which is too late to bind a *receiver* transform (Chrome silently bypasses a late-attached transform).

## Demos
- `sei-loopback.html` — standalone, no server/key: canvas or camera → H.264 → SEI → g2g latency, all in-browser.
- `sei-server-demo.html` — camera + prompts + connects to a server, reports through-server SEI g2g.

## Test plan
- ✅ 7 unit tests (`tests/sei-nal.unit.test.ts`) — codec roundtrip incl. emulation-prevention + multi-byte size.
- ✅ Loopback proof verified in-browser (sustained, codec `video/H264`).
- ✅ End-to-end verified against local `bit-invert-realtime` + the api SEI bridge: **SEI g2g latency reported, 144 frames matched, codec `video/H264`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebRTC connect/signaling (codec preference, WS query params) and mutates encoded H.264 bitstreams in a worker; default VP8 behavior is unchanged unless `seiLatency` is enabled.
> 
> **Overview**
> Adds **browser-side H.264 SEI read/write** for measuring glass-to-glass latency using `RTCRtpScriptTransform` on encoded frames, aligned with the server Python SEI codec.
> 
> New **`sei-nal`** codec and **`sei-worker`** inject a `Date.now()` stamp on send and parse it on receive. **`seiLatency: true`** on `realtime.connect` forces **H.264**, appends **`sei_latency=1`** to the WebSocket URL, and skips VP8 bitrate SDP tweaks. **`onPeerConnection`** fires after the PC is created but **before the offer**, and **`getPeerConnection()`** exposes the live PC so transforms can attach early (receiver transforms bound only at `ontrack` are too late when the client is the offerer).
> 
> Includes **loopback** and **through-server** HTML demos plus **unit tests** for the NAL codec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d288e8de5762f44776c2dc663c8b405a77cbf84c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->