### PR TITLE
[codex] Add realtime setup timing diagnostics

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -218,6 +218,72 @@
             border-left-color: #4CAF50;
             background: #e8f5e8;
         }
+
+        .setup-timing-table-wrap {
+            overflow-x: auto;
+        }
+
+        .setup-timing-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 12px;
+        }
+
+        .setup-timing-table th,
+        .setup-timing-table td {
+            border-bottom: 1px solid #e0e0e0;
+            padding: 6px 8px;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .setup-timing-table th {
+            background: #f8f9fa;
+            color: #333;
+            font-size: 11px;
+            text-transform: uppercase;
+        }
+
+        .setup-timing-row {
+            cursor: pointer;
+        }
+
+        .setup-timing-row:hover {
+            background: #f8f9fa;
+        }
+
+        .setup-timing-row.is-expanded {
+            background: #eef6ff;
+        }
+
+        .setup-timing-detail-cell {
+            background: #fbfcfd;
+            padding: 10px 12px;
+        }
+
+        .setup-flame-chart {
+            min-width: 720px;
+        }
+
+        .setup-flame-chart svg {
+            display: block;
+            width: 100%;
+            height: auto;
+            font-family: Arial, sans-serif;
+        }
+
+        .setup-flame-note {
+            margin: 0 0 8px 0;
+            color: #666;
+            font-size: 12px;
+        }
+
+        .setup-copy-btn {
+            padding: 5px 9px;
+            margin: 0;
+            font-size: 12px;
+            white-space: nowrap;
+        }
         
         .inline-controls {
             display: flex;
@@ -308,6 +374,35 @@
                 <input type="text" id="publisher-subscribe-token" readonly placeholder="Connect as publisher to generate a token">
                 <button id="copy-subscribe-token" class="secondary" disabled>Copy Subscribe Token</button>
             </div>
+        </div>
+    </div>
+
+    <!-- Setup Timing History -->
+    <div class="controls">
+        <h3>Setup Timing History</h3>
+        <div class="inline-controls" style="margin-bottom: 8px;">
+            <button id="clear-setup-timings-btn" class="secondary">Clear History</button>
+        </div>
+        <div class="setup-timing-table-wrap">
+            <table class="setup-timing-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Session ID</th>
+                        <th>API Host</th>
+                        <th>Setup</th>
+                        <th>SDK Connect</th>
+                        <th>Remote Stream</th>
+                        <th>First Frame Gap</th>
+                        <th>JSON</th>
+                    </tr>
+                </thead>
+                <tbody id="setup-timing-history-body">
+                    <tr>
+                        <td colspan="8">No setup timings recorded yet.</td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
     </div>
     
@@ -591,6 +686,7 @@
     
     <script type="module">
         // Import the Decart SDK (with cache busting timestamp)
+        import * as d3 from 'https://cdn.jsdelivr.net/npm/d3@7/+esm';
         import { createConsoleLogger, createDecartClient, models } from './dist/index.js';
 
         
@@ -652,6 +748,8 @@
             connectivityHeadline: document.getElementById('connectivity-headline'),
             connectivityMetrics: document.getElementById('connectivity-metrics'),
             connectivityReasons: document.getElementById('connectivity-reasons'),
+            setupTimingHistoryBody: document.getElementById('setup-timing-history-body'),
+            clearSetupTimingsBtn: document.getElementById('clear-setup-timings-btn'),
             // Image reference elements
             referenceImage: document.getElementById('reference-image'),
             setImage: document.getElementById('send-image'),
@@ -763,6 +861,575 @@
                 },
             };
         }
+
+        // ---------- Setup timing history ----------
+        const SETUP_TIMING_STORAGE_KEY = 'decart.debug.setupTimingHistory.v1';
+        const SETUP_TIMING_HISTORY_LIMIT = 50;
+        let activeSetupTiming = null;
+
+        function formatMs(ms) {
+            return ms == null ? '-' : `${Math.round(ms)}ms`;
+        }
+
+        function readSetupTimingHistory() {
+            try {
+                const raw = localStorage.getItem(SETUP_TIMING_STORAGE_KEY);
+                if (!raw) return [];
+                const parsed = JSON.parse(raw);
+                return Array.isArray(parsed) ? parsed : [];
+            } catch (error) {
+                addLog(`Failed to read setup timing history: ${error.message ?? error}`, 'error');
+                return [];
+            }
+        }
+
+        function writeSetupTimingHistory(history) {
+            try {
+                localStorage.setItem(
+                    SETUP_TIMING_STORAGE_KEY,
+                    JSON.stringify(history.slice(0, SETUP_TIMING_HISTORY_LIMIT)),
+                );
+            } catch (error) {
+                addLog(`Failed to write setup timing history: ${error.message ?? error}`, 'error');
+            }
+        }
+
+        let expandedSetupTimingId = null;
+
+        function renderSetupTimingHistory() {
+            const history = readSetupTimingHistory();
+            elements.setupTimingHistoryBody.innerHTML = '';
+
+            if (history.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 8;
+                cell.textContent = 'No setup timings recorded yet.';
+                row.appendChild(cell);
+                elements.setupTimingHistoryBody.appendChild(row);
+                return;
+            }
+
+            for (const record of history) {
+                const row = document.createElement('tr');
+                row.className = `setup-timing-row${expandedSetupTimingId === record.id ? ' is-expanded' : ''}`;
+                const cells = [
+                    new Date(record.date).toLocaleString(),
+                    record.sessionId || '-',
+                    record.realtimeHost || '-',
+                    formatMs(record.setupTimeMs),
+                    formatMs(record.sdkConnectTotalMs),
+                    formatMs(record.remoteStreamMs),
+                    formatMs(record.setupTimeMs != null && record.remoteStreamMs != null
+                        ? record.setupTimeMs - record.remoteStreamMs
+                        : null),
+                ];
+
+                for (const text of cells) {
+                    const cell = document.createElement('td');
+                    cell.textContent = text;
+                    row.appendChild(cell);
+                }
+
+                const copyCell = document.createElement('td');
+                const copyButton = document.createElement('button');
+                copyButton.type = 'button';
+                copyButton.className = 'secondary setup-copy-btn';
+                copyButton.textContent = 'Copy JSON';
+                copyButton.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    copySetupTimingJson(record);
+                });
+                copyCell.appendChild(copyButton);
+                row.appendChild(copyCell);
+
+                row.addEventListener('click', () => {
+                    expandedSetupTimingId = expandedSetupTimingId === record.id ? null : record.id;
+                    renderSetupTimingHistory();
+                });
+
+                elements.setupTimingHistoryBody.appendChild(row);
+
+                if (expandedSetupTimingId === record.id) {
+                    const detailRow = document.createElement('tr');
+                    const detailCell = document.createElement('td');
+                    detailCell.colSpan = 8;
+                    detailCell.className = 'setup-timing-detail-cell';
+                    const chart = document.createElement('div');
+                    chart.className = 'setup-flame-chart';
+                    detailCell.appendChild(chart);
+                    detailRow.appendChild(detailCell);
+                    elements.setupTimingHistoryBody.appendChild(detailRow);
+                    renderSetupTimingFlameChart(record, chart);
+                }
+            }
+        }
+
+        async function copySetupTimingJson(record) {
+            const payload = buildSetupTimingCopyPayload(record);
+            const json = JSON.stringify(payload, null, 2);
+            try {
+                await navigator.clipboard.writeText(json);
+                addLog(`Copied setup timing JSON for ${record.sessionId || record.id}`, 'success');
+            } catch {
+                const textarea = document.createElement('textarea');
+                textarea.value = json;
+                textarea.style.position = 'fixed';
+                textarea.style.left = '-9999px';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                textarea.remove();
+                addLog(`Copied setup timing JSON for ${record.sessionId || record.id} using fallback`, 'success');
+            }
+        }
+
+        function getLegacyPhaseFunctionName(phase) {
+            return {
+                'websocket-open': 'SignalingChannel.openSocket',
+                'room-join': 'SignalingChannel.waitForRoomInfo',
+                'initial-state-handshake': 'SignalingChannel.flushInitialState',
+                'webrtc-handshake': 'MediaChannel.connect',
+                'publish-local-track': 'MediaChannel.publishLocalTracks',
+            }[phase] || phase;
+        }
+
+        const BROAD_SETUP_TIMING_SPANS = new Set([
+            'connect button handler',
+            'decartClient.realtime.connect',
+            'SignalingChannel.openAndJoin',
+            'MediaChannel.connect',
+            'MediaChannel.publishLocalTracks',
+            'MediaChannel.publishTracks',
+        ]);
+
+        function getSpanDuration(span) {
+            return span.durationMs ?? span.endedAtMs - span.startedAtMs;
+        }
+
+        function getSpanSpecificity(span) {
+            let score = 0;
+            if (span.detail) score += 4;
+            if (!BROAD_SETUP_TIMING_SPANS.has(span.functionName)) score += 2;
+            if (span.functionName.startsWith('SignalingChannel') || span.functionName.startsWith('MediaChannel')) {
+                score += 1;
+            }
+            return score;
+        }
+
+        function cleanSetupTimingSpans(spans) {
+            const byWindow = new Map();
+            for (const span of spans) {
+                const durationMs = Math.round(getSpanDuration(span));
+                if (!Number.isFinite(durationMs) || durationMs < 1) continue;
+                const normalized = {
+                    ...span,
+                    startedAtMs: Math.round(span.startedAtMs),
+                    endedAtMs: Math.round(span.endedAtMs),
+                    durationMs,
+                };
+                const key = `${normalized.startedAtMs}:${normalized.endedAtMs}:${normalized.durationMs}`;
+                const previous = byWindow.get(key);
+                if (!previous || getSpanSpecificity(normalized) >= getSpanSpecificity(previous)) {
+                    byWindow.set(key, normalized);
+                }
+            }
+            return [...byWindow.values()].sort(
+                (a, b) => a.startedAtMs - b.startedAtMs || b.endedAtMs - a.endedAtMs,
+            );
+        }
+
+        function getSetupTimingSpans(record) {
+            if (Array.isArray(record.spans) && record.spans.length > 0) {
+                return {
+                    legacy: false,
+                    spans: cleanSetupTimingSpans(
+                        record.spans.filter((span) => span.startedAtMs != null && span.endedAtMs != null),
+                    ),
+                };
+            }
+
+            let cursor = 0;
+            const spans = [];
+            let legacy = false;
+
+            for (const phase of record.phases || []) {
+                if (phase.startedAtMs == null || phase.endedAtMs == null) {
+                    legacy = true;
+                    spans.push({
+                        functionName: getLegacyPhaseFunctionName(phase.phase),
+                        startedAtMs: cursor,
+                        endedAtMs: cursor + phase.durationMs,
+                        durationMs: phase.durationMs,
+                        success: phase.success,
+                        source: 'legacy',
+                    });
+                    cursor += phase.durationMs;
+                    continue;
+                }
+
+                spans.push({
+                    functionName: phase.functionName || getLegacyPhaseFunctionName(phase.phase),
+                    startedAtMs: phase.startedAtMs,
+                    endedAtMs: phase.endedAtMs,
+                    durationMs: phase.durationMs,
+                    success: phase.success,
+                    ...(phase.error ? { error: phase.error } : {}),
+                });
+            }
+
+            return { legacy, spans: cleanSetupTimingSpans(spans) };
+        }
+
+        function buildSetupTimingCopyPayload(record) {
+            const { legacy, spans } = getSetupTimingSpans(record);
+            return {
+                id: record.id,
+                date: record.date,
+                sessionId: record.sessionId,
+                setupTimeMs: record.setupTimeMs,
+                setupTimeSeconds: record.setupTimeSeconds,
+                model: record.model,
+                resolution: record.resolution,
+                preferredVideoCodec: record.preferredVideoCodec,
+                realtimeBaseUrl: record.realtimeBaseUrl,
+                realtimeHost: record.realtimeHost,
+                remoteStreamMs: record.remoteStreamMs,
+                firstFrameAt: record.firstFrameAt,
+                firstFrameSource: record.firstFrameSource,
+                sdkConnectTotalMs: record.sdkConnectTotalMs,
+                legacy,
+                phases: record.phases || [],
+                spans,
+            };
+        }
+
+        function colorForSetupTimingSpan(span) {
+            if (span.success === false) return '#d9534f';
+            if (span.functionName.startsWith('SignalingChannel')) return '#4f81bd';
+            if (span.functionName.startsWith('MediaChannel')) return '#70ad47';
+            if (span.functionName.startsWith('HTMLVideoElement')) return '#8064a2';
+            if (span.functionName === 'onRemoteStream') return '#c55a11';
+            return '#888';
+        }
+
+        function renderSetupTimingFlameChart(record, container) {
+            const { legacy, spans } = getSetupTimingSpans(record);
+            container.innerHTML = '';
+
+            if (legacy) {
+                const note = document.createElement('p');
+                note.className = 'setup-flame-note';
+                note.textContent = 'Legacy record: exact overlap unavailable';
+                container.appendChild(note);
+            }
+
+            if (spans.length === 0) {
+                const note = document.createElement('p');
+                note.className = 'setup-flame-note';
+                note.textContent = 'No chartable timing spans recorded.';
+                container.appendChild(note);
+                return;
+            }
+
+            const rows = spans.map((span, index) => ({ ...span, rowIndex: index }));
+            const margin = { top: 24, right: 16, bottom: 30, left: 270 };
+            const width = 1040;
+            const rowHeight = 28;
+            const height = margin.top + margin.bottom + rows.length * rowHeight;
+            const maxMs = Math.max(
+                record.setupTimeMs || 0,
+                ...spans.map((span) => span.endedAtMs),
+            );
+            const x = d3.scaleLinear([0, Math.max(maxMs, 1)], [margin.left, width - margin.right]);
+
+            const svg = d3
+                .select(container)
+                .append('svg')
+                .attr('viewBox', `0 0 ${width} ${height}`)
+                .attr('role', 'img');
+
+            svg
+                .append('g')
+                .attr('transform', `translate(0,${height - margin.bottom})`)
+                .call(d3.axisBottom(x).ticks(8).tickFormat((value) => `${value}ms`));
+
+            svg
+                .append('text')
+                .attr('x', margin.left)
+                .attr('y', 14)
+                .attr('fill', '#333')
+                .attr('font-size', 12)
+                .text('milliseconds since Connect button press');
+
+            for (const row of rows) {
+                const rowY = margin.top + row.rowIndex * rowHeight;
+                const label = row.detail ? `${row.functionName} (${row.detail})` : row.functionName;
+                svg
+                    .append('text')
+                    .attr('x', margin.left - 10)
+                    .attr('y', rowY + 18)
+                    .attr('text-anchor', 'end')
+                    .attr('fill', '#333')
+                    .attr('font-size', 12)
+                    .text(label.length > 43 ? `${label.slice(0, 40)}...` : label)
+                    .append('title')
+                    .text(label);
+
+                svg
+                    .append('line')
+                    .attr('x1', margin.left)
+                    .attr('x2', width - margin.right)
+                    .attr('y1', rowY + rowHeight - 4)
+                    .attr('y2', rowY + rowHeight - 4)
+                    .attr('stroke', '#eee');
+            }
+
+            const bar = svg
+                .append('g')
+                .selectAll('g')
+                .data(rows)
+                .join('g');
+
+            bar
+                .append('rect')
+                .attr('x', (span) => x(span.startedAtMs))
+                .attr('y', (span) => margin.top + span.rowIndex * rowHeight + 4)
+                .attr('width', (span) => Math.max(2, x(span.endedAtMs) - x(span.startedAtMs)))
+                .attr('height', rowHeight - 10)
+                .attr('rx', 3)
+                .attr('fill', colorForSetupTimingSpan)
+                .attr('opacity', 0.88);
+
+            bar
+                .append('title')
+                .text((span) => [
+                    span.functionName,
+                    `start: ${formatMs(span.startedAtMs)}`,
+                    `end: ${formatMs(span.endedAtMs)}`,
+                    `duration: ${formatMs(span.durationMs ?? span.endedAtMs - span.startedAtMs)}`,
+                    `success: ${span.success !== false}`,
+                    span.error ? `error: ${span.error}` : null,
+                ].filter(Boolean).join('\n'));
+
+            bar
+                .append('text')
+                .attr('x', (span) => x(span.startedAtMs) + 5)
+                .attr('y', (span) => margin.top + span.rowIndex * rowHeight + 18)
+                .attr('fill', '#fff')
+                .attr('font-size', 11)
+                .attr('pointer-events', 'none')
+                .text((span) => {
+                    const widthPx = x(span.endedAtMs) - x(span.startedAtMs);
+                    return widthPx > 70 ? formatMs(span.durationMs ?? span.endedAtMs - span.startedAtMs) : '';
+                });
+        }
+
+        function createSetupTimingId() {
+            if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+            return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        }
+
+        function resolveRealtimeBaseUrl() {
+            return elements.realtimeBaseUrl.value.trim() || 'wss://api3.decart.ai';
+        }
+
+        function resolveRealtimeHost(baseUrl) {
+            try {
+                return new URL(baseUrl).host;
+            } catch {
+                return baseUrl || '-';
+            }
+        }
+
+        function setupTimingOffsetNow() {
+            if (!activeSetupTiming) return null;
+            return performance.now() - activeSetupTiming.connectPressedAtMs;
+        }
+
+        function startSetupTimingSpan(functionName) {
+            const startedAtMs = setupTimingOffsetNow();
+            if (startedAtMs == null) return null;
+            return { functionName, startedAtMs };
+        }
+
+        function finishSetupTimingSpan(span, opts = {}) {
+            if (!activeSetupTiming || !span || span.finished) return;
+            const endedAtMs = setupTimingOffsetNow();
+            if (endedAtMs == null) return;
+            span.finished = true;
+            activeSetupTiming.spans.push({
+                functionName: span.functionName,
+                startedAtMs: Math.round(span.startedAtMs),
+                endedAtMs: Math.round(endedAtMs),
+                durationMs: Math.max(0, Math.round(endedAtMs - span.startedAtMs)),
+                success: opts.success !== false,
+                ...(opts.error ? { error: opts.error } : {}),
+            });
+        }
+
+        function beginSetupTiming() {
+            const realtimeBaseUrl = resolveRealtimeBaseUrl();
+            activeSetupTiming = {
+                id: createSetupTimingId(),
+                date: new Date().toISOString(),
+                connectPressedAtMs: performance.now(),
+                sdkConnectStartedAtMs: null,
+                model: model.name,
+                resolution: elements.resolutionSelect.value,
+                preferredVideoCodec: elements.codecSelect.value || 'default',
+                realtimeBaseUrl,
+                realtimeHost: resolveRealtimeHost(realtimeBaseUrl),
+                sessionId: null,
+                remoteStreamMs: null,
+                setupTimeMs: null,
+                firstFrameAt: null,
+                firstFrameSource: null,
+                sdkConnectTotalMs: null,
+                phases: [],
+                spans: [],
+            };
+            addLog('Setup timer started at Connect button press', 'info');
+        }
+
+        function buildSetupTimingRecord() {
+            if (activeSetupTiming?.setupTimeMs == null) return null;
+            return {
+                id: activeSetupTiming.id,
+                date: activeSetupTiming.date,
+                sessionId: activeSetupTiming.sessionId || currentSessionId || null,
+                setupTimeMs: activeSetupTiming.setupTimeMs,
+                setupTimeSeconds: Number((activeSetupTiming.setupTimeMs / 1000).toFixed(3)),
+                model: activeSetupTiming.model,
+                resolution: activeSetupTiming.resolution,
+                preferredVideoCodec: activeSetupTiming.preferredVideoCodec,
+                realtimeBaseUrl: activeSetupTiming.realtimeBaseUrl,
+                realtimeHost: activeSetupTiming.realtimeHost,
+                remoteStreamMs: activeSetupTiming.remoteStreamMs,
+                firstFrameAt: activeSetupTiming.firstFrameAt,
+                firstFrameSource: activeSetupTiming.firstFrameSource,
+                sdkConnectTotalMs: activeSetupTiming.sdkConnectTotalMs,
+                phases: activeSetupTiming.phases,
+                spans: activeSetupTiming.spans,
+            };
+        }
+
+        function upsertActiveSetupTimingRecord() {
+            const record = buildSetupTimingRecord();
+            if (!record) return;
+
+            const history = readSetupTimingHistory();
+            const existingIndex = history.findIndex((item) => item.id === record.id);
+            if (existingIndex >= 0) {
+                history[existingIndex] = record;
+            } else {
+                history.unshift(record);
+            }
+
+            writeSetupTimingHistory(history);
+            renderSetupTimingHistory();
+        }
+
+        function noteSetupTimingSessionId(sessionId) {
+            if (!activeSetupTiming || !sessionId) return;
+            activeSetupTiming.sessionId = sessionId;
+            upsertActiveSetupTimingRecord();
+        }
+
+        function noteRemoteStreamReceived() {
+            if (!activeSetupTiming || activeSetupTiming.remoteStreamMs != null) return;
+            activeSetupTiming.remoteStreamMs = Math.round(performance.now() - activeSetupTiming.connectPressedAtMs);
+        }
+
+        function noteConnectionBreakdown(event) {
+            if (!activeSetupTiming || event.name !== 'client-session-connection-breakdown') return;
+            activeSetupTiming.sdkConnectTotalMs = event.data.totalDurationMs;
+            activeSetupTiming.phases = event.data.phases.map((phase) => ({
+                phase: phase.phase,
+                functionName: phase.functionName,
+                startedAtMs: phase.startedAtMs,
+                endedAtMs: phase.endedAtMs,
+                durationMs: phase.durationMs,
+                success: phase.success,
+                ...(phase.error ? { error: phase.error } : {}),
+            }));
+            const sdkOffset = activeSetupTiming.sdkConnectStartedAtMs ?? 0;
+            activeSetupTiming.spans = activeSetupTiming.spans.filter((span) => span.source !== 'sdk-diagnostic');
+            const diagnosticSpans = Array.isArray(event.data.spans) && event.data.spans.length > 0
+                ? event.data.spans
+                : event.data.phases.map((phase) => ({
+                    functionName: phase.functionName || getLegacyPhaseFunctionName(phase.phase),
+                    startedAtMs: phase.startedAtMs,
+                    endedAtMs: phase.endedAtMs,
+                    durationMs: phase.durationMs,
+                    success: phase.success,
+                    ...(phase.error ? { error: phase.error } : {}),
+                }));
+
+            for (const span of diagnosticSpans) {
+                if (span.startedAtMs == null || span.endedAtMs == null) continue;
+                activeSetupTiming.spans.push({
+                    functionName: span.functionName,
+                    startedAtMs: Math.round(sdkOffset + span.startedAtMs),
+                    endedAtMs: Math.round(sdkOffset + span.endedAtMs),
+                    durationMs: span.durationMs,
+                    success: span.success,
+                    source: 'sdk-diagnostic',
+                    ...(span.detail ? { detail: span.detail } : {}),
+                    ...(span.error ? { error: span.error } : {}),
+                });
+            }
+            upsertActiveSetupTimingRecord();
+        }
+
+        function recordFirstRemoteFrame(source) {
+            if (!activeSetupTiming || activeSetupTiming.setupTimeMs != null) return;
+
+            activeSetupTiming.setupTimeMs = Math.round(performance.now() - activeSetupTiming.connectPressedAtMs);
+            activeSetupTiming.firstFrameAt = new Date().toISOString();
+            activeSetupTiming.firstFrameSource = source;
+            activeSetupTiming.sessionId = currentSessionId || decartRealtime?.sessionId || null;
+            finishSetupTimingSpan(activeSetupTiming.firstFrameWatchSpan);
+            upsertActiveSetupTimingRecord();
+
+            addLog(
+                `First remote frame arrived after ${formatMs(activeSetupTiming.setupTimeMs)} (session ${activeSetupTiming.sessionId || 'pending'})`,
+                'success',
+            );
+        }
+
+        function armFirstRemoteFrameWatcher() {
+            if (!activeSetupTiming) return;
+            const timingId = activeSetupTiming.id;
+            const video = elements.remoteVideo;
+            let done = false;
+            const record = (source) => {
+                if (done || activeSetupTiming?.id !== timingId) return;
+                done = true;
+                recordFirstRemoteFrame(source);
+            };
+
+            if ('requestVideoFrameCallback' in video) {
+                activeSetupTiming.firstFrameWatchSpan = startSetupTimingSpan('HTMLVideoElement.requestVideoFrameCallback');
+                video.requestVideoFrameCallback(() => record('requestVideoFrameCallback'));
+            } else {
+                activeSetupTiming.firstFrameWatchSpan = startSetupTimingSpan('HTMLVideoElement.loadeddata/playing');
+                video.addEventListener('loadeddata', () => record('loadeddata'), { once: true });
+                video.addEventListener('playing', () => record('playing'), { once: true });
+            }
+
+            video.play().catch((error) => {
+                addLog(`Remote video play() failed while timing first frame: ${error.message ?? error}`, 'error');
+            });
+        }
+
+        elements.clearSetupTimingsBtn.addEventListener('click', () => {
+            localStorage.removeItem(SETUP_TIMING_STORAGE_KEY);
+            renderSetupTimingHistory();
+            addLog('Cleared setup timing history', 'info');
+        });
+
+        renderSetupTimingHistory();
         
         // Update connection status
         function updateStatus(status) {
@@ -959,6 +1626,7 @@
 
             currentSessionId = decartRealtime.sessionId;
             elements.sessionIdText.textContent = currentSessionId || '-';
+            noteSetupTimingSessionId(currentSessionId);
 
             const previousSubscribeToken = currentSubscribeToken;
             currentSubscribeToken = decartRealtime.getSubscribeToken();
@@ -1091,7 +1759,11 @@
                 return;
             }
             
+            let connectHandlerSpan = null;
+            let sdkConnectSpan = null;
             try {
+                beginSetupTiming();
+                connectHandlerSpan = startSetupTimingSpan('connect button handler');
                 updateStatus('connecting');
                 elements.connectBtn.disabled = true;
                 elements.subscribeBtn.disabled = true;
@@ -1101,11 +1773,13 @@
                 addLog('Initializing Decart client...', 'info');
                 
                 const realtimeBaseUrl = elements.realtimeBaseUrl.value.trim();
+                const createClientSpan = startSetupTimingSpan('createDecartClient');
                 decartClient = createDecartClient({
                     apiKey,
                     ...(realtimeBaseUrl && { realtimeBaseUrl }),
                     logger: createDemoLogger("debug"),
                 });
+                finishSetupTimingSpan(createClientSpan);
                 
                 addLog('Connecting to Decart server via LiveKit...', 'info');
                 
@@ -1138,14 +1812,20 @@
                     addLog('Debug-quality (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
                 }
 
+                sdkConnectSpan = startSetupTimingSpan('decartClient.realtime.connect');
+                activeSetupTiming.sdkConnectStartedAtMs = Math.round(sdkConnectSpan?.startedAtMs ?? 0);
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
                     ...(debugQuality && { debugQuality: true }),
                     onRemoteStream: (stream) => {
+                        const onRemoteStreamSpan = startSetupTimingSpan('onRemoteStream');
                         addLog('Received remote stream from Decart', 'success');
+                        noteRemoteStreamReceived();
                         elements.remoteVideo.srcObject = stream;
+                        armFirstRemoteFrameWatcher();
+                        finishSetupTimingSpan(onRemoteStreamSpan);
                     },
                     onConnectionChange: (state) => {
                         updateStatus(state);
@@ -1168,6 +1848,9 @@
                         ...(initialImage && { image: initialImage }),
                     },
                 });
+                finishSetupTimingSpan(sdkConnectSpan);
+
+                decartRealtime.on('diagnostic', noteConnectionBreakdown);
                 
                 // Check connection status
                 if (decartRealtime.isConnected()) {
@@ -1189,11 +1872,15 @@
                     addLog('Successfully connected to Decart!', 'success');
                     addLog(`Session ID: ${currentSessionId || '(pending)'}`, 'success');
                     updateUseRefAsImageBtnState();
+                    finishSetupTimingSpan(connectHandlerSpan);
+                    upsertActiveSetupTimingRecord();
                 } else {
                     throw new Error('Connection established but not in connected state');
                 }
                 
             } catch (error) {
+                finishSetupTimingSpan(sdkConnectSpan, { success: false, error: error.message });
+                finishSetupTimingSpan(connectHandlerSpan, { success: false, error: error.message });
                 addLog(`Failed to connect: ${error.message}`, 'error');
                 updateStatus('disconnected');
                 elements.connectBtn.disabled = false;
@@ -1202,6 +1889,7 @@
                 activeConnectionMode = null;
                 currentSessionId = null;
                 currentSubscribeToken = null;
+                activeSetupTiming = null;
                 elements.sessionInfo.style.display = 'none';
                 elements.publisherTokenInfo.style.display = 'none';
                 elements.subscribeBtn.disabled = false;
@@ -1317,6 +2005,7 @@
             currentSessionId = null;
             currentSubscribeToken = null;
             activeConnectionMode = null;
+            activeSetupTiming = null;
             
             // Reset UI
             elements.startCamera.disabled = false;

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -73,6 +73,7 @@ export class MediaChannel {
   }
 
   async connect(opts: MediaConnectOptions): Promise<void> {
+    const connectSpan = this.config.observability?.startSpan("MediaChannel.connect");
     this.room ??= new Room(REALTIME_CONFIG.livekit.roomOptions);
     const room = this.room;
 
@@ -108,16 +109,38 @@ export class MediaChannel {
     });
 
     this.config.observability?.startPhase("webrtc-handshake");
-    await room.connect(opts.url, opts.token);
-    this.config.observability?.endPhase("webrtc-handshake", { success: true });
-    this.config.observability?.setLiveKitRoom(room);
+    const roomConnectSpan = this.config.observability?.startSpan("Room.connect");
+    try {
+      await room.connect(opts.url, opts.token);
+      this.config.observability?.endSpan(roomConnectSpan);
+      this.config.observability?.endPhase("webrtc-handshake", { success: true });
+      const statsSpan = this.config.observability?.startSpan("RealtimeObservability.setLiveKitRoom");
+      this.config.observability?.setLiveKitRoom(room);
+      this.config.observability?.endSpan(statsSpan);
+      this.config.observability?.endSpan(connectSpan);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.config.observability?.endSpan(roomConnectSpan, { success: false, error: message });
+      this.config.observability?.endPhase("webrtc-handshake", { success: false, error: message });
+      this.config.observability?.endSpan(connectSpan, { success: false, error: message });
+      throw error;
+    }
   }
 
   async publishLocalTracks(): Promise<void> {
     if (!this.config.localStream) return;
+    const span = this.config.observability?.startSpan("MediaChannel.publishLocalTracks");
     this.config.observability?.startPhase("publish-local-track");
-    await this.publishTracks(this.config.localStream);
-    this.config.observability?.endPhase("publish-local-track", { success: true });
+    try {
+      await this.publishTracks(this.config.localStream);
+      this.config.observability?.endPhase("publish-local-track", { success: true });
+      this.config.observability?.endSpan(span);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.config.observability?.endPhase("publish-local-track", { success: false, error: message });
+      this.config.observability?.endSpan(span, { success: false, error: message });
+      throw error;
+    }
   }
 
   disconnect(): void {
@@ -132,12 +155,28 @@ export class MediaChannel {
 
   private async publishTracks(stream: MediaStream): Promise<void> {
     if (!this.room) return;
-    for (const track of stream.getTracks()) {
-      if (track.kind === "video") {
-        await this.room.localParticipant.publishTrack(track, getDefaultVideoPublishOptions(this.config.videoCodec));
-      } else {
-        await this.room.localParticipant.publishTrack(track);
+    const span = this.config.observability?.startSpan("MediaChannel.publishTracks");
+    try {
+      for (const track of stream.getTracks()) {
+        const publishTrackSpan = this.config.observability?.startSpan(
+          "LocalParticipant.publishTrack",
+          `${track.kind}:${track.id}`,
+        );
+        if (track.kind === "video") {
+          const optionsSpan = this.config.observability?.startSpan("getDefaultVideoPublishOptions");
+          const options = getDefaultVideoPublishOptions(this.config.videoCodec);
+          this.config.observability?.endSpan(optionsSpan);
+          await this.room.localParticipant.publishTrack(track, options);
+        } else {
+          await this.room.localParticipant.publishTrack(track);
+        }
+        this.config.observability?.endSpan(publishTrackSpan);
       }
+      this.config.observability?.endSpan(span);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.config.observability?.endSpan(span, { success: false, error: message });
+      throw error;
     }
   }
 }

--- a/packages/sdk/src/realtime/observability/diagnostics.ts
+++ b/packages/sdk/src/realtime/observability/diagnostics.ts
@@ -1,7 +1,20 @@
 export type ClientSessionConnectionBreakdownPhase = {
   phase: string;
+  functionName?: string;
+  startedAtMs?: number;
+  endedAtMs?: number;
   durationMs: number;
   success: boolean;
+  error?: string;
+};
+
+export type ClientSessionConnectionBreakdownSpan = {
+  functionName: string;
+  startedAtMs: number;
+  endedAtMs: number;
+  durationMs: number;
+  success: boolean;
+  detail?: string;
   error?: string;
 };
 
@@ -11,6 +24,7 @@ export type ClientSessionConnectionBreakdownEvent = {
   totalDurationMs: number;
   initialImageSizeKb: number | null;
   phases: ClientSessionConnectionBreakdownPhase[];
+  spans?: ClientSessionConnectionBreakdownSpan[];
   error?: string;
 };
 

--- a/packages/sdk/src/realtime/observability/realtime-observability.ts
+++ b/packages/sdk/src/realtime/observability/realtime-observability.ts
@@ -4,6 +4,7 @@ import { REALTIME_CONFIG } from "../config-realtime";
 import { ConnectionQualityEvaluator, type ConnectionQualityReport } from "./connection-quality";
 import type {
   ClientSessionConnectionBreakdownPhase,
+  ClientSessionConnectionBreakdownSpan,
   DiagnosticEvent,
   DiagnosticEventName,
   DiagnosticEvents,
@@ -39,11 +40,29 @@ type PhaseEntry = {
   error?: string;
 };
 
+export type RealtimeTraceSpan = {
+  functionName: string;
+  startedAt: number;
+  endedAt?: number;
+  success?: boolean;
+  detail?: string;
+  error?: string;
+};
+
 type ConnectionBreakdownBuffer = {
   attempt: number;
   connectStartedAt: number;
   initialImageSizeKb: number | null;
   phases: Map<string, PhaseEntry>;
+  spans: RealtimeTraceSpan[];
+};
+
+const CONNECTION_PHASE_FUNCTION_NAMES: Record<string, string> = {
+  "websocket-open": "SignalingChannel.openSocket",
+  "room-join": "SignalingChannel.waitForRoomInfo",
+  "initial-state-handshake": "SignalingChannel.flushInitialState",
+  "webrtc-handshake": "MediaChannel.connect",
+  "publish-local-track": "MediaChannel.publishLocalTracks",
 };
 
 export class RealtimeObservability {
@@ -113,7 +132,29 @@ export class RealtimeObservability {
       connectStartedAt: Date.now(),
       initialImageSizeKb,
       phases: new Map(),
+      spans: [],
     };
+  }
+
+  startSpan(functionName: string, detail?: string): RealtimeTraceSpan | null {
+    if (!this.connectionBreakdown) return null;
+    const span: RealtimeTraceSpan = {
+      functionName,
+      startedAt: Date.now(),
+      ...(detail !== undefined ? { detail } : {}),
+    };
+    this.connectionBreakdown.spans.push(span);
+    return span;
+  }
+
+  endSpan(
+    span: RealtimeTraceSpan | null | undefined,
+    opts: { success: boolean; error?: string } = { success: true },
+  ): void {
+    if (!span || span.endedAt !== undefined) return;
+    span.endedAt = Date.now();
+    span.success = opts.success;
+    if (opts.error !== undefined) span.error = opts.error;
   }
 
   startPhase(name: string): void {
@@ -140,6 +181,7 @@ export class RealtimeObservability {
 
     const now = Date.now();
     const phases: ClientSessionConnectionBreakdownPhase[] = [];
+    const spans: ClientSessionConnectionBreakdownSpan[] = [];
     for (const [phase, entry] of buffer.phases) {
       const unfinished = entry.endedAt === undefined;
       const endedAt = entry.endedAt ?? now;
@@ -147,8 +189,25 @@ export class RealtimeObservability {
       const error = entry.error ?? (unfinished && !opts.success ? opts.error : undefined);
       phases.push({
         phase,
+        functionName: CONNECTION_PHASE_FUNCTION_NAMES[phase] ?? phase,
+        startedAtMs: entry.startedAt - buffer.connectStartedAt,
+        endedAtMs: endedAt - buffer.connectStartedAt,
         durationMs: endedAt - entry.startedAt,
         success,
+        ...(error !== undefined ? { error } : {}),
+      });
+    }
+    for (const entry of buffer.spans) {
+      const unfinished = entry.endedAt === undefined;
+      const endedAt = entry.endedAt ?? now;
+      const error = entry.error ?? (unfinished && !opts.success ? opts.error : undefined);
+      spans.push({
+        functionName: entry.functionName,
+        startedAtMs: entry.startedAt - buffer.connectStartedAt,
+        endedAtMs: endedAt - buffer.connectStartedAt,
+        durationMs: endedAt - entry.startedAt,
+        success: entry.success ?? false,
+        ...(entry.detail !== undefined ? { detail: entry.detail } : {}),
         ...(error !== undefined ? { error } : {}),
       });
     }
@@ -161,6 +220,7 @@ export class RealtimeObservability {
         totalDurationMs: now - buffer.connectStartedAt,
         initialImageSizeKb: buffer.initialImageSizeKb,
         phases,
+        spans,
         ...(opts.error !== undefined ? { error: opts.error } : {}),
       },
       now,

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -121,6 +121,7 @@ export class SignalingChannel {
   private pendingAcks: PendingAck[] = [];
   private bufferedAcks: IncomingRealtimeMessage[] = [];
   private pendingRoomInfo: PendingRoomInfo | null = null;
+  private earlyFatalError: Error | null = null;
   private connected = false;
   private closing = false;
   private readonly logger: Logger;
@@ -138,70 +139,97 @@ export class SignalingChannel {
   }
 
   async openAndJoin(opts: OpenAndJoinOptions = {}): Promise<OpenAndJoinResult> {
+    const openAndJoinSpan = this.config.observability?.startSpan("SignalingChannel.openAndJoin");
     const connectTimeout = opts.connectTimeout ?? REALTIME_CONFIG.signaling.connectTimeoutMs;
     const handshakeTimeout = opts.handshakeTimeout ?? REALTIME_CONFIG.signaling.handshakeTimeoutMs;
 
-    this.config.observability?.startPhase("websocket-open");
-    await this.openSocket(connectTimeout);
-    this.config.observability?.endPhase("websocket-open", { success: true });
-
-    this.config.observability?.startPhase("room-join");
-    const roomInfoWait = this.waitForRoomInfo(handshakeTimeout);
-
-    // Lean join first, then the initial state as its own frame. The server
-    // returns room_info off the small join frame without waiting for the
-    // (multi-MB) image to upload, so the upload overlaps the SFU connect rather
-    // than blocking room_info. Order matters: the join must be written first.
-    const initialStateRequest = buildInitialStateRequest(opts.initialState);
-    const userSetInitialState =
-      opts.initialState != null &&
-      (opts.initialState.image != null || opts.initialState.imageRef != null || opts.initialState.prompt != null);
-    const joinMessage: LiveKitJoinMessage = {
-      type: "livekit_join",
-      passthrough: opts.passthrough ?? !userSetInitialState,
-    };
-
-    if (!this.writeMessage(joinMessage)) {
-      roomInfoWait.cancel();
-      throw new Error("WebSocket is not open");
-    }
-
-    if (initialStateRequest && !this.writeMessage(initialStateRequest.message)) {
-      roomInfoWait.cancel();
-      throw new Error("WebSocket is not open");
-    }
-
-    let roomInfo: RoomInfo;
     try {
-      roomInfo = await roomInfoWait.promise;
+      this.config.observability?.startPhase("websocket-open");
+      await this.openSocket(connectTimeout);
+      this.throwEarlyFatalError();
+      this.config.observability?.endPhase("websocket-open", { success: true });
+
+      this.config.observability?.startPhase("room-join");
+      const roomInfoWait = this.waitForRoomInfo(handshakeTimeout);
+
+      // Lean join first, then the initial state as its own frame. The server
+      // returns room_info off the small join frame without waiting for the
+      // (multi-MB) image to upload, so the upload overlaps the SFU connect rather
+      // than blocking room_info. Order matters: the join must be written first.
+      const buildInitialStateSpan = this.config.observability?.startSpan("buildInitialStateRequest");
+      const initialStateRequest = buildInitialStateRequest(opts.initialState);
+      this.config.observability?.endSpan(buildInitialStateSpan);
+      const userSetInitialState =
+        opts.initialState != null &&
+        (opts.initialState.image != null || opts.initialState.imageRef != null || opts.initialState.prompt != null);
+      const joinMessage: LiveKitJoinMessage = {
+        type: "livekit_join",
+        passthrough: opts.passthrough ?? !userSetInitialState,
+      };
+
+      if (!this.writeMessage(joinMessage, "livekit_join")) {
+        roomInfoWait.cancel();
+        throw new Error("WebSocket is not open");
+      }
+
+      if (initialStateRequest && !this.writeMessage(initialStateRequest.message, initialStateRequest.message.type)) {
+        roomInfoWait.cancel();
+        throw new Error("WebSocket is not open");
+      }
+
+      let roomInfo: RoomInfo;
+      try {
+        roomInfo = await roomInfoWait.promise;
+      } catch (error) {
+        this.rejectAllPending(error instanceof Error ? error : new Error(String(error)));
+        throw error;
+      }
+      this.config.observability?.endPhase("room-join", { success: true });
+
+      this.connected = true;
+
+      // Arm the ack only now that room info arrived, so a long queue wait cannot
+      // trip the ack timeout. The message was already written as its own frame
+      // right after the join, so this waits for the ack without writing again.
+      const initialStateAck = initialStateRequest ? this.flushInitialState(initialStateRequest) : Promise.resolve();
+      initialStateAck.catch(() => {});
+
+      this.config.observability?.endSpan(openAndJoinSpan);
+      return { roomInfo, initialStateAck };
     } catch (error) {
-      this.rejectAllPending(error instanceof Error ? error : new Error(String(error)));
+      this.config.observability?.endSpan(openAndJoinSpan, {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     }
-    this.config.observability?.endPhase("room-join", { success: true });
-
-    this.connected = true;
-
-    // Arm the ack only now that room info arrived, so a long queue wait cannot
-    // trip the ack timeout. The message was already written as its own frame
-    // right after the join, so this waits for the ack without writing again.
-    const initialStateAck = initialStateRequest ? this.flushInitialState(initialStateRequest) : Promise.resolve();
-    initialStateAck.catch(() => {});
-
-    return { roomInfo, initialStateAck };
   }
 
   private async flushInitialState(request: InitialStateRequest): Promise<void> {
+    const span = this.config.observability?.startSpan("SignalingChannel.flushInitialState", request.label);
     this.config.observability?.startPhase("initial-state-handshake");
-    const ack = await this.request<SetImageAckMessage | PromptAckMessage>({
-      message: request.message,
-      matchAck: request.matchAck,
-      timeoutMs: REALTIME_CONFIG.signaling.requestTimeoutMs,
-      label: request.label,
-      write: false,
-    });
-    this.config.observability?.endPhase("initial-state-handshake", { success: true });
-    if (!ack.success) throw new Error(ack.error ?? `Failed: ${request.label}`);
+    try {
+      const ack = await this.request<SetImageAckMessage | PromptAckMessage>({
+        message: request.message,
+        matchAck: request.matchAck,
+        timeoutMs: REALTIME_CONFIG.signaling.requestTimeoutMs,
+        label: request.label,
+        write: false,
+      });
+      this.config.observability?.endPhase("initial-state-handshake", { success: true });
+      if (!ack.success) throw new Error(ack.error ?? `Failed: ${request.label}`);
+      this.config.observability?.endSpan(span);
+    } catch (error) {
+      this.config.observability?.endPhase("initial-state-handshake", {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.config.observability?.endSpan(span, {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 
   close(): void {
@@ -248,74 +276,96 @@ export class SignalingChannel {
   }
 
   private async openSocket(timeout: number): Promise<void> {
+    const span = this.config.observability?.startSpan("SignalingChannel.openSocket");
     const userAgent = encodeURIComponent(buildUserAgent(this.config.integration));
     const separator = this.config.url.includes("?") ? "&" : "?";
-    const wsUrl = `${this.config.url}${separator}user_agent=${userAgent}`;
+    // Tell the bouncer at WS-open that this is a livekit join so it returns room_info
+    // immediately instead of waiting ~1 RTT for the join frame written below.
+    const wsUrl = `${this.config.url}${separator}user_agent=${userAgent}&livekit_join=1`;
     this.closing = false;
+    this.earlyFatalError = null;
 
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error(`WebSocket open timeout (${timeout}ms)`)), timeout);
-      const ws = new WebSocket(wsUrl);
-      this.ws = ws;
-      ws.onopen = () => {
-        clearTimeout(timer);
-        resolve();
-      };
-      ws.onclose = (e) => {
-        clearTimeout(timer);
-        const wasConnected = this.connected;
-        const pendingCount = this.pendingAcks.length;
-        this.connected = false;
-        this.ws = null;
-        this.logger.warn("signaling: websocket closed", {
-          code: e.code,
-          reason: e.reason,
-          wasConnected,
-          closing: this.closing,
-          pendingAcks: pendingCount,
-        });
-        const error = new Error(`WebSocket closed: ${e.code} ${e.reason}`);
-        this.rejectPendingRoomInfo(error);
-        this.rejectAllPending(error);
-        if (wasConnected || this.closing) {
-          this.events.emit("closed", { code: e.code, reason: e.reason });
-        } else {
-          reject(error);
-        }
-      };
-      ws.onerror = () => {
-        // onclose fires after onerror with details; let it handle the rejection.
-      };
-      ws.onmessage = (e) => {
-        try {
-          this.handleMessage(JSON.parse(e.data) as IncomingRealtimeMessage);
-        } catch {
-          // ignore malformed
-        }
-      };
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`WebSocket open timeout (${timeout}ms)`)), timeout);
+        const ws = new WebSocket(wsUrl);
+        this.ws = ws;
+        ws.onopen = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+        ws.onclose = (e) => {
+          clearTimeout(timer);
+          const wasConnected = this.connected;
+          const pendingCount = this.pendingAcks.length;
+          this.connected = false;
+          this.ws = null;
+          this.logger.warn("signaling: websocket closed", {
+            code: e.code,
+            reason: e.reason,
+            wasConnected,
+            closing: this.closing,
+            pendingAcks: pendingCount,
+          });
+          const error = new Error(`WebSocket closed: ${e.code} ${e.reason}`);
+          if (!wasConnected && !this.closing) {
+            this.earlyFatalError = error;
+          }
+          this.rejectPendingRoomInfo(error);
+          this.rejectAllPending(error);
+          if (wasConnected || this.closing) {
+            this.events.emit("closed", { code: e.code, reason: e.reason });
+          } else {
+            reject(error);
+          }
+        };
+        ws.onerror = () => {
+          // onclose fires after onerror with details; let it handle the rejection.
+        };
+        ws.onmessage = (e) => {
+          try {
+            this.handleMessage(JSON.parse(e.data) as IncomingRealtimeMessage);
+          } catch {
+            // ignore malformed
+          }
+        };
+      });
+      this.config.observability?.endSpan(span);
+    } catch (error) {
+      this.config.observability?.endSpan(span, {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
   }
 
   private waitForRoomInfo(timeoutMs: number): RoomInfoWait {
+    const span = this.config.observability?.startSpan("SignalingChannel.waitForRoomInfo");
     let cleanup: () => void = () => {};
     const promise = new Promise<RoomInfo>((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
         cleanup();
         this.logger.warn("signaling: livekit_room_info timeout", { timeoutMs });
-        reject(new Error(`livekit_room_info timeout (${timeoutMs}ms)`));
+        const error = new Error(`livekit_room_info timeout (${timeoutMs}ms)`);
+        this.config.observability?.endSpan(span, { success: false, error: error.message });
+        reject(error);
       }, timeoutMs);
 
       const pendingRoomInfo: PendingRoomInfo = {
         resolve: (info) => {
           cleanup();
+          this.config.observability?.endSpan(span);
           resolve(info);
         },
         reject: (err) => {
           cleanup();
+          this.config.observability?.endSpan(span, { success: false, error: err.message });
           reject(err);
         },
         cancel: () => {
           cleanup();
+          this.config.observability?.endSpan(span, { success: false, error: "cancelled" });
         },
         pauseTimeout: () => {
           if (timer) {
@@ -348,10 +398,12 @@ export class SignalingChannel {
     label,
     write = true,
   }: RequestOptions): Promise<TAck> {
+    const span = this.config.observability?.startSpan("SignalingChannel.request", label);
     return new Promise<TAck>((resolve, reject) => {
       const buffered = this.bufferedAcks.findIndex((m) => matchAck(m));
       if (buffered !== -1) {
         const [claimed] = this.bufferedAcks.splice(buffered, 1);
+        this.config.observability?.endSpan(span);
         resolve(claimed as TAck);
         return;
       }
@@ -359,17 +411,21 @@ export class SignalingChannel {
       const timer = setTimeout(() => {
         cleanup();
         this.logger.warn("signaling: ack timed out", { label, timeoutMs });
-        reject(new Error(`${label} timed out`));
+        const error = new Error(`${label} timed out`);
+        this.config.observability?.endSpan(span, { success: false, error: error.message });
+        reject(error);
       }, timeoutMs);
 
       const entry: PendingAck = {
         matches: matchAck,
         onMatch: (msg) => {
           cleanup();
+          this.config.observability?.endSpan(span);
           resolve(msg as TAck);
         },
         reject: (err) => {
           cleanup();
+          this.config.observability?.endSpan(span, { success: false, error: err.message });
           reject(err);
         },
       };
@@ -381,64 +437,79 @@ export class SignalingChannel {
 
       if (write && !this.writeMessage(message)) {
         cleanup();
-        reject(new Error("WebSocket is not open"));
+        const error = new Error("WebSocket is not open");
+        this.config.observability?.endSpan(span, { success: false, error: error.message });
+        reject(error);
       }
     });
   }
 
-  private writeMessage(message: OutgoingRealtimeMessage): boolean {
-    if (this.ws?.readyState !== WebSocket.OPEN) return false;
+  private writeMessage(message: OutgoingRealtimeMessage, detail: string = message.type): boolean {
+    const span = this.config.observability?.startSpan("SignalingChannel.writeMessage", detail);
+    if (this.ws?.readyState !== WebSocket.OPEN) {
+      this.config.observability?.endSpan(span, { success: false, error: "WebSocket is not open" });
+      return false;
+    }
     this.ws.send(JSON.stringify(message));
+    this.config.observability?.endSpan(span);
     return true;
   }
 
   private handleMessage(msg: IncomingRealtimeMessage): void {
-    for (const ack of [...this.pendingAcks]) {
-      if (ack.matches(msg)) {
-        ack.onMatch(msg);
+    const span = this.config.observability?.startSpan("SignalingChannel.handleMessage", msg.type);
+    try {
+      for (const ack of [...this.pendingAcks]) {
+        if (ack.matches(msg)) {
+          ack.onMatch(msg);
+          return;
+        }
+      }
+
+      if (!this.connected && (msg.type === "set_image_ack" || msg.type === "prompt_ack")) {
+        this.bufferedAcks.push(msg);
         return;
       }
-    }
 
-    if (!this.connected && (msg.type === "set_image_ack" || msg.type === "prompt_ack")) {
-      this.bufferedAcks.push(msg);
-      return;
-    }
-
-    switch (msg.type) {
-      case "livekit_room_info":
-        this.resolvePendingRoomInfo({
-          livekitUrl: msg.livekit_url,
-          token: msg.token,
-          roomName: msg.room_name,
-          sessionId: msg.session_id,
-        });
-        break;
-      case "queue_position":
-        this.pendingRoomInfo?.pauseTimeout();
-        this.events.emit("queuePosition", {
-          position: msg.position,
-          queueSize: msg.queue_size,
-        });
-        break;
-      case "generation_started":
-        this.events.emit("generationStarted");
-        break;
-      case "generation_tick":
-        this.events.emit("generationTick", { seconds: msg.seconds });
-        break;
-      case "generation_ended":
-        this.events.emit("generationEnded", { seconds: msg.seconds, reason: msg.reason });
-        break;
-      case "error": {
-        const error = new Error(msg.error) as ServerError;
-        error.source = "server";
-        this.logger.error("signaling: server error received", { error: msg.error });
-        this.events.emit("serverError", error);
-        this.rejectPendingRoomInfo(error);
-        this.rejectAllPending(error);
-        break;
+      switch (msg.type) {
+        case "livekit_room_info":
+          this.resolvePendingRoomInfo({
+            livekitUrl: msg.livekit_url,
+            token: msg.token,
+            roomName: msg.room_name,
+            sessionId: msg.session_id,
+          });
+          break;
+        case "queue_position":
+          this.pendingRoomInfo?.pauseTimeout();
+          this.events.emit("queuePosition", {
+            position: msg.position,
+            queueSize: msg.queue_size,
+          });
+          break;
+        case "generation_started":
+          this.events.emit("generationStarted");
+          break;
+        case "generation_tick":
+          this.events.emit("generationTick", { seconds: msg.seconds });
+          break;
+        case "generation_ended":
+          this.events.emit("generationEnded", { seconds: msg.seconds, reason: msg.reason });
+          break;
+        case "error": {
+          const error = new Error(msg.error) as ServerError;
+          error.source = "server";
+          if (!this.connected) {
+            this.earlyFatalError = error;
+          }
+          this.logger.error("signaling: server error received", { error: msg.error });
+          this.events.emit("serverError", error);
+          this.rejectPendingRoomInfo(error);
+          this.rejectAllPending(error);
+          break;
+        }
       }
+    } finally {
+      this.config.observability?.endSpan(span);
     }
   }
 
@@ -446,6 +517,11 @@ export class SignalingChannel {
     const pending = this.pendingRoomInfo;
     if (!pending) return;
     pending.resolve(info);
+  }
+
+  private throwEarlyFatalError(): void {
+    if (!this.earlyFatalError) return;
+    throw this.earlyFatalError;
   }
 
   private rejectPendingRoomInfo(error: Error): void {

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -450,6 +450,19 @@ describe("SignalingChannel initial handshake", () => {
     vi.unstubAllGlobals();
   });
 
+  it("rejects early server errors before room-info wait is armed", async () => {
+    const { SignalingChannel } = await import("../src/realtime/signaling-channel.js");
+    const channel = new SignalingChannel({ url: "wss://example.test/realtime" });
+
+    const openPromise = channel.openAndJoin();
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    ws.receive({ type: "error", error: "Invalid API key" });
+
+    await expect(openPromise).rejects.toThrow("Invalid API key");
+    expect(ws.sentMessages).toEqual([]);
+  });
+
   it("sends lean livekit_join then initial set_image as its own frame, exposes ack as a separate promise", async () => {
     const { SignalingChannel } = await import("../src/realtime/signaling-channel.js");
     const channel = new SignalingChannel({ url: "wss://example.test/realtime" });
@@ -731,6 +744,22 @@ describe("StreamSession startup orchestration", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("does not retry permanent early server errors", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({
+      url: "wss://example.test/realtime",
+      localStream: null,
+    });
+
+    const connectPromise = session.connect();
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    ws.receive({ type: "error", error: "Invalid API key" });
+
+    await expect(connectPromise).rejects.toThrow("Invalid API key");
+    expect(FakeWebSocket.instances).toHaveLength(1);
   });
 
   it("starts LiveKit after room info, then resolves connect before caller initial-state ack", async () => {


### PR DESCRIPTION
## Summary
- Adds local debug-page setup timing history with API host, copyable JSON, and a toggleable flame/timeline view.
- Emits method-level realtime connection spans for signaling and media setup so overlap is visible.
- Latches early websocket server errors so permanent errors like Invalid API key stop retrying.

## Validation
- pnpm --dir packages/sdk exec biome check index.html src/realtime/observability/diagnostics.ts src/realtime/observability/realtime-observability.ts src/realtime/signaling-channel.ts src/realtime/media-channel.ts
- pnpm --dir packages/sdk exec tsc --noEmit
- pnpm --dir packages/sdk exec vitest tests/realtime-observability-unit.test.ts tests/realtime.unit.test.ts