### PR TITLE
feat(realtime): opt-in packet-trailer frame timing for E2E latency (re-merge of #164)

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,7 +56,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "livekit-client": "^2.0.0",
+    "livekit-client": "2.19.1",
     "mitt": "^3.0.1",
     "p-retry": "^6.2.1",
     "zod": "^4.0.17"

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -1,3 +1,4 @@
+import type { RemoteVideoTrack } from "livekit-client";
 import { z } from "zod";
 import { isFileRefId } from "../files/types";
 import {
@@ -35,6 +36,7 @@ type OnRemoteStreamFn = (stream: MediaStream) => void;
 type OnConnectionChangeFn = (state: ConnectionState) => void;
 type OnConnectionQualityFn = (report: ConnectionQualityReport) => void;
 type OnQueuePositionFn = (queuePosition: QueuePosition) => void;
+type OnRemoteVideoTrackFn = (track: RemoteVideoTrack) => void;
 export type RealTimeClientInitialState = z.infer<typeof realTimeClientInitialStateSchema>;
 
 const realTimeClientConnectOptionsSchema = z.object({
@@ -73,6 +75,30 @@ const realTimeClientConnectOptionsSchema = z.object({
    * end-user sessions.
    */
   debugQuality: z.boolean().optional(),
+  /**
+   * Opt-in per-frame end-to-end latency via LiveKit packet trailers. Provide a
+   * worker from `livekit-client/packet-trailer-worker` (bundling a Web Worker
+   * is build-tool specific, so the consumer supplies it). When set, the publish
+   * stamps `user_timestamp` on each frame's trailer, the join advertises the
+   * `frame_timing` capability so the server echoes it onto the output frame,
+   * and the subscribed track exposes `packetTrailerExtractor`. Pair with
+   * `onRemoteVideoTrack` to read the values back. See DecartAI/api#2075.
+   */
+  packetTrailerWorker: z
+    .custom<Worker>((val) => val != null && typeof (val as { postMessage?: unknown }).postMessage === "function", {
+      message: "packetTrailerWorker must be a Worker",
+    })
+    .optional(),
+  /**
+   * Receives the subscribed remote video track (LiveKit wrapper) when it is
+   * first subscribed. Use its `packetTrailerExtractor` (populated only when
+   * `packetTrailerWorker` is set) to read per-frame `user_timestamp`.
+   */
+  onRemoteVideoTrack: z
+    .custom<OnRemoteVideoTrackFn>((val) => typeof val === "function", {
+      message: "onRemoteVideoTrack must be a function",
+    })
+    .optional(),
 });
 export type RealTimeClientConnectOptions = Omit<z.infer<typeof realTimeClientConnectOptionsSchema>, "model"> & {
   model: ModelDefinition | CustomModelDefinition;
@@ -127,9 +153,11 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       onConnectionChange,
       onConnectionQuality,
       onQueuePosition,
+      onRemoteVideoTrack,
       initialState,
       resolution,
       preferredVideoCodec,
+      packetTrailerWorker,
     } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
     let inputStream: MediaStream = stream ?? new MediaStream();
@@ -214,12 +242,17 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         initialPassthrough: initialState?.passthrough,
         logger,
         videoCodec: publishCodec,
+        packetTrailerWorker,
+        // The worker is what makes trailer strip/extract possible client-side;
+        // only advertise the capability when we can actually handle the trailer.
+        frameTiming: !!packetTrailerWorker,
       });
 
       let sessionId: string | null = null;
       let subscribeToken: string | null = null;
 
       session.on("remoteStream", onRemoteStream);
+      if (onRemoteVideoTrack) session.on("remoteVideoTrack", onRemoteVideoTrack);
 
       session.on("connectionChange", (state) => {
         emitOrBuffer("connectionChange", state);

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -2,8 +2,10 @@ import {
   type DisconnectReason,
   type RemoteParticipant,
   type RemoteTrack,
+  type RemoteVideoTrack,
   Room,
   RoomEvent,
+  type RoomOptions,
   Track,
   type TrackPublishOptions,
 } from "livekit-client";
@@ -35,6 +37,13 @@ export function getDefaultVideoPublishOptions(videoCodec?: VideoCodec): TrackPub
 
 export type MediaChannelEvents = {
   remoteStream: MediaStream;
+  /**
+   * The subscribed remote video track (LiveKit wrapper, not the raw
+   * MediaStreamTrack). Carries `packetTrailerExtractor` when a
+   * packet-trailer worker is configured, letting consumers read per-frame
+   * `user_timestamp` for end-to-end latency.
+   */
+  remoteVideoTrack: RemoteVideoTrack;
   disconnected: { reason?: DisconnectReason };
 };
 
@@ -43,6 +52,15 @@ export interface MediaChannelConfig {
   localStream: MediaStream | null;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  /**
+   * Dedicated LiveKit packet-trailer worker (from
+   * `livekit-client/packet-trailer-worker`). When set, the Room is created
+   * with this worker, the local video publish opts into per-frame
+   * `user_timestamp` stamping, and `RemoteVideoTrack.packetTrailerExtractor`
+   * becomes available on the subscribed track. The worker must be provided by
+   * the consumer because bundling a Web Worker is build-tool specific.
+   */
+  packetTrailerWorker?: Worker;
 }
 
 export type MediaConnectOptions = {
@@ -73,7 +91,11 @@ export class MediaChannel {
   }
 
   async connect(opts: MediaConnectOptions): Promise<void> {
-    this.room ??= new Room(REALTIME_CONFIG.livekit.roomOptions);
+    const roomOptions: RoomOptions = { ...REALTIME_CONFIG.livekit.roomOptions };
+    if (this.config.packetTrailerWorker) {
+      roomOptions.packetTrailer = { worker: this.config.packetTrailerWorker };
+    }
+    this.room ??= new Room(roomOptions);
     const room = this.room;
 
     room.on(RoomEvent.TrackSubscribed, (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
@@ -86,6 +108,10 @@ export class MediaChannel {
         // (no-op unless g2g measurement is enabled).
         if (track.kind === Track.Kind.Video) {
           this.config.observability?.attachRemoteVideoTrack(mediaStreamTrack);
+          // Surface the LiveKit track wrapper too — its `packetTrailerExtractor`
+          // (present when a packet-trailer worker is configured) is how
+          // consumers read per-frame `user_timestamp` for E2E latency.
+          this.events.emit("remoteVideoTrack", track as RemoteVideoTrack);
         }
         // Emit a fresh MediaStream whenever the track set changes. Consumers
         // assign this to an element's `srcObject`; mutating the existing stream
@@ -134,7 +160,13 @@ export class MediaChannel {
     if (!this.room) return;
     for (const track of stream.getTracks()) {
       if (track.kind === "video") {
-        await this.room.localParticipant.publishTrack(track, getDefaultVideoPublishOptions(this.config.videoCodec));
+        const publishOptions = getDefaultVideoPublishOptions(this.config.videoCodec);
+        if (this.config.packetTrailerWorker) {
+          // Auto-fill `user_timestamp = Date.now() * 1000` on every encoded
+          // frame's packet trailer; the server echoes it onto the output frame.
+          publishOptions.packetTrailer = { timestamp: true };
+        }
+        await this.room.localParticipant.publishTrack(track, publishOptions);
       } else {
         await this.room.localParticipant.publishTrack(track);
       }

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -44,6 +44,13 @@ export interface SignalingChannelConfig {
   integration?: string;
   logger?: Logger;
   observability?: RealtimeObservability;
+  /**
+   * When true, advertise `client_capabilities: { frame_timing: true }` in the
+   * `livekit_join` so the server stamps per-frame `user_timestamp` onto the
+   * output packet trailer. Gated on the client having a packet-trailer worker
+   * configured (see MediaChannelConfig.packetTrailerWorker).
+   */
+  frameTiming?: boolean;
 }
 
 type PendingAck = {
@@ -159,6 +166,7 @@ export class SignalingChannel {
     const joinMessage: LiveKitJoinMessage = {
       type: "livekit_join",
       passthrough: opts.passthrough ?? !userSetInitialState,
+      ...(this.config.frameTiming ? { client_capabilities: { frame_timing: true } } : {}),
     };
 
     if (!this.writeMessage(joinMessage)) {

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -1,3 +1,4 @@
+import type { RemoteVideoTrack } from "livekit-client";
 import mitt, { type Emitter } from "mitt";
 import pRetry, { AbortError } from "p-retry";
 
@@ -47,6 +48,7 @@ type StreamSessionEvents = {
   generationTick: GenerationTick;
   generationEnded: GenerationEnded;
   remoteStream: MediaStream;
+  remoteVideoTrack: RemoteVideoTrack;
   error: Error;
 };
 
@@ -61,6 +63,10 @@ interface StreamSessionConfig {
   initialPassthrough?: boolean;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  /** Packet-trailer worker; enables per-frame E2E latency. See MediaChannelConfig. */
+  packetTrailerWorker?: Worker;
+  /** Advertise `frame_timing` capability in the join. See SignalingChannelConfig. */
+  frameTiming?: boolean;
 }
 
 export class StreamSession {
@@ -281,6 +287,7 @@ export class StreamSession {
 
   private wireMediaEvents(): void {
     this.media.on("remoteStream", (stream) => this.events.emit("remoteStream", stream));
+    this.media.on("remoteVideoTrack", (track) => this.events.emit("remoteVideoTrack", track));
     this.media.on("disconnected", (info) => this.handleConnectionLoss({ source: "media", reason: info.reason }));
   }
 
@@ -326,12 +333,14 @@ export class StreamSession {
       integration: this.config.integration,
       logger: this.logger,
       observability: this.config.observability,
+      frameTiming: this.config.frameTiming,
     });
     this.media = new MediaChannel({
       observability: this.config.observability,
       localStream: this.config.localStream,
       logger: this.logger,
       videoCodec: this.config.videoCodec,
+      packetTrailerWorker: this.config.packetTrailerWorker,
     });
     this.wireSignalingEvents();
     this.wireMediaEvents();

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -48,6 +48,16 @@ export type GenerationStartedMessage = {
 export type LiveKitJoinMessage = {
   type: "livekit_join";
   passthrough: boolean;
+  /**
+   * Opt-in client capabilities advertised to the inference server at join.
+   * `frame_timing` asks the server to thread the publisher's per-frame
+   * `user_timestamp` (carried in the LiveKit packet trailer) through to the
+   * output track's trailer, so the client can measure true end-to-end
+   * latency. Only sent when the client configured a packet-trailer worker —
+   * otherwise the server would append trailer bytes the client can't strip.
+   * See DecartAI/api#2075.
+   */
+  client_capabilities?: { frame_timing?: boolean };
 };
 
 export type LiveKitRoomInfoMessage = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,8 +318,8 @@ importers:
   packages/sdk:
     dependencies:
       livekit-client:
-        specifier: ^2.0.0
-        version: 2.18.3(@types/dom-mediacapture-record@1.0.22)
+        specifier: 2.19.1
+        version: 2.19.1(@types/dom-mediacapture-record@1.0.22)
       mitt:
         specifier: ^3.0.1
         version: 3.0.1
@@ -584,17 +584,17 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@emnapi/core@1.9.2':
-    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+  '@emnapi/core@1.11.0':
+    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3':
     resolution: {integrity: sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==}
@@ -1357,15 +1357,15 @@ packages:
   '@livekit/mutex@1.1.1':
     resolution: {integrity: sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==}
 
-  '@livekit/protocol@1.45.3':
-    resolution: {integrity: sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==}
+  '@livekit/protocol@1.45.8':
+    resolution: {integrity: sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==}
 
   '@mswjs/interceptors@0.39.7':
     resolution: {integrity: sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==}
     engines: {node: '>=18'}
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1553,8 +1553,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@oxc-project/types@0.126.0':
-    resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1562,91 +1562,91 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==}
+  '@rolldown/binding-android-arm64@1.1.1':
+    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==}
+  '@rolldown/binding-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
-    resolution: {integrity: sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==}
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
-    resolution: {integrity: sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
-    resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
-    resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
-    resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
-    resolution: {integrity: sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==}
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
-    resolution: {integrity: sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==}
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1657,8 +1657,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.40':
     resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
 
-  '@rolldown/pluginutils@1.0.0-rc.16':
-    resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.46.2':
     resolution: {integrity: sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==}
@@ -1877,8 +1877,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -2727,8 +2727,8 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  livekit-client@2.18.3:
-    resolution: {integrity: sha512-A8QDaVPo+Ye35bJFyKe6PjMOtY33dmdRXGKP/3+BG48ynEES3YwFzHbsPHJiScgI4OZouNef3Ew/BPazXKwo8Q==}
+  livekit-client@2.19.1:
+    resolution: {integrity: sha512-knwEuozt3d7optuUMvw+0PGrV/68GWXrTdAefezOM51Dk8QLb28qOm73UMSSQET58gUqelxqU1afchd2YyPKnQ==}
     peerDependencies:
       '@types/dom-mediacapture-record': ^1
 
@@ -3117,8 +3117,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.0-rc.16:
-    resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==}
+  rolldown@1.1.1:
+    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4050,9 +4050,14 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@emnapi/core@1.9.2':
+  '@emnapi/core@1.11.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -4061,12 +4066,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4538,7 +4538,7 @@ snapshots:
 
   '@livekit/mutex@1.1.1': {}
 
-  '@livekit/protocol@1.45.3':
+  '@livekit/protocol@1.45.8':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
@@ -4551,11 +4551,11 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@next/env@15.5.7': {}
@@ -4708,7 +4708,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@oxc-project/types@0.126.0': {}
+  '@oxc-project/types@0.135.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -4716,60 +4716,60 @@ snapshots:
     dependencies:
       quansync: 0.2.10
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.16':
+  '@rolldown/binding-android-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.16':
+  '@rolldown/binding-darwin-x64@1.1.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.16':
+  '@rolldown/binding-freebsd-x64@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
+  '@rolldown/binding-linux-x64-musl@1.1.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
+  '@rolldown/binding-openharmony-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.16':
+  '@rolldown/binding-wasm32-wasi@1.1.1':
     dependencies:
-      '@emnapi/core': 1.9.2
-      '@emnapi/runtime': 1.9.2
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-beta.40': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.16': {}
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.46.2':
     optional: true
@@ -5035,7 +5035,7 @@ snapshots:
       '@testing-library/dom': 10.4.1
     optional: true
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6029,10 +6029,10 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  livekit-client@2.18.3(@types/dom-mediacapture-record@1.0.22):
+  livekit-client@2.19.1(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       '@livekit/mutex': 1.1.1
-      '@livekit/protocol': 1.45.3
+      '@livekit/protocol': 1.45.8
       '@types/dom-mediacapture-record': 1.0.22
       events: 3.3.0
       jose: 6.2.2
@@ -6413,7 +6413,7 @@ snapshots:
 
   rettime@0.7.0: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.0.0-rc.16)(typescript@5.9.2):
+  rolldown-plugin-dts@0.15.6(rolldown@1.1.1)(typescript@5.9.2):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -6423,33 +6423,33 @@ snapshots:
       debug: 4.4.1
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.0.0-rc.16
+      rolldown: 1.1.1
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.0-rc.16:
+  rolldown@1.1.1:
     dependencies:
-      '@oxc-project/types': 0.126.0
-      '@rolldown/pluginutils': 1.0.0-rc.16
+      '@oxc-project/types': 0.135.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.16
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.16
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.16
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.16
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.16
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.16
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
+      '@rolldown/binding-android-arm64': 1.1.1
+      '@rolldown/binding-darwin-arm64': 1.1.1
+      '@rolldown/binding-darwin-x64': 1.1.1
+      '@rolldown/binding-freebsd-x64': 1.1.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
+      '@rolldown/binding-linux-arm64-gnu': 1.1.1
+      '@rolldown/binding-linux-arm64-musl': 1.1.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
+      '@rolldown/binding-linux-s390x-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-musl': 1.1.1
+      '@rolldown/binding-openharmony-arm64': 1.1.1
+      '@rolldown/binding-wasm32-wasi': 1.1.1
+      '@rolldown/binding-win32-arm64-msvc': 1.1.1
+      '@rolldown/binding-win32-x64-msvc': 1.1.1
 
   rollup-plugin-inject@3.0.2:
     dependencies:
@@ -6793,8 +6793,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.0-rc.16
-      rolldown-plugin-dts: 0.15.6(rolldown@1.0.0-rc.16)(typescript@5.9.2)
+      rolldown: 1.1.1
+      rolldown-plugin-dts: 0.15.6(rolldown@1.1.1)(typescript@5.9.2)
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.14


### PR DESCRIPTION
## What

Re-introduces the opt-in **packet-trailer frame-timing** E2E-latency feature. It was merged by accident in #164 and reverted by #165 ("can be re-merged when intended") — this is the intended re-merge, **rebased onto current `main` (v0.1.8)**.

A `packetTrailerWorker` connect option (+ an `onRemoteVideoTrack` callback) wires LiveKit packet trailers end to end:
- Room is created with the worker; local video publish stamps per-frame `user_timestamp`.
- The `livekit_join` advertises `client_capabilities: { frame_timing: true }` so the server echoes that timestamp onto the output frame's trailer.
- The subscribed `RemoteVideoTrack` is surfaced via `onRemoteVideoTrack`, so consumers read it back through `packetTrailerExtractor` and compute `(timeOrigin + expectedDisplayTime) − user_timestamp`.

Bumps `livekit-client` to **2.19.1** (first release with the packet-trailer API). The consumer supplies the worker (bundling a Web Worker is build-tool specific). All gated on the worker being provided — no behavior change when absent.

## Rebase notes
- Reconciled with **#168 ("lean `livekit_join`")**: `client_capabilities` now rides alongside the new `passthrough` field on the join frame (the old `initial_state`-in-join is gone; trailers are independent of it).
- Lockfile regenerated against current `main` + the 2.19.1 pin — `--frozen-lockfile` clean.

## Status & caveats
- **typecheck ✓** on v0.1.8. Previously validated live: trailer E2E ≈ pixel-marker E2E within ~20 ms.
- This keeps the **original, explicit** API shape (consumer-supplied worker + `onRemoteVideoTrack`). A consolidation behind `debugQuality` (single metric, SDK-internal worker) was explored and **deferred** — it traded the leaky surface for hidden machinery + a semantic mismatch, so it's not obviously cleaner. Worth a follow-up discussion before shipping this publicly.

## Refs
- Reverted predecessor: #164 (merge) / #165 (revert)
- Server side: DecartAI/api#2075
- Validation harness: DecartAI/decart-webrtc-tester#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime WebRTC publish/subscribe and signaling join shape; changes are opt-in but depend on server `frame_timing` support and a pinned LiveKit minor release.
> 
> **Overview**
> Adds **opt-in per-frame end-to-end latency** via LiveKit packet trailers, gated entirely on a consumer-supplied `packetTrailerWorker` (from `livekit-client/packet-trailer-worker`). When enabled, the SDK wires the worker into the LiveKit `Room`, stamps `user_timestamp` on outgoing video publishes, and advertises `client_capabilities: { frame_timing: true }` on the lean `livekit_join` so the server can echo timestamps on the output trailer.
> 
> Connect options gain optional **`packetTrailerWorker`** and **`onRemoteVideoTrack`**: the latter delivers the subscribed `RemoteVideoTrack` (with `packetTrailerExtractor`) alongside the existing `MediaStream` callback. Events propagate through `StreamSession` → `MediaChannel` → `SignalingChannel` without changing default connect behavior when the worker is omitted.
> 
> Pins **`livekit-client` to 2.19.1** (packet-trailer API) and refreshes the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5eb22f1adc738ffe6a91e7b241de0357790b667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->