### PR TITLE
feat(realtime): pause/resume + startPaused; skip empty set_image on connect

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -394,10 +394,33 @@
             <input type="checkbox" id="stream-audio-toggle" unchecked>
             <label for="stream-audio-toggle" style="margin: 0; font-weight: normal;">Stream microphone audio</label>
         </div>
+        <div class="control-group checkbox-group">
+            <input type="checkbox" id="no-video-toggle">
+            <label for="no-video-toggle" style="margin: 0; font-weight: normal;">Connect without video track (i2v / no-input — passes <code>null</code> stream)</label>
+        </div>
+        <div class="control-group checkbox-group">
+            <input type="checkbox" id="start-paused-toggle">
+            <label for="start-paused-toggle" style="margin: 0; font-weight: normal;">Start paused (<code>pause_mode</code> on join — output appears after resume)</label>
+        </div>
         <div class="inline-controls">
             <button id="start-camera">Start Camera</button>
             <button id="connect-btn" disabled>Connect to Decart</button>
             <button id="disconnect-btn" disabled>Disconnect</button>
+        </div>
+    </div>
+
+    <!-- Pause / Resume -->
+    <div class="controls">
+        <h3>Pause / Resume</h3>
+        <p style="margin: 0 0 10px 0; font-size: 12px; color: #666;">
+            <code>pause()</code> / <code>resume()</code> resolve on the server ack. While paused the output holds (v2v: black frame; i2v / no-input: nothing until resume). Publisher sessions only.
+        </p>
+        <div class="inline-controls">
+            <button id="pause-btn" disabled>Pause</button>
+            <button id="resume-btn" class="secondary" disabled>Resume</button>
+        </div>
+        <div id="pause-resume-status" style="margin-top: 10px; padding: 10px; background: #f8f9fa; border-radius: 6px; display: none;">
+            <strong>Status:</strong> <span id="pause-resume-status-text">Ready</span>
         </div>
     </div>
 
@@ -616,9 +639,15 @@
             initialImage: document.getElementById('initial-image'),
             cameraFps: document.getElementById('camera-fps'),
             streamAudioToggle: document.getElementById('stream-audio-toggle'),
+            noVideoToggle: document.getElementById('no-video-toggle'),
+            startPausedToggle: document.getElementById('start-paused-toggle'),
             startCamera: document.getElementById('start-camera'),
             connectBtn: document.getElementById('connect-btn'),
             disconnectBtn: document.getElementById('disconnect-btn'),
+            pauseBtn: document.getElementById('pause-btn'),
+            resumeBtn: document.getElementById('resume-btn'),
+            pauseResumeStatus: document.getElementById('pause-resume-status'),
+            pauseResumeStatusText: document.getElementById('pause-resume-status-text'),
             localVideo: document.getElementById('local-video'),
             remoteVideo: document.getElementById('remote-video'),
             promptInput: document.getElementById('prompt-input'),
@@ -1076,13 +1105,28 @@
             }
         });
         
+        elements.noVideoToggle.addEventListener('change', () => {
+            if (isConnected) return;
+            if (elements.noVideoToggle.checked) {
+                stopCameraResources();
+                elements.startCamera.disabled = true;
+                elements.connectBtn.disabled = false;
+                addLog('No-video mode on: connect will pass a null stream (no track published)', 'info');
+            } else {
+                elements.startCamera.disabled = false;
+                elements.connectBtn.disabled = !localStream;
+                addLog('No-video mode off: start the camera to connect with a video track', 'info');
+            }
+        });
+
         // Connect to Decart
         elements.connectBtn.addEventListener('click', async () => {
             const apiKey = resolveCredential();
             if (!apiKey) return;
 
-            if (!localStream) {
-                addLog('Please start camera first', 'error');
+            const noVideo = elements.noVideoToggle.checked;
+            if (!noVideo && !localStream) {
+                addLog('Please start camera first (or check "Connect without video track")', 'error');
                 return;
             }
 
@@ -1138,11 +1182,15 @@
                     addLog('Debug-quality (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
                 }
 
-                decartRealtime = await decartClient.realtime.connect(localStream, {
+                const startPaused = elements.startPausedToggle.checked;
+                addLog(`Start paused: ${startPaused}; video track: ${noVideo ? 'none (null stream)' : 'published'}`, 'info');
+
+                decartRealtime = await decartClient.realtime.connect(noVideo ? null : localStream, {
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
                     ...(debugQuality && { debugQuality: true }),
+                    ...(startPaused && { startPaused: true }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;
@@ -1179,6 +1227,8 @@
                     elements.promisePromptInput.disabled = false;
                     elements.sendPromisePrompt.disabled = false;
                     elements.referenceImage.disabled = false;
+                    elements.pauseBtn.disabled = false;
+                    elements.resumeBtn.disabled = false;
                     elements.subscribeBtn.disabled = true;
 
                     // Show session ID
@@ -1322,6 +1372,13 @@
             elements.startCamera.disabled = false;
             elements.connectBtn.disabled = true;
             elements.subscribeBtn.disabled = false;
+            elements.pauseBtn.disabled = true;
+            elements.resumeBtn.disabled = true;
+            elements.pauseResumeStatus.style.display = 'none';
+            if (elements.noVideoToggle.checked) {
+                elements.startCamera.disabled = true;
+                elements.connectBtn.disabled = false;
+            }
             elements.disconnectBtn.disabled = true;
             elements.promptInput.disabled = true;
             elements.sendPrompt.disabled = true;
@@ -1434,6 +1491,35 @@
                 sendPromisePrompt();
             }
         });
+
+        async function runPauseResume(action) {
+            if (!decartRealtime || !isConnected || activeConnectionMode !== 'publisher') {
+                addLog('Not connected to Decart as a publisher', 'error');
+                return;
+            }
+            const isPause = action === 'pause';
+            const btn = isPause ? elements.pauseBtn : elements.resumeBtn;
+            try {
+                elements.pauseResumeStatus.style.display = 'block';
+                elements.pauseResumeStatusText.textContent = isPause ? '⏳ Pausing…' : '⏳ Resuming…';
+                elements.pauseResumeStatusText.style.color = '#ff9800';
+                btn.disabled = true;
+                addLog(`${isPause ? 'Pausing' : 'Resuming'} session…`, 'info');
+                await (isPause ? decartRealtime.pause() : decartRealtime.resume());
+                elements.pauseResumeStatusText.textContent = isPause ? '⏸️ Paused (ack received)' : '▶️ Resumed (ack received)';
+                elements.pauseResumeStatusText.style.color = '#4CAF50';
+                addLog(`Session ${isPause ? 'paused' : 'resumed'} (${action}_ack)`, 'success');
+            } catch (error) {
+                elements.pauseResumeStatusText.textContent = `❌ ${isPause ? 'Pause' : 'Resume'} failed: ${error.message ?? error}`;
+                elements.pauseResumeStatusText.style.color = '#f44336';
+                addLog(`${isPause ? 'Pause' : 'Resume'} failed: ${error.message ?? error}`, 'error');
+            } finally {
+                btn.disabled = false;
+            }
+        }
+
+        elements.pauseBtn.addEventListener('click', () => runPauseResume('pause'));
+        elements.resumeBtn.addEventListener('click', () => runPauseResume('resume'));
 
         // Reference image selection handler
         elements.referenceImage.addEventListener('change', (e) => {

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -58,6 +58,7 @@ const realTimeClientConnectOptionsSchema = z.object({
     })
     .optional(),
   initialState: realTimeClientInitialStateSchema.optional(),
+  startPaused: z.boolean().optional(),
   queryParams: z.record(z.string(), z.string()).optional(),
   mirror: z.union([z.literal("auto"), z.boolean()]).optional(),
   resolution: z.enum(["720p", "1080p"]).optional(),
@@ -92,6 +93,8 @@ export type Events = {
 export type RealTimeClient = {
   set: (input: SetInput) => Promise<void>;
   setPrompt: (prompt: string, { enhance }?: { enhance?: boolean }) => Promise<void>;
+  pause: () => Promise<void>;
+  resume: () => Promise<void>;
   isConnected: () => boolean;
   getConnectionState: () => ConnectionState;
   /** Latest interpreted connection-quality verdict, or null before any stats arrive. */
@@ -128,6 +131,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       onConnectionQuality,
       onQueuePosition,
       initialState,
+      startPaused,
       resolution,
       preferredVideoCodec,
     } = parsedOptions.data;
@@ -212,6 +216,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
         initialImageRef,
         initialPrompt,
         initialPassthrough: initialState?.passthrough,
+        startPaused,
         logger,
         videoCodec: publishCodec,
       });

--- a/packages/sdk/src/realtime/methods.ts
+++ b/packages/sdk/src/realtime/methods.ts
@@ -55,5 +55,13 @@ export const realtimeMethods = (
     });
   };
 
-  return { set, setPrompt };
+  const pause = async (): Promise<void> => {
+    await session.pause();
+  };
+
+  const resume = async (): Promise<void> => {
+    await session.resume();
+  };
+
+  return { set, setPrompt, pause, resume };
 };

--- a/packages/sdk/src/realtime/signaling-channel.ts
+++ b/packages/sdk/src/realtime/signaling-channel.ts
@@ -13,10 +13,12 @@ import type {
   InitialState,
   LiveKitJoinMessage,
   OutgoingRealtimeMessage,
+  PauseAckMessage,
   PromptAckMessage,
   PromptMessage,
   PromptSendOptions,
   QueuePosition,
+  ResumeAckMessage,
   ServerError,
   SetImageAckMessage,
   SetImageMessage,
@@ -64,6 +66,7 @@ export type OpenAndJoinOptions = {
   handshakeTimeout?: number;
   initialState?: InitialState;
   passthrough?: boolean;
+  startPaused?: boolean;
 };
 
 export type OpenAndJoinResult = {
@@ -158,7 +161,8 @@ export class SignalingChannel {
       (opts.initialState.image != null || opts.initialState.imageRef != null || opts.initialState.prompt != null);
     const joinMessage: LiveKitJoinMessage = {
       type: "livekit_join",
-      passthrough: opts.passthrough ?? !userSetInitialState,
+      passthrough: opts.startPaused ? false : (opts.passthrough ?? !userSetInitialState),
+      ...(opts.startPaused ? { pause_mode: true } : {}),
     };
 
     if (!this.writeMessage(joinMessage)) {
@@ -245,6 +249,26 @@ export class SignalingChannel {
       label: "Image send",
     });
     if (!ack.success) throw new Error(ack.error ?? "Failed to send image");
+  }
+
+  async pause(): Promise<void> {
+    const ack = await this.request<PauseAckMessage>({
+      message: { type: "pause" },
+      matchAck: (msg) => msg.type === "pause_ack",
+      timeoutMs: REALTIME_CONFIG.signaling.requestTimeoutMs,
+      label: "Pause",
+    });
+    if (!ack.success) throw new Error(ack.error ?? "Failed to pause");
+  }
+
+  async resume(): Promise<void> {
+    const ack = await this.request<ResumeAckMessage>({
+      message: { type: "resume" },
+      matchAck: (msg) => msg.type === "resume_ack",
+      timeoutMs: REALTIME_CONFIG.signaling.requestTimeoutMs,
+      label: "Resume",
+    });
+    if (!ack.success) throw new Error(ack.error ?? "Failed to resume");
   }
 
   private async openSocket(timeout: number): Promise<void> {

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -59,6 +59,7 @@ interface StreamSessionConfig {
   initialImageRef?: string;
   initialPrompt?: InitialPrompt;
   initialPassthrough?: boolean;
+  startPaused?: boolean;
   logger?: Logger;
   videoCodec?: VideoCodec;
 }
@@ -130,6 +131,16 @@ export class StreamSession {
     return this.signaling.setImage(payload, opts);
   }
 
+  async pause(): Promise<void> {
+    this.assertConnected();
+    return this.signaling.pause();
+  }
+
+  async resume(): Promise<void> {
+    this.assertConnected();
+    return this.signaling.resume();
+  }
+
   disconnect(): void {
     this.disposed = true;
     this.tearDown();
@@ -176,6 +187,7 @@ export class StreamSession {
         connectTimeout: REALTIME_CONFIG.session.connectionTimeoutMs,
         initialState,
         passthrough: this.config.initialPassthrough,
+        startPaused: this.config.startPaused,
       });
       this.watchInitialStateAck(initialStateAck, attempt);
 
@@ -248,10 +260,6 @@ export class StreamSession {
         prompt: this.config.initialPrompt.text,
         enhance: this.config.initialPrompt.enhance,
       };
-    }
-
-    if (this.config.localStream) {
-      return { image: null, prompt: null };
     }
 
     return undefined;

--- a/packages/sdk/src/realtime/types.ts
+++ b/packages/sdk/src/realtime/types.ts
@@ -33,6 +33,26 @@ export type SetImageAckMessage = {
   error: null | string;
 };
 
+export type PauseMessage = {
+  type: "pause";
+};
+
+export type ResumeMessage = {
+  type: "resume";
+};
+
+export type PauseAckMessage = {
+  type: "pause_ack";
+  success: boolean;
+  error: null | string;
+};
+
+export type ResumeAckMessage = {
+  type: "resume_ack";
+  success: boolean;
+  error: null | string;
+};
+
 export type GenerationTickMessage = GenerationTick & {
   type: "generation_tick";
 };
@@ -48,6 +68,7 @@ export type GenerationStartedMessage = {
 export type LiveKitJoinMessage = {
   type: "livekit_join";
   passthrough: boolean;
+  pause_mode?: boolean;
 };
 
 export type LiveKitRoomInfoMessage = {
@@ -129,6 +150,8 @@ export type IncomingRealtimeMessage =
   | PromptAckMessage
   | ErrorMessage
   | SetImageAckMessage
+  | PauseAckMessage
+  | ResumeAckMessage
   | GenerationTickMessage
   | GenerationEndedMessage
   | GenerationStartedMessage
@@ -136,6 +159,11 @@ export type IncomingRealtimeMessage =
   | QueuePositionMessage;
 
 // Outgoing message types (to server)
-export type OutgoingRealtimeMessage = LiveKitJoinMessage | PromptMessage | SetImageMessage;
+export type OutgoingRealtimeMessage =
+  | LiveKitJoinMessage
+  | PromptMessage
+  | SetImageMessage
+  | PauseMessage
+  | ResumeMessage;
 
 export type OutgoingMessage = PromptMessage | SetImageMessage;


### PR DESCRIPTION
## What

Adds realtime **pause/resume** and a **`startPaused`** connect option to the SDK, drops a redundant empty `set_image` frame on connect, and adds dev-page controls to exercise it all.

### `feat(realtime)` — pause/resume + startPaused
- `pause()` / `resume()` on `RealTimeClient`, awaiting `pause_ack` / `resume_ack` via the existing `request()` + `matchAck` helper.
- `startPaused` connect option → `pause_mode` on the `livekit_join` frame.
- New wire messages (`Pause`/`Resume` + their acks) added to the in/out unions; `pause_mode?` on `LiveKitJoinMessage`.
- Public methods guarded by `assertConnected()` (calling before connect rejects).

### ⚠️ Behavior change — no empty initial `set_image` frame
`getInitialState()` used to return `{ image: null, prompt: null }` for a bare `localStream` (v2v with no image/prompt), which sent `{"type":"set_image","image_data":null,"prompt":null}` on every v2v connect. That frame carried no information, so it's gone. `passthrough` is unaffected (still defaults to `true` for v2v — `userSetInitialState` was already `false`), and `initialStateAck` resolves immediately instead of awaiting an ack for the empty frame.

### `example(dev page)`
- "Start paused" and "Connect without video track" checkboxes in Configuration.
- A Pause/Resume section that awaits the acks and shows status.

## Why

Companion to the inference + bouncer pause/resume work. Lets a consumer connect a session paused — including **video-track-agnostic** (i2v / no-input): `connect(null, { startPaused: true })` publishes no track and produces nothing until `resume()`, after which output appears on the first generated frame.

## Design notes for reviewers

- **`passthrough` forced off when `startPaused`.** A no-`initialState` paused connect would otherwise default `passthrough` to `true` (`!userSetInitialState`) and request echo. `pause_mode` is only added to the join frame when paused, keeping the lean-join frame minimal.
- **No new transport for track-less connect.** `connect(null)` already coerces to an empty `MediaStream` so `publishLocalTracks()` no-ops, and the handshake resolves on `room_info` (not on a remote track) — paused-no-output neither blocks the handshake nor errors.

## Verification

- `pnpm -C packages/sdk typecheck` ✅, `build` ✅, `biome check` ✅ on changed files.
- Behavioral checks (v2v black↔live, i2v/no-input nothing-until-resume, mid-session pause/resume acks, and confirming the empty `set_image` no longer goes out) are **manual against a live API** — not yet run; the dev page now carries the controls for it.

## Out of scope

Server-published black track for no-input paused sessions; mid-session track-add; client-side paid gating (server enforces 1008; the SDK just surfaces the error).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime connect signaling (join `passthrough`/`pause_mode` and removal of empty `set_image`), which can affect v2v and paused-session behavior if server expectations differ; new APIs are additive but tied to server pause semantics.
> 
> **Overview**
> Adds **pause/resume** and **`startPaused`** to the realtime SDK, aligned with server pause support, plus dev-page controls to exercise **no-video** and **start-paused** connects.
> 
> **`pause()` / `resume()`** on `RealTimeClient` send `pause` / `resume` over the signaling WebSocket and resolve when **`pause_ack` / `resume_ack`** return (same `request()` pattern as prompts/images). **`startPaused`** on `connect()` sets **`pause_mode: true`** on `livekit_join` and forces **`passthrough: false`** so a paused join does not request echo.
> 
> **Connect handshake change:** `getInitialState()` no longer emits an empty **`set_image`** (`image_data: null`) for plain v2v connects with only a local stream—only real initial image/prompt/ref state is sent.
> 
> The SDK test **`index.html`** gains checkboxes for null-stream connect and start-paused, plus Pause/Resume buttons with ack status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbeb0a0be50fc1515ad2c734e35b914a380c617e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->