### PR TITLE
fix(realtime): don't send empty set_image on bare-localStream connect

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -372,6 +372,14 @@
             </label>
         </div>
         <div class="control-group">
+            <label for="passthrough-select">Passthrough (initial):</label>
+            <select id="passthrough-select">
+                <option value="" selected>Default (auto — on when no initial state)</option>
+                <option value="true">On (echo input)</option>
+                <option value="false">Off (generate)</option>
+            </select>
+        </div>
+        <div class="control-group">
             <label for="initial-prompt">Initial Prompt (empty = passthrough):</label>
             <input type="text" id="initial-prompt" placeholder="e.g. Lego World">
         </div>
@@ -612,6 +620,7 @@
             realtimeBaseUrl: document.getElementById('realtime-base-url'),
             resolutionSelect: document.getElementById('resolution-select'),
             codecSelect: document.getElementById('codec-select'),
+            passthroughSelect: document.getElementById('passthrough-select'),
             initialPrompt: document.getElementById('initial-prompt'),
             initialImage: document.getElementById('initial-image'),
             cameraFps: document.getElementById('camera-fps'),
@@ -1138,6 +1147,10 @@
                     addLog('Debug-quality (glass-to-glass) measurement ON (marker visible bottom-left of output)', 'info');
                 }
 
+                const passthroughChoice = elements.passthroughSelect.value;
+                const passthrough = passthroughChoice === '' ? undefined : passthroughChoice === 'true';
+                addLog(`Initial passthrough: ${passthrough === undefined ? 'default (auto)' : passthrough}`, 'info');
+
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
@@ -1166,6 +1179,7 @@
                     initialState: {
                         ...(promptValue && { prompt: promptValue }),
                         ...(initialImage && { image: initialImage }),
+                        ...(passthrough !== undefined && { passthrough }),
                     },
                 });
                 

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -402,6 +402,11 @@
             <input type="checkbox" id="stream-audio-toggle" unchecked>
             <label for="stream-audio-toggle" style="margin: 0; font-weight: normal;">Stream microphone audio</label>
         </div>
+        <div class="control-group checkbox-group">
+            <input type="checkbox" id="replace-test-toggle">
+            <label for="replace-test-toggle" style="margin: 0; font-weight: normal;">Replace-track test (publish green frames at model resolution)</label>
+            <button id="replace-with-camera-btn" disabled>Request camera + replace track</button>
+        </div>
         <div class="inline-controls">
             <button id="start-camera">Start Camera</button>
             <button id="connect-btn" disabled>Connect to Decart</button>
@@ -625,6 +630,8 @@
             initialImage: document.getElementById('initial-image'),
             cameraFps: document.getElementById('camera-fps'),
             streamAudioToggle: document.getElementById('stream-audio-toggle'),
+            replaceTestToggle: document.getElementById('replace-test-toggle'),
+            replaceWithCameraBtn: document.getElementById('replace-with-camera-btn'),
             startCamera: document.getElementById('start-camera'),
             connectBtn: document.getElementById('connect-btn'),
             disconnectBtn: document.getElementById('disconnect-btn'),
@@ -1085,6 +1092,91 @@
             }
         });
         
+        let greenTest = null;
+        let replaceCameraStream = null;
+
+        function startGreenTest() {
+            stopGreenTest();
+            const camera = getSelectedCameraSettings();
+            const canvas = document.createElement('canvas');
+            canvas.width = camera.width;
+            canvas.height = camera.height;
+            const ctx = canvas.getContext('2d');
+            const draw = () => {
+                ctx.fillStyle = '#00ff00';
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                if (greenTest) greenTest.rafId = requestAnimationFrame(draw);
+            };
+            const stream = canvas.captureStream(camera.fps);
+            greenTest = { rafId: 0, stream };
+            draw();
+            localStream = stream;
+            elements.localVideo.srcObject = stream;
+            addLog(`Replace-track test: publishing green ${camera.width}×${camera.height} @ ${camera.fps}fps`, 'info');
+        }
+
+        function stopGreenTest() {
+            if (greenTest) {
+                cancelAnimationFrame(greenTest.rafId);
+                greenTest.stream.getTracks().forEach((track) => {
+                    track.stop();
+                });
+                greenTest = null;
+            }
+            if (replaceCameraStream) {
+                replaceCameraStream.getTracks().forEach((track) => {
+                    track.stop();
+                });
+                replaceCameraStream = null;
+            }
+        }
+
+        elements.replaceTestToggle.addEventListener('change', () => {
+            if (isConnected) {
+                elements.replaceTestToggle.checked = !elements.replaceTestToggle.checked;
+                addLog('Toggle the replace-track test before connecting', 'error');
+                return;
+            }
+            if (elements.replaceTestToggle.checked) {
+                stopCameraResources();
+                startGreenTest();
+                elements.startCamera.disabled = true;
+                elements.connectBtn.disabled = false;
+            } else {
+                stopGreenTest();
+                localStream = null;
+                elements.localVideo.srcObject = null;
+                elements.startCamera.disabled = false;
+                elements.connectBtn.disabled = true;
+            }
+        });
+
+        elements.replaceWithCameraBtn.addEventListener('click', async () => {
+            if (!decartRealtime || !isConnected || activeConnectionMode !== 'publisher') {
+                addLog('Not connected to Decart as a publisher', 'error');
+                return;
+            }
+            try {
+                elements.replaceWithCameraBtn.disabled = true;
+                addLog('Requesting camera to replace the green track…', 'info');
+                const camera = getSelectedCameraSettings();
+                const cameraStream = await navigator.mediaDevices.getUserMedia({
+                    video: { width: { ideal: camera.width }, height: { ideal: camera.height }, frameRate: { ideal: camera.fps } },
+                    audio: false,
+                });
+                const cameraTrack = cameraStream.getVideoTracks()[0];
+                if (!cameraTrack) throw new Error('No camera video track available');
+                await decartRealtime.replaceVideoTrack(cameraTrack);
+                replaceCameraStream = cameraStream;
+                elements.localVideo.srcObject = cameraStream;
+                addLog('Replaced green track with camera track (no reconnect)', 'success');
+            } catch (error) {
+                addLog(`Replace with camera failed: ${error.message ?? error}`, 'error');
+            } finally {
+                elements.replaceWithCameraBtn.disabled = false;
+            }
+        });
+
         // Connect to Decart
         elements.connectBtn.addEventListener('click', async () => {
             const apiKey = resolveCredential();
@@ -1193,6 +1285,7 @@
                     elements.promisePromptInput.disabled = false;
                     elements.sendPromisePrompt.disabled = false;
                     elements.referenceImage.disabled = false;
+                    if (elements.replaceTestToggle.checked) elements.replaceWithCameraBtn.disabled = false;
                     elements.subscribeBtn.disabled = true;
 
                     // Show session ID
@@ -1350,6 +1443,9 @@
             elements.copySubscribeToken.disabled = true;
             elements.referenceImage.disabled = true;
             elements.setImage.disabled = true;
+            elements.replaceWithCameraBtn.disabled = true;
+            elements.replaceTestToggle.checked = false;
+            stopGreenTest();
             elements.referenceImage.value = '';
             elements.imageStatus.style.display = 'none';
             elements.imagePreview.style.display = 'none';

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -109,6 +109,7 @@ export type RealTimeClient = {
    * - `null`: clear the current image.
    */
   setImage: (image: Blob | File | string | null, options?: ImageSetOptions) => Promise<void>;
+  replaceVideoTrack: (track: MediaStreamTrack) => Promise<void>;
 };
 
 export const createRealTimeClient = (opts: RealTimeClientOptions) => {

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -120,6 +120,15 @@ export class MediaChannel {
     this.config.observability?.endPhase("publish-local-track", { success: true });
   }
 
+  async replaceVideoTrack(track: MediaStreamTrack): Promise<void> {
+    const room = this.room;
+    if (!room) throw new Error("Cannot replace video track: media channel is not connected");
+    const publication = [...room.localParticipant.videoTrackPublications.values()][0];
+    const videoTrack = publication?.videoTrack;
+    if (!videoTrack) throw new Error("Cannot replace video track: no published video track");
+    await videoTrack.replaceTrack(track);
+  }
+
   disconnect(): void {
     const room = this.room;
     this.room = null;

--- a/packages/sdk/src/realtime/methods.ts
+++ b/packages/sdk/src/realtime/methods.ts
@@ -55,5 +55,9 @@ export const realtimeMethods = (
     });
   };
 
-  return { set, setPrompt };
+  const replaceVideoTrack = async (track: MediaStreamTrack): Promise<void> => {
+    await session.replaceVideoTrack(track);
+  };
+
+  return { set, setPrompt, replaceVideoTrack };
 };

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -132,7 +132,9 @@ export class StreamSession {
 
   async replaceVideoTrack(track: MediaStreamTrack): Promise<void> {
     this.assertConnected();
-    return this.media.replaceVideoTrack(track);
+    await this.media.replaceVideoTrack(track);
+    const previous = this.config.localStream;
+    this.config.localStream = new MediaStream(previous ? [track, ...previous.getAudioTracks()] : [track]);
   }
 
   disconnect(): void {

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -130,6 +130,11 @@ export class StreamSession {
     return this.signaling.setImage(payload, opts);
   }
 
+  async replaceVideoTrack(track: MediaStreamTrack): Promise<void> {
+    this.assertConnected();
+    return this.media.replaceVideoTrack(track);
+  }
+
   disconnect(): void {
     this.disposed = true;
     this.tearDown();

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -250,10 +250,6 @@ export class StreamSession {
       };
     }
 
-    if (this.config.localStream) {
-      return { image: null, prompt: null };
-    }
-
     return undefined;
   }
 

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -86,6 +86,10 @@ class FakeMediaStream {
     return this.tracks.filter((track) => (track as { kind?: string }).kind === "video");
   }
 
+  getAudioTracks(): unknown[] {
+    return this.tracks.filter((track) => (track as { kind?: string }).kind === "audio");
+  }
+
   addTrack(track: unknown): void {
     this.tracks.push(track);
   }
@@ -950,6 +954,8 @@ describe("StreamSession startup orchestration", () => {
     await session.replaceVideoTrack(newTrack);
 
     expect(publication.videoTrack.replaceTrack).toHaveBeenCalledWith(newTrack);
+    const stored = (session as unknown as { config: { localStream: MediaStream } }).config.localStream;
+    expect(stored.getVideoTracks()[0]).toBe(newTrack);
   });
 
   it("replaceVideoTrack rejects when not connected", async () => {

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -29,13 +29,23 @@ const liveKitMock = vi.hoisted(() => {
     handlers = new Map<string, Array<(...args: unknown[]) => void>>();
     state = ConnectionState.Connected;
     localParticipant = {
-      publishTrack: vi.fn().mockResolvedValue(undefined),
+      publishTrack: vi.fn(),
+      videoTrackPublications: new Map<string, { videoTrack: { replaceTrack: ReturnType<typeof vi.fn> } }>(),
     };
     connect = vi.fn().mockImplementation(() => connectMocks.shift()?.() ?? Promise.resolve());
     disconnect = vi.fn().mockResolvedValue(undefined);
 
     constructor() {
       roomInstances.push(this);
+      const lp = this.localParticipant;
+      lp.publishTrack.mockImplementation((track: { kind?: string }) => {
+        if (track?.kind === "video") {
+          lp.videoTrackPublications.set("camera", {
+            videoTrack: { replaceTrack: vi.fn().mockResolvedValue(undefined) },
+          });
+        }
+        return Promise.resolve(undefined);
+      });
     }
 
     on(event: string, handler: (...args: unknown[]) => void): this {
@@ -917,6 +927,37 @@ describe("StreamSession startup orchestration", () => {
     expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(2);
     expect(remoteStreams).toHaveLength(1);
     expect(states).toEqual(["connecting", "connected"]);
+  });
+
+  it("replaceVideoTrack swaps the published video track without reconnecting", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const localStream = createLocalStream();
+    const session = new StreamSession({ url: "wss://example.test/realtime", localStream });
+
+    const connectPromise = session.connect();
+    const ws = FakeWebSocket.instances[0];
+    ws.onopen?.();
+    await flushMicrotasks();
+    sendRoomInfo(ws);
+    await flushMicrotasks();
+    subscribeRemoteTrack();
+    await expect(connectPromise).resolves.toBeUndefined();
+
+    const room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
+    const publication = [...room.localParticipant.videoTrackPublications.values()][0];
+    const newTrack = { id: "replacement", kind: "video" } as unknown as MediaStreamTrack;
+
+    await session.replaceVideoTrack(newTrack);
+
+    expect(publication.videoTrack.replaceTrack).toHaveBeenCalledWith(newTrack);
+  });
+
+  it("replaceVideoTrack rejects when not connected", async () => {
+    const { StreamSession } = await import("../src/realtime/stream-session.js");
+    const session = new StreamSession({ url: "wss://example.test/realtime", localStream: createLocalStream() });
+    const newTrack = { id: "replacement", kind: "video" } as unknown as MediaStreamTrack;
+
+    await expect(session.replaceVideoTrack(newTrack)).rejects.toThrow(/connection is disconnected/);
   });
 
   it("emits async errors without retrying when caller initial-state ack fails after connect", async () => {

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -887,7 +887,7 @@ describe("StreamSession startup orchestration", () => {
     await flushMicrotasks();
   });
 
-  it("does not gate remoteStream or connected state on the internal null-image bootstrap ack", async () => {
+  it("sends only a lean passthrough join for a bare localStream connect (no set_image bootstrap)", async () => {
     const { StreamSession } = await import("../src/realtime/stream-session.js");
     const localStream = createLocalStream();
     const session = new StreamSession({
@@ -900,17 +900,16 @@ describe("StreamSession startup orchestration", () => {
     session.on("remoteStream", (stream) => remoteStreams.push(stream));
 
     const leanJoin = { type: "livekit_join", passthrough: true };
-    const bootstrapImage = { type: "set_image", image_data: null, prompt: null };
 
     const connectPromise = session.connect();
     const ws = FakeWebSocket.instances[0];
     ws.onopen?.();
     await flushMicrotasks();
-    expect(ws.sentMessages).toEqual([leanJoin, bootstrapImage]);
+    expect(ws.sentMessages).toEqual([leanJoin]);
 
     sendRoomInfo(ws);
     await flushMicrotasks();
-    expect(ws.sentMessages).toEqual([leanJoin, bootstrapImage]);
+    expect(ws.sentMessages).toEqual([leanJoin]);
     subscribeRemoteTrack();
 
     const room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
@@ -918,9 +917,6 @@ describe("StreamSession startup orchestration", () => {
     expect(room.localParticipant.publishTrack).toHaveBeenCalledTimes(2);
     expect(remoteStreams).toHaveLength(1);
     expect(states).toEqual(["connecting", "connected"]);
-
-    ws.receive({ type: "set_image_ack", success: true, error: null });
-    await flushMicrotasks();
   });
 
   it("emits async errors without retrying when caller initial-state ack fails after connect", async () => {


### PR DESCRIPTION
## What

`getInitialState()` returned `{ image: null, prompt: null }` for a bare `localStream` (v2v with no image/prompt/ref), which sent `{"type":"set_image","image_data":null,"prompt":null}` on every v2v connect. That frame carries no information.

This returns `undefined` for that case so **no initial-state frame is sent**.

## Why

Redundant no-op wire traffic; the empty frame also made `connect()` await a `set_image_ack` for nothing.

## Behavior

- `passthrough` unchanged — still defaults to `true` for a bare-localStream connect (`userSetInitialState` was already `false`, so `!userSetInitialState` is identical whether the synthetic `{image:null,prompt:null}` or `undefined` is returned).
- `initialStateAck` now resolves immediately instead of awaiting an ack for the empty frame.
- A v2v connect that *does* provide an image/prompt is unaffected — it still sends its real `set_image` / `prompt`.

## Verification

`pnpm -C packages/sdk typecheck` ✅, `biome check` ✅.

## Note

This same change is also bundled into #175 (pause/resume + startPaused). This PR isolates just the fix so it can land independently; #175 can be rebased once this merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connect-time signaling (fewer frames on common v2v paths) and adds in-session LiveKit track replacement on the published video path; both affect core realtime media behavior though scope is targeted and tested.
> 
> **Overview**
> **Bare video-to-video connects** no longer send a no-op `set_image` with null image/prompt: `getInitialState()` returns `undefined` when only a `localStream` is present, so the handshake is just a lean `livekit_join` with passthrough still defaulting to on. Connect no longer waits on a pointless `set_image_ack`.
> 
> **Runtime video swap** is exposed as `replaceVideoTrack` on the realtime client: it calls LiveKit `replaceTrack` on the first published video publication and refreshes the session’s stored `localStream` (keeping audio tracks).
> 
> The **SDK demo page** adds an initial passthrough selector, a pre-connect “green frames” publish mode, and a post-connect button to swap the green track for a live camera without reconnecting.
> 
> Unit tests cover the lean join behavior and `replaceVideoTrack` success/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50eed309885ca8b70d3d10ed0d3829640772ffd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->