### PR TITLE
test(e2e-realtime): drop retired lucy-2.1-vton model

### DIFF
--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -59,7 +59,6 @@ const REALTIME_MODELS: RealTimeModels[] = [
   // Actively served realtime video models and supported aliases.
   "lucy-restyle-2",
   "lucy-2.1",
-  "lucy-2.1-vton",
   "lucy-vton-2",
   "lucy-vton-3",
   "mirage_v2",


### PR DESCRIPTION
## Why

The scheduled **E2E Tests** run is failing on a single realtime model: `lucy-2.1-vton`.

The model was retired server-side, so every realtime session against it is rejected with WebSocket close code `1008` and:

> This model has been retired. See https://docs.platform.decart.ai/getting-started/models for available models.

The test exhausts all retries (x2) and the job exits 1. The other 8 tests pass.

## Fix

Remove the stale `lucy-2.1-vton` entry from `REALTIME_MODELS` in `packages/sdk/tests/e2e-realtime.test.ts`. No replacement needed — its successors `lucy-vton-2` and `lucy-vton-3` are already in the list and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to the E2E model allowlist; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Removes **`lucy-2.1-vton`** from the `REALTIME_MODELS` list in the realtime E2E suite so CI no longer opens sessions against a model the platform has retired (WebSocket `1008`).
> 
> VTON coverage stays on **`lucy-vton-2`** and **`lucy-vton-3`**, which remain in the same array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21d8699927fb3f7a8cec250de5475e28928d462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->