### PR TITLE
test(e2e): drop retired lucy-2.1-vton queue-API tests

### DIFF
--- a/packages/sdk/tests/e2e.test.ts
+++ b/packages/sdk/tests/e2e.test.ts
@@ -165,29 +165,6 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
       await expectResult(result, "lucy-2.1-reference_image", ".mp4");
     });
 
-    it("lucy-2.1-vton: virtual try-on (prompt)", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-2.1-vton"),
-        prompt: "Wearing a red leather jacket",
-        data: videoBlob,
-        seed: 42,
-      });
-
-      await expectResult(result, "lucy-2.1-vton-prompt", ".mp4");
-    });
-
-    it("lucy-2.1-vton: virtual try-on (reference_image)", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-2.1-vton"),
-        prompt: "",
-        reference_image: imageBlob,
-        data: videoBlob,
-        seed: 42,
-      });
-
-      await expectResult(result, "lucy-2.1-vton-reference_image", ".mp4");
-    });
-
     it("lucy-vton-3: virtual try-on (prompt)", async () => {
       const result = await client.queue.submitAndPoll({
         model: models.video("lucy-vton-3"),


### PR DESCRIPTION
## Why

Follow-up to #178. That PR removed `lucy-2.1-vton` from the **realtime** suite (`e2e-realtime.test.ts`), but the **Queue API** suite (`e2e.test.ts`, the `e2e` job) still submits `lucy-2.1-vton` virtual try-on jobs, which now fail:

```
Queue API - Video Models > lucy-2.1-vton: virtual try-on (prompt)
Queue API - Video Models > lucy-2.1-vton: virtual try-on (reference_image)
→ 410 {"detail":"This model has been retired.","model":"lucy-2.1-vton"}
```

## Fix

Remove the two retired `lucy-2.1-vton` queue tests. The `lucy-vton-3` successor tests already sit directly below them, so coverage is preserved.

## Note (out of scope)

The same `e2e` run also showed **504s** on `lucy-image-2` / `lucy-image-latest` / `lucy-pro-i2i` image-to-image. That's a backend/gateway issue, not a retired model, and is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change removing obsolete cases; no production or SDK behavior changes.
> 
> **Overview**
> Removes the two **Queue API** e2e cases that still called the retired `lucy-2.1-vton` model (prompt and `reference_image` virtual try-on), which were failing with **410** “This model has been retired.”
> 
> **`lucy-vton-3`** queue tests in the same block are unchanged, so virtual try-on coverage stays on the current model. Aligns the `e2e` job with #178, which already dropped this model from the realtime suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca4664d31204d2ab713dc28aa059f6d1baef4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->