### PR TITLE
feat(realtime): add lucy-2.5 realtime model

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -69,6 +69,7 @@
 
 ### Realtime Models (WebRTC)
 - `lucy-2.1` - Real-time video editing (supports reference image)
+- `lucy-2.5` - Real-time video editing (supports reference image)
 - `lucy-vton-2` - Real-time virtual try-on 2
 - `lucy-vton-3` - Real-time virtual try-on 3
 - `lucy-restyle-2` - Real-time video restyling

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -338,6 +338,7 @@
                 </optgroup>
                 <optgroup label="Canonical">
                     <option value="lucy-2.1" selected>Lucy 2.1</option>
+                    <option value="lucy-2.5">Lucy 2.5</option>
                     <option value="lucy-vton-2">Lucy VTON 2</option>
                     <option value="lucy-vton-3">Lucy VTON 3</option>
                     <option value="lucy-restyle-2">Lucy Restyle 2</option>

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -3,6 +3,7 @@ import { createModelNotFoundError } from "../utils/errors";
 
 const CANONICAL_MODEL_NAMES = [
   "lucy-2.1",
+  "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
   "lucy-restyle-2",
@@ -10,7 +11,13 @@ const CANONICAL_MODEL_NAMES = [
   "lucy-image-2",
 ] as const;
 
-const CANONICAL_REALTIME_MODEL_NAMES = ["lucy-2.1", "lucy-vton-2", "lucy-vton-3", "lucy-restyle-2"] as const;
+const CANONICAL_REALTIME_MODEL_NAMES = [
+  "lucy-2.1",
+  "lucy-2.5",
+  "lucy-vton-2",
+  "lucy-vton-3",
+  "lucy-restyle-2",
+] as const;
 const CANONICAL_VIDEO_MODEL_NAMES = ["lucy-clip", "lucy-2.1", "lucy-vton-2", "lucy-vton-3", "lucy-restyle-2"] as const;
 const CANONICAL_IMAGE_MODEL_NAMES = ["lucy-image-2"] as const;
 
@@ -52,6 +59,7 @@ function warnDeprecated(model: string): void {
 export const realtimeModels = z.union([
   // Canonical names
   z.literal("lucy-2.1"),
+  z.literal("lucy-2.5"),
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
   z.literal("lucy-restyle-2"),
@@ -243,6 +251,7 @@ export const modelInputSchemas = {
   "lucy-image-2": imageEditSchema,
   "lucy-restyle-2": restyleSchema,
   "lucy-2.1": videoEdit2Schema,
+  "lucy-2.5": videoEdit2Schema,
   "lucy-vton-2": videoEdit2Schema,
   "lucy-vton-3": videoEdit2Schema,
   // Latest aliases (server-side resolution)
@@ -325,6 +334,14 @@ const _models = {
       urlPath: "/v1/stream",
       name: "lucy-2.1" as const,
       fps: { ideal: 30, max: 30 },
+      width: 1088,
+      height: 624,
+      inputSchema: z.object({}),
+    },
+    "lucy-2.5": {
+      urlPath: "/v1/stream",
+      name: "lucy-2.5" as const,
+      fps: 20,
       width: 1088,
       height: 624,
       inputSchema: z.object({}),
@@ -579,6 +596,7 @@ export const models = {
    *
    * Available options:
    *   - `"lucy-2.1"` - Lucy 2.1 realtime video editing
+   *   - `"lucy-2.5"` - Lucy 2.5 realtime video editing
    *   - `"lucy-vton-2"` - Lucy virtual try-on 2
    *   - `"lucy-vton-3"` - Lucy virtual try-on 3
    *   - `"lucy-restyle-2"` - Realtime video restyling

--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -59,6 +59,7 @@ const REALTIME_MODELS: RealTimeModels[] = [
   // Actively served realtime video models and supported aliases.
   "lucy-restyle-2",
   "lucy-2.1",
+  "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
   "mirage_v2",

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2430,7 +2430,13 @@ describe("Canonical Model Names", () => {
         expect(canonicalModelSchema.safeParse(alias).success).toBe(false);
       }
 
-      expect(canonicalRealtimeModels.options).toEqual(["lucy-2.1", "lucy-vton-2", "lucy-vton-3", "lucy-restyle-2"]);
+      expect(canonicalRealtimeModels.options).toEqual([
+        "lucy-2.1",
+        "lucy-2.5",
+        "lucy-vton-2",
+        "lucy-vton-3",
+        "lucy-restyle-2",
+      ]);
       expect(canonicalVideoModels.options).toEqual([
         "lucy-clip",
         "lucy-2.1",
@@ -2496,7 +2502,7 @@ describe("Canonical Model Names", () => {
     it("lists all models when called without options", () => {
       const listedModels = listModels();
 
-      expect(listedModels).toHaveLength(24);
+      expect(listedModels).toHaveLength(25);
       expect(listedModels.some((model) => model.kind === "realtime" && model.name === "lucy-2.1")).toBe(true);
       expect(listedModels.some((model) => model.kind === "video" && model.name === "lucy-clip")).toBe(true);
       expect(listedModels.some((model) => model.kind === "image" && model.name === "lucy-image-2")).toBe(true);
@@ -2561,6 +2567,16 @@ describe("Canonical Model Names", () => {
       expect(model.width).toBe(1088);
       expect(model.height).toBe(624);
     });
+
+    it("lucy-2.5 canonical name works", () => {
+      const model = models.realtime("lucy-2.5");
+      expect(model.name).toBe("lucy-2.5");
+      expect(model.urlPath).toBe("/v1/stream");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
+    });
+
     it("lucy-vton-2 canonical name works", () => {
       const model = models.realtime("lucy-vton-2");
       expect(model.name).toBe("lucy-vton-2");


### PR DESCRIPTION
Adds `lucy-2.5` as a new canonical realtime model, making the latest Lucy generation available to SDK users for realtime video editing. It streams at 20 fps at 1088×624 and supports reference images, and is now selectable in the demo page's model dropdown as well.

Usage:

```ts
const realtimeClient = await client.realtime.connect(myStream, {
  model: models.realtime("lucy-2.5"),
  onRemoteStream: (stream) => { /* ... */ },
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK model registration and tests; no auth or breaking changes to existing model ids.
> 
> **Overview**
> Adds **`lucy-2.5`** as a new **canonical realtime** model so callers can use `models.realtime("lucy-2.5")` and have it validated through the public Zod unions and canonical realtime lists.
> 
> The realtime definition uses **`/v1/stream`** at **1088×624** with a fixed **`fps` of 20** (unlike `lucy-2.1`, which uses ideal/max 30). Registry docs, **`AGENTS.md`**, the SDK demo **`index.html`** model dropdown, **unit** expectations (`listModels` count, canonical options), and **e2e realtime** coverage are updated to include the new id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b7433e0bec194d8f3c3c8c1bac52c9088847e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->