### PR TITLE
feat(queue): add lucy-2.5 batch/queue model

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -79,6 +79,7 @@
 ### Video Models (Queue API)
 - `lucy-clip` - video-to-video editing
 - `lucy-2.1` - long-form video editing (720p)
+- `lucy-2.5` - long-form video editing (720p)
 - `lucy-vton-2` - virtual try-on 2 video editing
 - `lucy-vton-3` - virtual try-on 3 video editing
 - `lucy-restyle-2` - video restyling

--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -163,7 +163,7 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
   ? ImageEditingInputs
   : T["name"] extends "lucy-restyle-v2v" | "lucy-restyle-2"
     ? VideoRestyleInputs
-    : T["name"] extends "lucy-2.1" | "lucy-vton-2" | "lucy-vton-3" | "lucy-2.1-vton-2" | "lucy-vton-latest"
+    : T["name"] extends "lucy-2.1" | "lucy-2.5" | "lucy-vton-2" | "lucy-vton-3" | "lucy-2.1-vton-2" | "lucy-vton-latest"
       ? VideoEdit2Inputs
       : T["name"] extends "lucy-pro-v2v" | "lucy-clip"
         ? VideoEditInputs

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -18,7 +18,14 @@ const CANONICAL_REALTIME_MODEL_NAMES = [
   "lucy-vton-3",
   "lucy-restyle-2",
 ] as const;
-const CANONICAL_VIDEO_MODEL_NAMES = ["lucy-clip", "lucy-2.1", "lucy-vton-2", "lucy-vton-3", "lucy-restyle-2"] as const;
+const CANONICAL_VIDEO_MODEL_NAMES = [
+  "lucy-clip",
+  "lucy-2.1",
+  "lucy-2.5",
+  "lucy-vton-2",
+  "lucy-vton-3",
+  "lucy-restyle-2",
+] as const;
 const CANONICAL_IMAGE_MODEL_NAMES = ["lucy-image-2"] as const;
 
 export const canonicalRealtimeModels = z.enum(CANONICAL_REALTIME_MODEL_NAMES);
@@ -75,6 +82,7 @@ export const videoModels = z.union([
   // Canonical names
   z.literal("lucy-clip"),
   z.literal("lucy-2.1"),
+  z.literal("lucy-2.5"),
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
   z.literal("lucy-restyle-2"),
@@ -466,6 +474,15 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-2.1"],
     },
+    "lucy-2.5": {
+      urlPath: "/v1/generate/lucy-2.5",
+      queueUrlPath: "/v1/jobs/lucy-2.5",
+      name: "lucy-2.5" as const,
+      fps: 20,
+      width: 1088,
+      height: 624,
+      inputSchema: modelInputSchemas["lucy-2.5"],
+    },
     "lucy-vton-2": {
       urlPath: "/v1/generate/lucy-vton-2",
       queueUrlPath: "/v1/jobs/lucy-vton-2",
@@ -615,6 +632,7 @@ export const models = {
    * Available options:
    *   - `"lucy-clip"` - Video-to-video editing
    *   - `"lucy-2.1"` - Long-form video editing (Lucy 2.1)
+   *   - `"lucy-2.5"` - Long-form video editing (Lucy 2.5)
    *   - `"lucy-vton-2"` - Virtual try-on 2 video editing
    *   - `"lucy-vton-3"` - Virtual try-on 3 video editing
    *   - `"lucy-restyle-2"` - Video restyling

--- a/packages/sdk/tests/e2e.test.ts
+++ b/packages/sdk/tests/e2e.test.ts
@@ -165,6 +165,29 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
       await expectResult(result, "lucy-2.1-reference_image", ".mp4");
     });
 
+    it("lucy-2.5: video editing (prompt)", async () => {
+      const result = await client.queue.submitAndPoll({
+        model: models.video("lucy-2.5"),
+        prompt: "Watercolor painting style with soft brushstrokes",
+        data: videoBlob,
+        seed: 42,
+      });
+
+      await expectResult(result, "lucy-2.5-prompt", ".mp4");
+    });
+
+    it("lucy-2.5: video editing (reference_image)", async () => {
+      const result = await client.queue.submitAndPoll({
+        model: models.video("lucy-2.5"),
+        prompt: "",
+        reference_image: imageBlob,
+        data: videoBlob,
+        seed: 42,
+      });
+
+      await expectResult(result, "lucy-2.5-reference_image", ".mp4");
+    });
+
     it("lucy-vton-3: virtual try-on (prompt)", async () => {
       const result = await client.queue.submitAndPoll({
         model: models.video("lucy-vton-3"),

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2440,6 +2440,7 @@ describe("Canonical Model Names", () => {
       expect(canonicalVideoModels.options).toEqual([
         "lucy-clip",
         "lucy-2.1",
+        "lucy-2.5",
         "lucy-vton-2",
         "lucy-vton-3",
         "lucy-restyle-2",
@@ -2502,7 +2503,7 @@ describe("Canonical Model Names", () => {
     it("lists all models when called without options", () => {
       const listedModels = listModels();
 
-      expect(listedModels).toHaveLength(25);
+      expect(listedModels).toHaveLength(26);
       expect(listedModels.some((model) => model.kind === "realtime" && model.name === "lucy-2.1")).toBe(true);
       expect(listedModels.some((model) => model.kind === "video" && model.name === "lucy-clip")).toBe(true);
       expect(listedModels.some((model) => model.kind === "image" && model.name === "lucy-image-2")).toBe(true);
@@ -2617,6 +2618,16 @@ describe("Canonical Model Names", () => {
       expect(model.urlPath).toBe("/v1/generate/lucy-2.1");
       expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.1");
       expect(model.fps).toBe(20);
+    });
+
+    it("lucy-2.5 as video model works", () => {
+      const model = models.video("lucy-2.5");
+      expect(model.name).toBe("lucy-2.5");
+      expect(model.urlPath).toBe("/v1/generate/lucy-2.5");
+      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.5");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1088);
+      expect(model.height).toBe(624);
     });
     it("lucy-vton-2 as video model works", () => {
       const model = models.video("lucy-vton-2");


### PR DESCRIPTION
Adds `lucy-2.5` — the latest Lucy generation — to the batch/queue surface for long-form video editing jobs, completing the realtime support that shipped in #180.

Usage:

```ts
const result = await client.queue.submitAndPoll({
  model: models.video("lucy-2.5"),
  prompt: "Watercolor painting style with soft brushstrokes",
  data: videoFile,
});
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK registry and typing aligned with lucy-2.1; no auth or data-path changes. Queue e2e may fail until the backend route is live.
> 
> **Overview**
> Adds **`lucy-2.5`** to the SDK’s **queue (long-form video)** surface so callers can use `models.video("lucy-2.5")` with `client.queue.submitAndPoll`, matching realtime support that already exists.
> 
> The model registry now treats `lucy-2.5` as a canonical video model (`/v1/jobs/lucy-2.5`, same **720p** geometry and **`videoEdit2`** inputs as `lucy-2.1`). Docs and process typings are updated so `lucy-2.5` gets **`VideoEdit2Inputs`** where applicable.
> 
> **Tests:** unit expectations and a **`lucy-2.5` video definition** test; two **queue e2e** cases (prompt + `reference_image`). Per the PR note, those e2e tests may fail until the API exposes `POST /v1/jobs/lucy-2.5`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632f6e2e57fa3bdc6eafa708f4c3de30161270ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->