### PR TITLE
fix: correct lucy-2.5 resolution (720p) and realtime fps

### DIFF
--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -349,9 +349,9 @@ const _models = {
     "lucy-2.5": {
       urlPath: "/v1/stream",
       name: "lucy-2.5" as const,
-      fps: 20,
-      width: 1088,
-      height: 624,
+      fps: { ideal: 30, max: 30 },
+      width: 1280,
+      height: 720,
       inputSchema: z.object({}),
     },
     "lucy-vton-2": {
@@ -479,8 +479,8 @@ const _models = {
       queueUrlPath: "/v1/jobs/lucy-2.5",
       name: "lucy-2.5" as const,
       fps: 20,
-      width: 1088,
-      height: 624,
+      width: 1280,
+      height: 720,
       inputSchema: modelInputSchemas["lucy-2.5"],
     },
     "lucy-vton-2": {

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2573,9 +2573,9 @@ describe("Canonical Model Names", () => {
       const model = models.realtime("lucy-2.5");
       expect(model.name).toBe("lucy-2.5");
       expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toBe(20);
-      expect(model.width).toBe(1088);
-      expect(model.height).toBe(624);
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
+      expect(model.width).toBe(1280);
+      expect(model.height).toBe(720);
     });
 
     it("lucy-vton-2 canonical name works", () => {
@@ -2626,8 +2626,8 @@ describe("Canonical Model Names", () => {
       expect(model.urlPath).toBe("/v1/generate/lucy-2.5");
       expect(model.queueUrlPath).toBe("/v1/jobs/lucy-2.5");
       expect(model.fps).toBe(20);
-      expect(model.width).toBe(1088);
-      expect(model.height).toBe(624);
+      expect(model.width).toBe(1280);
+      expect(model.height).toBe(720);
     });
     it("lucy-vton-2 as video model works", () => {
       const model = models.video("lucy-vton-2");


### PR DESCRIPTION
## What

Corrects the SDK configuration for `lucy-2.5` so it reflects the model's actual output. Previously `lucy-2.5` inherited the older Lucy resolution (`1088×624`) and a `20fps` realtime rate, which misrepresented the model to consumers and drove the connectivity/preflight source at the wrong dimensions.

## Why

`lucy-2.5` is a 720p model and runs realtime at 30fps like the rest of the realtime lineup. The mismatched config meant anyone reading these values (or relying on the preflight synthetic source) got the wrong resolution and frame rate.

Realtime and video/batch resolution are now `1280×720`, and realtime fps is `{ ideal: 30, max: 30 }`. Video/batch fps stays at `20`, consistent with the other Lucy video models.

## Usage

```ts
const model = models.realtime("lucy-2.5");
// model.width === 1280, model.height === 720, model.fps === { ideal: 30, max: 30 }

const videoModel = models.video("lucy-2.5");
// videoModel.width === 1280, videoModel.height === 720
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and test-only changes with no API surface changes; may shift realtime preflight/connect behavior to the correct resolution and frame rate.
> 
> **Overview**
> Updates **`lucy-2.5`** in the SDK model registry so metadata matches the real model: **1280×720** for both realtime and video/batch, instead of the older **1088×624** Lucy sizing.
> 
> For **realtime**, **`fps`** changes from a flat **`20`** to **`{ ideal: 30, max: 30 }`**, aligned with other realtime Lucy models. **Video** **`fps`** stays **`20`**.
> 
> Unit tests for **`models.realtime("lucy-2.5")`** and **`models.video("lucy-2.5")`** are updated to assert the new values. Anything that reads these fields (e.g. preflight synthetic sources and realtime **`resolveFpsNumber`**) will now use 720p and 30fps for realtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33605c1c8ed3179d31b7a99692e4c9244344bc5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->