### PR TITLE
Remove the deprecated mirage_v2 alias

### DIFF
--- a/examples/sdk-core/README.md
+++ b/examples/sdk-core/README.md
@@ -47,7 +47,7 @@ Video models use the asynchronous Queue API - jobs are submitted and polled for 
 These examples require browser APIs (WebRTC) and are for reference.
 See `examples/nextjs-realtime` or `examples/react-vite` for runnable demos.
 
-- `realtime/mirage-v2-basic.ts` - Realtime style transformation with `lucy-restyle-2`
+- `realtime/lucy-restyle-basic.ts` - Realtime style transformation with `lucy-restyle-2`
 - `realtime/lucy-2.1.ts` - Lucy 2.1 realtime video editing with reference image support
 - `realtime/lucy-vton-2.ts` - Lucy VTON 2
 - `realtime/connection-events.ts` - Handling connection state and errors

--- a/examples/sdk-core/realtime/lucy-restyle-basic.ts
+++ b/examples/sdk-core/realtime/lucy-restyle-basic.ts
@@ -1,6 +1,6 @@
 /**
  * Browser-only example - requires WebRTC APIs
- * Mirage v2 for realtime style transformation
+ * Lucy Restyle for realtime style transformation
  * See examples/nextjs-realtime or examples/react-vite for runnable demos
  */
 

--- a/examples/tanstack-streamer/README.md
+++ b/examples/tanstack-streamer/README.md
@@ -53,5 +53,5 @@ pnpm dev
 
 This example uses `lucy-2.1` for video editing with reference image support. You can also use:
 
-- `lucy-restyle-2` - MirageLSD v2 for style transformation
+- `lucy-restyle-2` - Lucy Restyle for style transformation
 - `lucy-vton-2` - Lucy VTON 2

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -344,7 +344,6 @@
                     <option value="lucy-restyle-2">Lucy Restyle 2</option>
                 </optgroup>
                 <optgroup label="Deprecated aliases">
-                    <option value="mirage_v2">Mirage v2</option>
                     <option value="lucy-2.1-vton-2">Lucy 2.1 VTON 2 (alias for Lucy VTON 2)</option>
                 </optgroup>
             </select>

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -272,7 +272,7 @@ export const createDecartClient = (options: DecartClientOptions = {}) => {
        * if (quality === "critical") showFallbackUI(reasons);
        *
        * // Accurate, measured glass-to-glass verdict
-       * const probe = await client.realtime.checkConnectivity({ deep: true, model: models.realtime("mirage") });
+       * const probe = await client.realtime.checkConnectivity({ deep: true, model: models.realtime("lucy-restyle-2") });
        * console.log(probe.metrics.g2gMs);
        * ```
        */

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -39,7 +39,6 @@ export type CanonicalModel = z.infer<typeof canonicalModelSchema>;
  * Old names still work but will log a deprecation warning.
  */
 export const modelAliases = {
-  mirage_v2: "lucy-restyle-2",
   "lucy-2.1-vton-2": "lucy-vton-2",
   "lucy-pro-v2v": "lucy-clip",
   "lucy-restyle-v2v": "lucy-restyle-2",
@@ -75,7 +74,6 @@ export const realtimeModels = z.union([
   z.literal("lucy-vton-latest"),
   z.literal("lucy-restyle-latest"),
   // Deprecated names (use canonical names above instead)
-  z.literal("mirage_v2"),
   z.literal("lucy-2.1-vton-2"),
 ]);
 export const videoModels = z.union([
@@ -405,14 +403,6 @@ const _models = {
       inputSchema: z.object({}),
     },
     // Deprecated names (use canonical names above instead)
-    mirage_v2: {
-      urlPath: "/v1/stream",
-      name: "mirage_v2" as const,
-      fps: { ideal: 30, max: 30 },
-      width: 1280,
-      height: 704,
-      inputSchema: z.object({}),
-    },
     "lucy-2.1-vton-2": {
       urlPath: "/v1/stream",
       name: "lucy-2.1-vton-2" as const,

--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -62,7 +62,6 @@ const REALTIME_MODELS: RealTimeModels[] = [
   "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
-  "mirage_v2",
 ];
 
 const TIMEOUT = 1 * 60 * 1000; // 1 minute

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2423,7 +2423,7 @@ describe("Canonical Model Names", () => {
       "lucy-clip-latest",
       "lucy-image-latest",
     ];
-    const deprecatedAliases = ["mirage_v2", "lucy-2.1-vton-2", "lucy-pro-v2v", "lucy-restyle-v2v", "lucy-pro-i2i"];
+    const deprecatedAliases = ["lucy-2.1-vton-2", "lucy-pro-v2v", "lucy-restyle-v2v", "lucy-pro-i2i"];
 
     it("canonical schemas exclude deprecated and latest aliases", () => {
       for (const alias of [...latestAliases, ...deprecatedAliases]) {
@@ -2460,7 +2460,6 @@ describe("Canonical Model Names", () => {
       }
 
       expect(realtimeModels.safeParse("lucy-latest").success).toBe(true);
-      expect(realtimeModels.safeParse("mirage_v2").success).toBe(true);
       expect(videoModels.safeParse("lucy-clip-latest").success).toBe(true);
       expect(videoModels.safeParse("lucy-pro-v2v").success).toBe(true);
       expect(imageModels.safeParse("lucy-image-latest").success).toBe(true);
@@ -2503,7 +2502,7 @@ describe("Canonical Model Names", () => {
     it("lists all models when called without options", () => {
       const listedModels = listModels();
 
-      expect(listedModels).toHaveLength(26);
+      expect(listedModels).toHaveLength(25);
       expect(listedModels.some((model) => model.kind === "realtime" && model.name === "lucy-2.1")).toBe(true);
       expect(listedModels.some((model) => model.kind === "video" && model.name === "lucy-clip")).toBe(true);
       expect(listedModels.some((model) => model.kind === "image" && model.name === "lucy-image-2")).toBe(true);
@@ -2515,7 +2514,7 @@ describe("Canonical Model Names", () => {
 
       expect(realtimeModels.every((model) => model.kind === "realtime")).toBe(true);
       expect(realtimeNames).toContain("lucy-latest");
-      expect(realtimeNames).toContain("mirage_v2");
+      expect(realtimeNames).toContain("lucy-2.1-vton-2");
     });
 
     it("lists canonical model definitions without latest or deprecated aliases", () => {
@@ -2793,10 +2792,6 @@ describe("Canonical Model Names", () => {
   });
 
   describe("Deprecated names still work", () => {
-    it("mirage_v2 still works as realtime model", () => {
-      const model = models.realtime("mirage_v2");
-      expect(model.name).toBe("mirage_v2");
-    });
     it("lucy-2.1-vton-2 still works as realtime and video alias", () => {
       _resetDeprecationWarnings();
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});


### PR DESCRIPTION
mirage_v2 aliased lucy-restyle-2. Drops the alias map entry, the realtimeModels zod literal, and the _models.realtime definition; repoints the one live use (sdk-core example) to lucy-restyle-2 and renames the example file mirage-v2-basic.ts -> lucy-restyle-basic.ts; fixes unit tests (listModels count 26->25) and the e2e realtime list. Breaking: callers passing mirage_v2 now get an unknown-model error instead of a deprecation warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for any integration still passing `mirage_v2`; otherwise limited to model registry and documentation with no runtime logic beyond model validation.
> 
> **Overview**
> Removes the deprecated **`mirage_v2`** realtime alias (it mapped to **`lucy-restyle-2`**). The SDK no longer accepts that string in schemas, alias resolution, or the internal realtime model registry—**`models.realtime("mirage_v2")`** now fails with an unknown-model error instead of a deprecation warning.
> 
> Docs and demos are aligned on **`lucy-restyle-2`**: the sdk-core realtime example is renamed to **`lucy-restyle-basic.ts`**, JSDoc uses **`lucy-restyle-2`** for deep connectivity checks, and the SDK test page drops **`mirage_v2`** from the model dropdown. Unit and e2e tests drop **`mirage_v2`** coverage and **`listModels()`** count is **25** (was **26**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f96eccb6b510cb4281dacb5a7c902defbc4903a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->