### PR TITLE
fix(sdk): report the real SDK version in the User-Agent

### DIFF
--- a/packages/sdk/src/version.ts
+++ b/packages/sdk/src/version.ts
@@ -1,9 +1,12 @@
-// Version string injected at build time via tsdown
-declare const __PACKAGE_VERSION__: string | undefined;
+import packageJson from "../package.json" with { type: "json" };
 
 /**
- * The current version of the Decart SDK.
- * Injected at build time from package.json.
- * Falls back to '0.0.0-dev' in development.
+ * The current version of the Decart SDK, read from package.json.
+ *
+ * Read as a real module binding rather than a build-time `define` replacement:
+ * `define` is rejected by the pinned tsdown/rolldown ("Invalid key: define"),
+ * so a magic-token approach silently fell back to a placeholder and shipped the
+ * wrong version in the User-Agent. The bundler tree-shakes this import down to
+ * just the version string at build time.
  */
-export const VERSION: string = typeof __PACKAGE_VERSION__ !== "undefined" ? __PACKAGE_VERSION__ : "0.0.0-dev";
+export const VERSION: string = packageJson.version;

--- a/packages/sdk/tests/built-package.mjs
+++ b/packages/sdk/tests/built-package.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import pkg from "../package.json" with { type: "json" };
 
 for (const name of ["File", "Blob", "ReadableStream", "WritableStream", "TransformStream", "DOMException"]) {
   Object.defineProperty(globalThis, name, { configurable: true, value: undefined });
@@ -8,6 +9,21 @@ for (const name of ["File", "Blob", "ReadableStream", "WritableStream", "Transfo
 const browserSdk = await import("../dist/index.js");
 assert.equal(browserSdk.models.realtime("lucy-2.5").name, "lucy-2.5");
 assert.doesNotThrow(() => browserSdk.createDecartClient({ apiKey: "test" }));
+
+// Guard the build-time version injection: a broken injection silently ships the
+// wrong SDK version in the User-Agent (breaks version attribution in telemetry).
+const { VERSION } = await import("../dist/version.js");
+const { buildUserAgent } = await import("../dist/utils/user-agent.js");
+assert.equal(VERSION, pkg.version, `built VERSION "${VERSION}" != package.json "${pkg.version}"`);
+assert.notEqual(
+  VERSION,
+  "0.0.0-dev",
+  "VERSION fell back to the dev placeholder; build-time version injection is broken",
+);
+assert.ok(
+  buildUserAgent().includes(`decart-js-sdk/${pkg.version}`),
+  `User-Agent must carry the real version, got "${buildUserAgent()}"`,
+);
 
 const reactNativeCheck = spawnSync(
   process.execPath,

--- a/packages/sdk/tsdown.config.ts
+++ b/packages/sdk/tsdown.config.ts
@@ -12,8 +12,5 @@ export default defineConfig([
         to: "./dist/realtime/browser/frame-metadata-worker.js",
       },
     ],
-    define: {
-      __PACKAGE_VERSION__: JSON.stringify((await import("./package.json", { with: { type: "json" } })).default.version),
-    },
   },
 ]);


### PR DESCRIPTION
## What & why

Every published release of `@decartai/sdk` reported its version as `0.0.0-dev` in the outgoing User-Agent, regardless of the actual version. This broke SDK version attribution in our observability — we couldn't tell which SDK version a customer was actually running, which slowed down a live customer debugging session.

The version is now sourced reliably at build time so the User-Agent always carries the real version (e.g. `decart-js-sdk/0.1.14 …`). A build-package regression check was added so a placeholder or mismatched version can never silently ship again.

Note: this corrects all *future* releases; already-published versions keep reporting `0.0.0-dev` until a new version is cut.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow build/version wiring and test coverage only; no auth, data handling, or runtime API behavior changes beyond correct version strings in headers and telemetry.
> 
> **Overview**
> Published `@decartai/sdk` builds were shipping **`VERSION` as `0.0.0-dev`** in the User-Agent and telemetry because tsdown/rolldown rejected the **`define`** block and the old magic-token path silently fell back to a placeholder.
> 
> **`VERSION`** now comes from a real **`package.json` import** in `version.ts` (tree-shaken to the version string at build time), and the **`define`** entry is removed from **`tsdown.config.ts`**.
> 
> **`built-package.mjs`** now asserts the built **`VERSION`** matches **`package.json`**, is not the dev placeholder, and that **`buildUserAgent()`** includes `decart-js-sdk/<real version>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20cfdd8b333aafaa47be8c711217382a7921829c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->