### PR TITLE
Revert "feat(sdk): add lucy-vton-3.5 realtime and batch models (#188)"

### DIFF
--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -72,9 +72,8 @@
 - `lucy-2.5` - Real-time video editing (supports reference image)
 - `lucy-vton-2` - Real-time virtual try-on 2
 - `lucy-vton-3` - Real-time virtual try-on 3
-- `lucy-vton-3.5` - Real-time virtual try-on 3.5
 - `lucy-restyle-2` - Real-time video restyling
-- `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest` - Server-resolved aliases for the latest stable version (`lucy-vton-latest` → `lucy-vton-3.5`)
+- `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest` - Server-resolved aliases for the latest stable version (`lucy-vton-latest` → `lucy-vton-3`)
 - Deprecated: `lucy-2.1-vton-2` → `lucy-vton-2`
 
 ### Video Models (Queue API)
@@ -83,9 +82,8 @@
 - `lucy-2.5` - long-form video editing (720p)
 - `lucy-vton-2` - virtual try-on 2 video editing
 - `lucy-vton-3` - virtual try-on 3 video editing
-- `lucy-vton-3.5` - virtual try-on 3.5 video editing
 - `lucy-restyle-2` - video restyling
-- `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest`, `lucy-clip-latest` - Server-resolved aliases (`lucy-vton-latest` → `lucy-vton-3.5`)
+- `lucy-latest`, `lucy-vton-latest`, `lucy-restyle-latest`, `lucy-clip-latest` - Server-resolved aliases (`lucy-vton-latest` → `lucy-vton-3`)
 - Deprecated: `lucy-2.1-vton-2` → `lucy-vton-2`
 
 ### Image Models (Process API)

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -341,7 +341,6 @@
                     <option value="lucy-2.5">Lucy 2.5</option>
                     <option value="lucy-vton-2">Lucy VTON 2</option>
                     <option value="lucy-vton-3">Lucy VTON 3</option>
-                    <option value="lucy-vton-3.5">Lucy VTON 3.5</option>
                     <option value="lucy-restyle-2">Lucy Restyle 2</option>
                 </optgroup>
                 <optgroup label="Deprecated aliases">

--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -163,14 +163,7 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
   ? ImageEditingInputs
   : T["name"] extends "lucy-restyle-v2v" | "lucy-restyle-2"
     ? VideoRestyleInputs
-    : T["name"] extends
-          | "lucy-2.1"
-          | "lucy-2.5"
-          | "lucy-vton-2"
-          | "lucy-vton-3"
-          | "lucy-vton-3.5"
-          | "lucy-2.1-vton-2"
-          | "lucy-vton-latest"
+    : T["name"] extends "lucy-2.1" | "lucy-2.5" | "lucy-vton-2" | "lucy-vton-3" | "lucy-2.1-vton-2" | "lucy-vton-latest"
       ? VideoEdit2Inputs
       : T["name"] extends "lucy-pro-v2v" | "lucy-clip"
         ? VideoEditInputs

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -7,7 +7,6 @@ const CANONICAL_MODEL_NAMES = [
   "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
-  "lucy-vton-3.5",
   "lucy-restyle-2",
   "lucy-clip",
   "lucy-image-2",
@@ -18,7 +17,6 @@ const CANONICAL_REALTIME_MODEL_NAMES = [
   "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
-  "lucy-vton-3.5",
   "lucy-restyle-2",
 ] as const;
 const CANONICAL_VIDEO_MODEL_NAMES = [
@@ -27,7 +25,6 @@ const CANONICAL_VIDEO_MODEL_NAMES = [
   "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
-  "lucy-vton-3.5",
   "lucy-restyle-2",
 ] as const;
 const CANONICAL_IMAGE_MODEL_NAMES = ["lucy-image-2"] as const;
@@ -72,7 +69,6 @@ export const realtimeModels = z.union([
   z.literal("lucy-2.5"),
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
-  z.literal("lucy-vton-3.5"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -88,7 +84,6 @@ export const videoModels = z.union([
   z.literal("lucy-2.5"),
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
-  z.literal("lucy-vton-3.5"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -266,7 +261,6 @@ export const modelInputSchemas = {
   "lucy-2.5": videoEdit2Schema,
   "lucy-vton-2": videoEdit2Schema,
   "lucy-vton-3": videoEdit2Schema,
-  "lucy-vton-3.5": videoEdit2Schema,
   // Latest aliases (server-side resolution)
   "lucy-latest": videoEdit2Schema,
   "lucy-vton-latest": videoEdit2Schema,
@@ -375,14 +369,6 @@ const _models = {
       height: 624,
       inputSchema: z.object({}),
     },
-    "lucy-vton-3.5": {
-      urlPath: "/v1/stream",
-      name: "lucy-vton-3.5" as const,
-      fps: { ideal: 30, max: 30 },
-      width: 1088,
-      height: 624,
-      inputSchema: z.object({}),
-    },
     "lucy-restyle-2": {
       urlPath: "/v1/stream",
       name: "lucy-restyle-2" as const,
@@ -400,7 +386,7 @@ const _models = {
       height: 624,
       inputSchema: z.object({}),
     },
-    // Server-side alias currently resolves to lucy-vton-3.5.
+    // Server-side alias currently resolves to lucy-vton-3.
     "lucy-vton-latest": {
       urlPath: "/v1/stream",
       name: "lucy-vton-latest" as const,
@@ -506,15 +492,6 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-vton-3"],
     },
-    "lucy-vton-3.5": {
-      urlPath: "/v1/generate/lucy-vton-3.5",
-      queueUrlPath: "/v1/jobs/lucy-vton-3.5",
-      name: "lucy-vton-3.5" as const,
-      fps: 20,
-      width: 1088,
-      height: 624,
-      inputSchema: modelInputSchemas["lucy-vton-3.5"],
-    },
     "lucy-restyle-2": {
       urlPath: "/v1/generate/lucy-restyle-2",
       queueUrlPath: "/v1/jobs/lucy-restyle-2",
@@ -534,7 +511,7 @@ const _models = {
       height: 624,
       inputSchema: modelInputSchemas["lucy-latest"],
     },
-    // Server-side alias currently resolves to lucy-vton-3.5.
+    // Server-side alias currently resolves to lucy-vton-3.
     "lucy-vton-latest": {
       urlPath: "/v1/generate/lucy-vton-latest",
       queueUrlPath: "/v1/jobs/lucy-vton-latest",
@@ -630,7 +607,6 @@ export const models = {
    *   - `"lucy-2.5"` - Lucy 2.5 realtime video editing
    *   - `"lucy-vton-2"` - Lucy virtual try-on 2
    *   - `"lucy-vton-3"` - Lucy virtual try-on 3
-   *   - `"lucy-vton-3.5"` - Lucy virtual try-on 3.5 (latest)
    *   - `"lucy-restyle-2"` - Realtime video restyling
    */
   realtime: <T extends RealTimeModels>(model: T): ModelDefinition<T> => {
@@ -650,7 +626,6 @@ export const models = {
    *   - `"lucy-2.5"` - Long-form video editing (Lucy 2.5)
    *   - `"lucy-vton-2"` - Virtual try-on 2 video editing
    *   - `"lucy-vton-3"` - Virtual try-on 3 video editing
-   *   - `"lucy-vton-3.5"` - Virtual try-on 3.5 video editing (latest)
    *   - `"lucy-restyle-2"` - Video restyling
    */
   video: <T extends VideoModels>(model: T): ModelDefinition<T> & { fps: number; queueUrlPath: string } => {

--- a/packages/sdk/tests/e2e-realtime.test.ts
+++ b/packages/sdk/tests/e2e-realtime.test.ts
@@ -62,7 +62,6 @@ const REALTIME_MODELS: RealTimeModels[] = [
   "lucy-2.5",
   "lucy-vton-2",
   "lucy-vton-3",
-  "lucy-vton-3.5",
 ];
 
 const TIMEOUT = 1 * 60 * 1000; // 1 minute

--- a/packages/sdk/tests/e2e.test.ts
+++ b/packages/sdk/tests/e2e.test.ts
@@ -211,29 +211,6 @@ describe.concurrent("E2E Tests", { timeout: TIMEOUT, retry: 2 }, () => {
       await expectResult(result, "lucy-vton-3-reference_image", ".mp4");
     });
 
-    it("lucy-vton-3.5: virtual try-on (prompt)", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-vton-3.5"),
-        prompt: "Wearing a red leather jacket",
-        data: videoBlob,
-        seed: 42,
-      });
-
-      await expectResult(result, "lucy-vton-3.5-prompt", ".mp4");
-    });
-
-    it("lucy-vton-3.5: virtual try-on (reference_image)", async () => {
-      const result = await client.queue.submitAndPoll({
-        model: models.video("lucy-vton-3.5"),
-        prompt: "",
-        reference_image: imageBlob,
-        data: videoBlob,
-        seed: 42,
-      });
-
-      await expectResult(result, "lucy-vton-3.5-reference_image", ".mp4");
-    });
-
     // Deprecated video model names (aliases)
     it("lucy-restyle-v2v (deprecated): video restyling", async () => {
       const result = await client.queue.submitAndPoll({

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2435,7 +2435,6 @@ describe("Canonical Model Names", () => {
         "lucy-2.5",
         "lucy-vton-2",
         "lucy-vton-3",
-        "lucy-vton-3.5",
         "lucy-restyle-2",
       ]);
       expect(canonicalVideoModels.options).toEqual([
@@ -2444,7 +2443,6 @@ describe("Canonical Model Names", () => {
         "lucy-2.5",
         "lucy-vton-2",
         "lucy-vton-3",
-        "lucy-vton-3.5",
         "lucy-restyle-2",
       ]);
       expect(canonicalImageModels.options).toEqual(["lucy-image-2"]);
@@ -2504,7 +2502,7 @@ describe("Canonical Model Names", () => {
     it("lists all models when called without options", () => {
       const listedModels = listModels();
 
-      expect(listedModels).toHaveLength(27);
+      expect(listedModels).toHaveLength(25);
       expect(listedModels.some((model) => model.kind === "realtime" && model.name === "lucy-2.1")).toBe(true);
       expect(listedModels.some((model) => model.kind === "video" && model.name === "lucy-clip")).toBe(true);
       expect(listedModels.some((model) => model.kind === "image" && model.name === "lucy-image-2")).toBe(true);
@@ -2597,15 +2595,6 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-3.5 canonical name works", () => {
-      const model = models.realtime("lucy-vton-3.5");
-      expect(model.name).toBe("lucy-vton-3.5");
-      expect(model.urlPath).toBe("/v1/stream");
-      expect(model.fps).toEqual({ ideal: 30, max: 30 });
-      expect(model.width).toBe(1088);
-      expect(model.height).toBe(624);
-    });
-
     it("lucy-restyle-2 canonical name works", () => {
       const model = models.realtime("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -2659,16 +2648,6 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-3.5 as video model works", () => {
-      const model = models.video("lucy-vton-3.5");
-      expect(model.name).toBe("lucy-vton-3.5");
-      expect(model.urlPath).toBe("/v1/generate/lucy-vton-3.5");
-      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-vton-3.5");
-      expect(model.fps).toBe(20);
-      expect(model.width).toBe(1088);
-      expect(model.height).toBe(624);
-    });
-
     it("lucy-restyle-2 as video model works", () => {
       const model = models.video("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -2696,7 +2675,7 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-latest works as realtime model and resolves server-side to lucy-vton-3.5", () => {
+    it("lucy-vton-latest works as realtime model and resolves server-side to lucy-vton-3", () => {
       const model = models.realtime("lucy-vton-latest");
       expect(model.name).toBe("lucy-vton-latest");
       expect(model.urlPath).toBe("/v1/stream");
@@ -2724,7 +2703,7 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(624);
     });
 
-    it("lucy-vton-latest works as video model and resolves server-side to lucy-vton-3.5", () => {
+    it("lucy-vton-latest works as video model and resolves server-side to lucy-vton-3", () => {
       const model = models.video("lucy-vton-latest");
       expect(model.name).toBe("lucy-vton-latest");
       expect(model.urlPath).toBe("/v1/generate/lucy-vton-latest");


### PR DESCRIPTION
Reverts DecartAI/sdk#188.

lucy-vton-3.5 is being rolled back from the JS SDK. This cleanly reverts the merged squash commit that added the CanonicalModel name(s), Zod schema, `.realtime/`.video` registry entries, ModelSpecificInputs wiring, and unit/e2e tests.

Note: the published @decartai/sdk release (v0.1.15) still ships the id; this revert only returns source `main` to its pre-3.5 state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for code calling models.realtime/video("lucy-vton-3.5") against builds from main; scope is limited to model IDs and tests with no auth or data-path changes.
> 
> **Overview**
> Rolls back **`lucy-vton-3.5`** from the JS SDK after the prior add-3.5 change, so `main` no longer exposes that id for realtime or queue/video APIs.
> 
> **Registry & types:** The model is dropped from canonical name lists, Zod `realtime`/`video` unions, `modelInputSchemas`, and the internal realtime/video `_models` maps (including generate/job URL paths). `ModelSpecificInputs` no longer treats `lucy-vton-3.5` as `VideoEdit2Inputs`. Comments and **AGENTS.md** now document **`lucy-vton-latest` → `lucy-vton-3`** (not 3.5).
> 
> **Surface area:** The SDK demo **`index.html`** model picker no longer lists Lucy VTON 3.5. Unit tests drop 3.5 coverage and expect **`listModels()`** to return **25** entries (was 27); e2e realtime and queue tests for **`lucy-vton-3.5`** are removed.
> 
> **Note:** A published release may still ship 3.5 until a new publish; this revert only affects source on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eaf73f78c535f022a486546b220045ea09168ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->