### PR TITLE
feat(realtime): scale uplink maxBitrate with publish fps below 15 fps

### DIFF
--- a/packages/sdk/src/realtime/browser/prepare-connection.ts
+++ b/packages/sdk/src/realtime/browser/prepare-connection.ts
@@ -79,6 +79,7 @@ export const prepareBrowserConnection: PrepareConnection = ({
     createMediaChannel: (config) =>
       createLiveKitMediaChannel({
         ...config,
+        publishFps: fps,
         createFrameMetadataWorker: frameTiming ? takeFrameMetadataWorker : undefined,
       }),
     dispose: () => {

--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -35,6 +35,22 @@ export const REALTIME_CONFIG = {
     defaultMaxVideoBitrateBps: 3_500_000,
     vp9MaxVideoBitrateBps: 3_000_000,
     defaultPublishFps: 30,
+    /**
+     * Low-fps uplink bitrate scaling (measured 2026-07-28, api repo
+     * experiments/2026-07-28-livekit-size-vs-interval-jb). The encoder spends
+     * its per-SECOND budget regardless of cadence, so a 10 fps publisher packs
+     * ~3x the bytes into every frame; the frames' wire-arrival span then
+     * inflates the server's ingest jitter buffer by ~35-100 ms. Scaling the
+     * cap to ~200 kbit per frame restores 30 fps-parity ingest latency at
+     * equal-or-better QP (measured: 10 fps hold 129.7 -> 28.4 ms, e2e
+     * 660 -> 557 ms from us-east4). At >=15 fps the natural rate is already
+     * optimal and a binding cap measurably hurts (rate-controller churn), so
+     * scaling only engages BELOW the threshold; the floor keeps the encoder
+     * far from the simulcast layer-starvation cliff.
+     */
+    lowFpsBitrateScaleBelowFps: 15,
+    lowFpsBitsPerFrame: 200_000,
+    lowFpsMinBitrateBps: 1_000_000,
   },
   observability: {
     stallFpsThreshold: 0.5,

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -19,12 +19,26 @@ export function getDefaultVideoPublishOptions(
   source: TrackPublishOptions["source"],
   videoCodec?: VideoCodec,
   frameMetadata = false,
+  publishFps?: number,
 ): TrackPublishOptions {
   const resolvedCodec = videoCodec ?? REALTIME_CONFIG.livekit.defaultVideoCodec;
-  const maxBitrate =
+  const naturalBitrate =
     resolvedCodec === "vp9"
       ? REALTIME_CONFIG.livekit.vp9MaxVideoBitrateBps
       : REALTIME_CONFIG.livekit.defaultMaxVideoBitrateBps;
+  // The encoder spends its per-second budget regardless of cadence, so at low
+  // publish rates a fixed cap packs into oversized frames whose wire-arrival
+  // span inflates the server's ingest jitter buffer. Scale the cap to
+  // ~constant bits-per-frame below the threshold; at >=15 fps the natural
+  // rate is optimal and a binding cap hurts, so leave it untouched.
+  const fps = publishFps ?? REALTIME_CONFIG.livekit.defaultPublishFps;
+  const maxBitrate =
+    fps < REALTIME_CONFIG.livekit.lowFpsBitrateScaleBelowFps
+      ? Math.max(
+          REALTIME_CONFIG.livekit.lowFpsMinBitrateBps,
+          Math.min(naturalBitrate, Math.round(fps * REALTIME_CONFIG.livekit.lowFpsBitsPerFrame)),
+        )
+      : naturalBitrate;
 
   return {
     source,
@@ -48,6 +62,8 @@ export interface MediaChannelConfig {
   localStream: MediaStream | null;
   logger?: Logger;
   videoCodec?: VideoCodec;
+  /** Intended publish cadence (fps) — scales the uplink maxBitrate below 15 fps. */
+  publishFps?: number;
   createFrameMetadataWorker?: () => Worker;
 }
 
@@ -192,7 +208,7 @@ export class LiveKitMediaChannel implements MediaChannel {
         if (!this.cameraTrackSource) throw new Error("Cannot publish video track: media channel is not connected");
         await this.room.localParticipant.publishTrack(
           track,
-          getDefaultVideoPublishOptions(this.cameraTrackSource, this.config.videoCodec, this.frameMetadataEnabled),
+          getDefaultVideoPublishOptions(this.cameraTrackSource, this.config.videoCodec, this.frameMetadataEnabled, this.config.publishFps),
         );
       } else {
         await this.room.localParticipant.publishTrack(track);

--- a/packages/sdk/tests/publish-options.unit.test.ts
+++ b/packages/sdk/tests/publish-options.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime";
+import { getDefaultVideoPublishOptions } from "../src/realtime/media-channel";
+
+const NATURAL_H264 = REALTIME_CONFIG.livekit.defaultMaxVideoBitrateBps;
+const NATURAL_VP9 = REALTIME_CONFIG.livekit.vp9MaxVideoBitrateBps;
+
+describe("getDefaultVideoPublishOptions low-fps bitrate scaling", () => {
+  it("keeps the natural bitrate at the default 30 fps", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "h264", false, 30);
+    expect(opts.videoEncoding?.maxBitrate).toBe(NATURAL_H264);
+  });
+
+  it("keeps the natural bitrate when fps is omitted (registry models)", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "h264", false);
+    expect(opts.videoEncoding?.maxBitrate).toBe(NATURAL_H264);
+  });
+
+  it("does NOT engage at 15 fps (binding caps measurably hurt at >=15 fps)", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "h264", false, 15);
+    expect(opts.videoEncoding?.maxBitrate).toBe(NATURAL_H264);
+  });
+
+  it("scales to ~200 kbit/frame at 10 fps", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "h264", false, 10);
+    expect(opts.videoEncoding?.maxBitrate).toBe(10 * REALTIME_CONFIG.livekit.lowFpsBitsPerFrame);
+  });
+
+  it("never drops below the viability floor at very low fps", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "h264", false, 2);
+    expect(opts.videoEncoding?.maxBitrate).toBe(REALTIME_CONFIG.livekit.lowFpsMinBitrateBps);
+  });
+
+  it("never exceeds the codec's natural bitrate", () => {
+    const opts = getDefaultVideoPublishOptions("camera", "vp9", false, 14.9);
+    expect(opts.videoEncoding?.maxBitrate).toBeLessThanOrEqual(NATURAL_VP9);
+  });
+});


### PR DESCRIPTION
## What

`getDefaultVideoPublishOptions` derives the uplink `maxBitrate` from the intended publish fps instead of using the static 3.5M cap, engaging **only below 15 fps**:

| declared fps | maxBitrate | bits/frame | change |
|---|---|---|---|
| 30 (all registry models today) | 3.5M | ~117kbit | **none — byte-identical** |
| ≥15 | 3.5M | ≤233kbit | **none** |
| 10 | 2.0M | 200kbit | new |
| ≤5 | 1.0M floor | — | new |

The fps is threaded from `prepareBrowserConnection` (which already receives `resolveFpsNumber(model.fps)` for the mirror canvas) into the media-channel factory. React-native path unchanged (no `publishFps` → natural rate).

## Why

Chrome's encoder spends its per-**second** budget regardless of cadence, so a 10 fps publisher packs ~3× the bytes into every frame (44KB vs 14KB). Those frames' wire-arrival span inflates the server's ingest jitter buffer — measured **+98ms at 10 fps** on a clean path. Scaling to ~200kbit/frame restores full 30 fps-parity:

| 10 fps arm (GCP us-east4 → us-east-1 SFU → usw2 test-pool) | ingest hold p50 | server residency | e2e p50 | uplink QP |
|---|---|---|---|---|
| default 3.5M (today) | 129.7 | 505 | 660 | 14.2 |
| capped 2.0M (this PR) | **28.4** | **403** (= 30fps parity) | **557** | 18.1 |

Full causal A/B (19 sessions, size vs interval decomposition, dose–response, both IL and us-east4 clients): `DecartAI/api` → `experiments/2026-07-28-livekit-size-vs-interval-jb/` (branch `eilon/feature/lk-input-latency`).

Guardrail evidence baked into the constants: at ≥15 fps a binding cap measurably *hurts* (rate-controller churn, +32ms), and very low caps hit the simulcast layer-starvation cliff — hence the 15 fps threshold and the 1M floor.

## Tests

- `tests/publish-options.unit.test.ts` — 6 new unit tests (threshold, scaling, floor, natural-rate ceiling, omitted-fps fallback), all green.
- `pnpm typecheck` / suite: the pre-existing `frame-metadata-diagnostics.ts` typecheck error and the msw `unit.test.ts` env failure exist identically on `origin/main` — not introduced here (verified via stash A/B).

## Follow-up (separate PR)

This covers *declared* low-fps models. Users whose camera *actually* delivers <15 fps while the model declares 30 need the measured-fps adaptive loop (`sender.getStats()` → live `setParameters` re-apply with hysteresis) — mechanism already validated by the probe's cap loop.

**Linear (Platform team):** [PLA-660](https://linear.app/decart/issue/PLA-660/sdk-scale-uplink-maxbitrate-with-publish-fps-15fps-kills-the-low-fps)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches realtime uplink encoding for all browser sessions where fps is passed, but the scaling gate limits behavior change to declared fps below 15 fps; default registry paths remain unchanged.
> 
> **Overview**
> **Low-fps models** now get a **dynamic uplink `maxBitrate`** instead of the fixed 3.5M cap. `getDefaultVideoPublishOptions` scales toward ~200 kbit/frame when declared publish fps is **below 15**, with a **1M floor** and the existing codec ceiling; at **≥15 fps** or when fps is omitted, behavior stays **byte-identical** to today.
> 
> Browser setup passes the model’s intended **`publishFps`** from `prepareBrowserConnection` into `createLiveKitMediaChannel`, so LiveKit publish options reflect declared cadence. New **`REALTIME_CONFIG.livekit`** knobs document the threshold and scaling constants.
> 
> **Tests:** `publish-options.unit.test.ts` covers threshold, scaling, floor, ceiling, and omitted-fps fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b18b6acbde1238346d223b0809758a163d087a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
