### PR TITLE
Revert "Enable browser G2G latency measurement by default"

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -88,18 +88,6 @@ A connected realtime session exposes an SDK `subscribeToken` once it reaches a
 connected state. Share that SDK token with viewers — `client.realtime.subscribe`
 uses it to request receive-only LiveKit credentials from Decart, then connects to
 the LiveKit room for the styled output stream. No viewer camera is required.
-Browser-produced streams can include LiveKit frame metadata for glass-to-glass
-latency, so viewers also need a browser runtime that can create the SDK's
-frame-metadata worker; unsupported runtimes reject those tokens before joining.
-
-> **Viewers must be on this SDK version or newer.** A browser publisher now
-> advertises frame timing by default, which makes the server append a packet
-> trailer to every frame in the room. Viewers on an older `@decartai/sdk`
-> ignore the token's `frame_timing` flag and join without a strip worker — they
-> connect successfully but decode nothing, so the video element stays black with
-> no error raised. React Native viewers cannot strip trailers at all and are
-> rejected with `UNSUPPORTED_PLATFORM_FEATURE`. Upgrade viewers before upgrading
-> publishers.
 
 **Producer** — capture the token from the active session:
 
@@ -187,12 +175,12 @@ realtimeClient.getConnectionQuality(); // latest report, or null before the firs
 > setInterval(() => console.log(realtimeClient.getConnectionQuality()?.metrics.g2gMs), 1000);
 > ```
 
-**Glass-to-glass latency.** Network RTT hides the dominant cost in real-time video — model
-inference — so a session can read "good" while actually feeling laggy. In browser sessions, the SDK
-automatically attaches a capture timestamp using LiveKit frame metadata when the required worker is
-available; the server propagates it through inference and the SDK matches it to output playout.
-This surfaces **startup** (`ttffMs`) and **steady-state** (`g2gMs`) latency. When present,
-glass-to-glass drives the latency verdict instead of RTT.
+**Glass-to-glass latency (opt-in, diagnostic).** Network RTT hides the dominant cost in
+real-time video — model inference — so a session can read "good" while actually feeling laggy.
+Set `debugQuality: true` to measure the *real* camera→display latency. The SDK attaches a capture
+timestamp using LiveKit frame metadata; the server propagates it through inference and the SDK
+matches it to output playout. This surfaces **startup** (`ttffMs`) and **steady-state**
+(`g2gMs`) latency. When present, glass-to-glass drives the latency verdict instead of RTT.
 
 > Frame metadata is currently experimental in LiveKit and requires encoded-transform support.
 > It does not alter visible pixels. `g2gDropRatio` remains `null` until frame IDs are propagated
@@ -201,6 +189,7 @@ glass-to-glass drives the latency verdict instead of RTT.
 ```typescript
 const realtimeClient = await client.realtime.connect(stream, {
   model,
+  debugQuality: true,
 });
 
 // g2g updates every stats tick — read it from the `stats` event (the
@@ -349,9 +338,9 @@ Add them to `app.json`:
 Run `npx expo prebuild` and rebuild the native app. LiveKit does not run in Expo
 Go. Bare React Native apps must follow LiveKit's native setup instructions.
 
-Outgoing `mirror` and deep connectivity preflight are browser-only and fail with
-`UNSUPPORTED_PLATFORM_FEATURE` on React Native. Mirror the local preview with your
-native video view instead.
+Outgoing `mirror`, `debugQuality`, and deep connectivity preflight are browser-only
+and fail with `UNSUPPORTED_PLATFORM_FEATURE` on React Native. Mirror the local
+preview with your native video view instead.
 
 ## Development
 

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -364,6 +364,12 @@
             </select>
         </div>
         <div class="control-group">
+            <label>
+                <input type="checkbox" id="measure-g2g" />
+                Measure glass-to-glass latency (frame metadata; opt-in)
+            </label>
+        </div>
+        <div class="control-group">
             <label for="passthrough-select">Passthrough (initial):</label>
             <select id="passthrough-select">
                 <option value="" selected>Default (auto — on when no initial state)</option>
@@ -653,6 +659,7 @@
             connectionQualityBadge: document.getElementById('connection-quality-badge'),
             connectionQualityDetail: document.getElementById('connection-quality-detail'),
             // Connectivity preflight elements
+            measureG2g: document.getElementById('measure-g2g'),
             checkConnectivityBtn: document.getElementById('check-connectivity-btn'),
             activeProbeBtn: document.getElementById('active-probe-btn'),
             connectivityResult: document.getElementById('connectivity-result'),
@@ -1225,6 +1232,11 @@
                     addLog(`Preferred video codec: ${preferredVideoCodec}`, 'info');
                 }
 
+                const debugQuality = elements.measureG2g.checked;
+                if (debugQuality) {
+                    addLog('Debug-quality (glass-to-glass) measurement ON via frame metadata', 'info');
+                }
+
                 const passthroughChoice = elements.passthroughSelect.value;
                 const passthrough = passthroughChoice === '' ? undefined : passthroughChoice === 'true';
                 addLog(`Initial passthrough: ${passthrough === undefined ? 'default (auto)' : passthrough}`, 'info');
@@ -1233,6 +1245,7 @@
                     model,
                     resolution,
                     ...(preferredVideoCodec && { preferredVideoCodec }),
+                    ...(debugQuality && { debugQuality: true }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');
                         elements.remoteVideo.srcObject = stream;

--- a/packages/sdk/src/realtime/browser/frame-metadata-diagnostics.ts
+++ b/packages/sdk/src/realtime/browser/frame-metadata-diagnostics.ts
@@ -67,15 +67,6 @@ export class FrameMetadataTracker {
 
 const TIME_SYNC_UPDATE = "timeSyncUpdate" as TrackEvent.TimeSyncUpdate;
 
-type LiveKitFrameMetadata = {
-  userTimestamp: bigint;
-  frameId?: number;
-};
-
-type FrameMetadataTrack = RemoteVideoTrack & {
-  lookupFrameMetadata?: (options: { rtpTimestamp: number }) => LiveKitFrameMetadata | undefined;
-};
-
 function createFrameReader(tracker: FrameMetadataTracker): {
   attach(track: RemoteVideoTrack): void;
   detach(): void;
@@ -84,11 +75,11 @@ function createFrameReader(tracker: FrameMetadataTracker): {
   let attachedTrack: RemoteVideoTrack | null = null;
 
   const onTimeSyncUpdate = ({ timestamp, rtpTimestamp }: { timestamp: number; rtpTimestamp: number }) => {
-    const frameMetadata = (attachedTrack as FrameMetadataTrack | null)?.lookupFrameMetadata?.({ rtpTimestamp });
-    // `timestamp` is the sync-source playout time, already specified as
-    // `performance.timeOrigin + performance.now()` (epoch ms), so it lines up
-    // with the publisher's epoch `userTimestamp` and the epoch `startMs` as-is.
-    if (frameMetadata) tracker.recordFrame(frameMetadata.userTimestamp, timestamp);
+    const frameMetadata = attachedTrack?.lookupFrameMetadata({ rtpTimestamp });
+    // `timestamp` is the sync-source playout time as a DOMHighResTimeStamp
+    // (relative to performance.timeOrigin); convert to epoch ms so it lines up
+    // with the publisher's epoch `userTimestamp` and the epoch `startMs`.
+    if (frameMetadata) tracker.recordFrame(frameMetadata.userTimestamp, performance.timeOrigin + timestamp);
   };
 
   const detach = () => {
@@ -127,20 +118,4 @@ export function createBrowserFrameMetadataDiagnostics(): GlassToGlassDiagnostics
 
 export function createFrameMetadataWorker(): Worker {
   return new Worker(new URL("./frame-metadata-worker.js", import.meta.url));
-}
-
-export function isFrameMetadataRuntimeSupported(): boolean {
-  if (typeof window === "undefined") return false;
-  const maybeWindow = window as typeof window & {
-    RTCRtpScriptTransform?: unknown;
-    RTCRtpSender?: { prototype?: { createEncodedStreams?: unknown } };
-    RTCRtpReceiver?: { prototype?: { createEncodedStreams?: unknown } };
-  };
-  const userAgent = window.navigator?.userAgent?.toLowerCase() ?? "";
-  const isChromiumBased = /(?:chrome|chromium|crmo)\//.test(userAgent) && !/crios\//.test(userAgent);
-  const scriptTransformSupported = typeof maybeWindow.RTCRtpScriptTransform !== "undefined" && !isChromiumBased;
-  const insertableStreamsSupported =
-    typeof maybeWindow.RTCRtpSender?.prototype?.createEncodedStreams !== "undefined" &&
-    typeof maybeWindow.RTCRtpReceiver?.prototype?.createEncodedStreams !== "undefined";
-  return scriptTransformSupported || insertableStreamsSupported;
 }

--- a/packages/sdk/src/realtime/browser/index.ts
+++ b/packages/sdk/src/realtime/browser/index.ts
@@ -1,7 +1,6 @@
 import { createRealTimeClient, type RealTimeClientConnectOptions } from "../client";
 import type { CreateRealtime } from "../factory";
 import { createRealTimeSubscribeClient } from "../subscribe-client";
-import { createFrameMetadataWorker, isFrameMetadataRuntimeSupported } from "./frame-metadata-diagnostics";
 import { createPreflight } from "./preflight";
 import { prepareBrowserConnection } from "./prepare-connection";
 
@@ -19,8 +18,6 @@ export const createBrowserRealtime: CreateRealtime = (options) => {
     apiKey: options.apiKey,
     integration: options.integration,
     logger: options.logger,
-    createFrameMetadataWorker,
-    isFrameMetadataRuntimeSupported,
   });
   const preflight = createPreflight({ logger: options.logger, connect: publish.connect });
 

--- a/packages/sdk/src/realtime/browser/preflight.ts
+++ b/packages/sdk/src/realtime/browser/preflight.ts
@@ -261,6 +261,7 @@ async function runActiveProbe(args: {
 
     const connectTask = connect(source.stream, {
       model,
+      debugQuality: true,
       onRemoteStream: () => {},
     });
     signal?.addEventListener("abort", () => connectTask.then((c) => c.disconnect()).catch(() => {}), {

--- a/packages/sdk/src/realtime/browser/prepare-connection.ts
+++ b/packages/sdk/src/realtime/browser/prepare-connection.ts
@@ -2,16 +2,13 @@ import { isDesktopSafari } from "../../utils/platform";
 import type { PrepareConnection } from "../client";
 import { createLiveKitMediaChannel } from "../media-channel";
 import { RealtimeObservability } from "../observability/realtime-observability";
-import {
-  createBrowserFrameMetadataDiagnostics,
-  createFrameMetadataWorker,
-  isFrameMetadataRuntimeSupported,
-} from "./frame-metadata-diagnostics";
+import { createBrowserFrameMetadataDiagnostics, createFrameMetadataWorker } from "./frame-metadata-diagnostics";
 import { createMirroredStream, shouldMirrorTrack } from "./mirror-stream";
 
 export const prepareBrowserConnection: PrepareConnection = ({
   stream,
   mirror,
+  debugQuality,
   preferredVideoCodec,
   fps,
   logger,
@@ -44,16 +41,14 @@ export const prepareBrowserConnection: PrepareConnection = ({
   // strip it and the VP8/VP9 decoder then fails on every frame. Worker
   // availability is environment-deterministic, so this also predicts reconnects.
   let pendingWorker: Worker | undefined;
-  if (isFrameMetadataRuntimeSupported()) {
+  if (debugQuality) {
     try {
       pendingWorker = createFrameMetadataWorker();
     } catch (error) {
-      logger.debug("Frame-metadata worker unavailable; glass-to-glass latency measurement disabled", {
+      logger.warn("Frame-metadata worker unavailable; glass-to-glass latency measurement disabled", {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  } else {
-    logger.debug("Frame-metadata runtime unavailable; glass-to-glass latency measurement disabled");
   }
   const frameTiming = pendingWorker !== undefined;
   // Hand the pre-created worker to the first connect, then create a fresh one

--- a/packages/sdk/src/realtime/client.ts
+++ b/packages/sdk/src/realtime/client.ts
@@ -42,6 +42,7 @@ export type PreparedConnection = {
 export type PrepareConnection = (options: {
   stream: MediaStream | null;
   mirror: "auto" | boolean;
+  debugQuality: boolean;
   preferredVideoCodec?: VideoCodec;
   fps: number;
   logger: Logger;
@@ -82,9 +83,11 @@ const realTimeClientConnectOptionsSchema = z.object({
   /** Local track publish codec. Desktop Safari is always pinned to vp8 and ignores this value. */
   preferredVideoCodec: z.enum(["h264", "vp8", "vp9"]).optional(),
   /**
-   * @deprecated Glass-to-glass measurement now runs automatically in browsers
-   * when LiveKit frame metadata is available. This legacy flag is accepted for
-   * compatibility and no longer gates measurement.
+   * Opt-in quality measurement using LiveKit frame metadata. The capture
+   * timestamp is propagated through inference and matched to output playout to
+   * surface true glass-to-glass `g2gMs` / `ttffMs` on the `stats` and
+   * `connectionQuality` signals. Browser-only and experimental because it
+   * relies on LiveKit's frame-metadata worker and encoded transforms.
    */
   debugQuality: z.boolean().optional(),
 });
@@ -156,6 +159,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       preferredVideoCodec,
     } = parsedOptions.data;
     const mirror = parsedOptions.data.mirror ?? false;
+    const debugQuality = parsedOptions.data.debugQuality ?? false;
 
     let session: StreamSession | undefined;
     let observability: RealtimeObservability | undefined;
@@ -175,6 +179,7 @@ export const createRealTimeClient = (opts: RealTimeClientOptions) => {
       preparedConnection = opts.prepareConnection({
         stream,
         mirror,
+        debugQuality,
         preferredVideoCodec: preferredVideoCodec as VideoCodec | undefined,
         fps: resolveFpsNumber(options.model.fps),
         logger,

--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -19,7 +19,6 @@ export const REALTIME_CONFIG = {
       "401",
       "invalid api key",
       "unauthorized",
-      "failed to create livekit frame-metadata worker",
     ],
   },
   methods: {

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -101,13 +101,9 @@ export class LiveKitMediaChannel implements MediaChannel {
         try {
           worker = this.config.createFrameMetadataWorker();
         } catch (error) {
-          const detail = error instanceof Error ? error.message : String(error);
-          this.logger.warn("Failed to create LiveKit frame-metadata worker", { error: detail });
-          // The server is already appending packet trailers for this session, so
-          // continuing without a strip transform would decode to garbage. Worker
-          // availability is environment-deterministic, so a retry can't recover
-          // either — surface it as permanent (see `permanentErrorSubstrings`).
-          throw new Error(`Failed to create LiveKit frame-metadata worker: ${detail}`, { cause: error });
+          this.logger.warn("Failed to create LiveKit frame-metadata worker; continuing without latency metrics", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
       }
       this.frameMetadataEnabled = worker !== undefined;
@@ -130,8 +126,8 @@ export class LiveKitMediaChannel implements MediaChannel {
 
       const mediaStreamTrack = track.mediaStreamTrack;
       if (mediaStreamTrack) {
-        // Feed the LiveKit track to the frame-metadata render reader when
-        // browser frame metadata is available.
+        // Feed the LiveKit track to the frame-metadata render reader (a no-op
+        // unless opt-in glass-to-glass measurement is enabled).
         if (track.kind === "video") {
           this.config.observability?.attachRemoteVideoTrack(track as RemoteVideoTrack);
         }

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -20,10 +20,10 @@ export type ConnectionQualityMetrics = {
   rttMs: number | null;
   /**
    * Mid-stream (steady-state) glass-to-glass latency (ms) — the real per-frame
-   * camera→display latency through the model, excluding startup. Populated in
-   * browser sessions when LiveKit frame metadata is available and past warm-up;
-   * null otherwise. When present it drives the latency verdict instead of
-   * `rttMs`.
+   * camera→display latency through the model, excluding startup. Only populated
+   * when the opt-in frame-metadata measurement is on (`connect({ debugQuality: true })`)
+   * and past warm-up; null otherwise. When present it drives the latency verdict
+   * instead of `rttMs`.
    */
   g2gMs: number | null;
   /**
@@ -144,7 +144,7 @@ export function scoreMetrics(
   options: ScoreOptions = {},
 ): { quality: ConnectionQuality; limitingFactor: ConnectionQualityLimitingFactor } {
   // Prefer measured glass-to-glass — the real experienced latency — when the
-  // frame-metadata measurement is active. It already includes both network
+  // opt-in frame-metadata measurement is active. It already includes both network
   // legs, so relay headroom doesn't apply. Fall back to RTT otherwise.
   const relayExtra = signals.isRelayed ? thresholds.rtt.relayExtraMs : 0;
   const latency =

--- a/packages/sdk/src/realtime/observability/webrtc-stats.ts
+++ b/packages/sdk/src/realtime/observability/webrtc-stats.ts
@@ -133,8 +133,9 @@ export type WebRTCStats = {
   };
   /**
    * True glass-to-glass latency + end-to-end drop signal, merged in by
-   * `RealtimeObservability` when frame-metadata measurement is active. Null
-   * otherwise — the stats collector does not populate it.
+   * `RealtimeObservability` when the opt-in frame-metadata measurement is active.
+   * Null otherwise — the stats collector does not
+   * populate it.
    */
   glassToGlass: G2GMetrics | null;
 };

--- a/packages/sdk/src/realtime/react-native/prepare-connection.ts
+++ b/packages/sdk/src/realtime/react-native/prepare-connection.ts
@@ -16,11 +16,13 @@ export function unsupportedReactNativeFeature(feature: string): never {
 export const prepareReactNativeConnection: PrepareConnection = ({
   stream,
   mirror,
+  debugQuality,
   preferredVideoCodec,
   observability: observabilityOptions,
 }) => {
   assertReactNativeReady();
   if (mirror !== false) unsupportedReactNativeFeature("Outgoing video mirroring");
+  if (debugQuality) unsupportedReactNativeFeature("debugQuality");
 
   return {
     stream: stream ?? new MediaStream(),

--- a/packages/sdk/src/realtime/stream-session.ts
+++ b/packages/sdk/src/realtime/stream-session.ts
@@ -27,8 +27,8 @@ type RetryAttemptError = Error & {
 
 type ConnectionLossCause = Record<string, unknown>;
 
-export function encodeSubscribeToken(roomName: string, options: { frameTiming?: boolean } = {}): string {
-  return btoa(JSON.stringify({ room_name: roomName, ...(options.frameTiming ? { frame_timing: true } : {}) }));
+export function encodeSubscribeToken(roomName: string): string {
+  return btoa(JSON.stringify({ room_name: roomName }));
 }
 
 function getInitialImageSizeKb(image: string | null | undefined): number | null {
@@ -217,7 +217,7 @@ export class StreamSession {
       this.setState("connected");
       this.events.emit("sessionStarted", {
         sessionId: roomInfo.sessionId,
-        subscribeToken: encodeSubscribeToken(roomInfo.roomName, { frameTiming: this.config.frameTiming }),
+        subscribeToken: encodeSubscribeToken(roomInfo.roomName),
       });
     } catch (error) {
       this.config.observability?.finishConnectionBreakdown({

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -1,6 +1,6 @@
 import type { RemoteParticipant, RemoteTrack, Room } from "livekit-client";
 
-import { classifyWebrtcError, createSDKError, type DecartSDKError, ERROR_CODES } from "../utils/errors";
+import { classifyWebrtcError, type DecartSDKError } from "../utils/errors";
 import { createConsoleLogger, type Logger } from "../utils/logger";
 import { REALTIME_CONFIG } from "./config-realtime";
 import { createEventBuffer } from "./event-buffer";
@@ -11,7 +11,6 @@ import type { ConnectionState } from "./types";
 
 type TokenPayload = {
   room_name: string;
-  frame_timing?: boolean;
 };
 
 type WatchStreamResponse = {
@@ -26,31 +25,13 @@ type WatchStreamCredentialsRequest = {
   roomName: string;
 };
 
-function isDecartSDKError(error: unknown): error is DecartSDKError {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    typeof (error as Partial<DecartSDKError>).code === "string" &&
-    typeof (error as Partial<DecartSDKError>).message === "string"
-  );
-}
-
-function createFrameMetadataSubscribeUnsupportedError(detail?: string): DecartSDKError {
-  const suffix = detail ? `: ${detail}` : "";
-  return createSDKError(
-    ERROR_CODES.UNSUPPORTED_PLATFORM_FEATURE,
-    `This realtime stream requires LiveKit frame metadata, which this SDK environment does not support${suffix}.`,
-    { feature: "LiveKit frame metadata subscribe", platform: "this SDK environment" },
-  );
-}
-
 export function decodeSubscribeToken(token: string): TokenPayload {
   try {
     const payload = JSON.parse(atob(token)) as Partial<TokenPayload>;
     if (!payload.room_name || typeof payload.room_name !== "string") {
       throw new Error("Invalid subscribe token format");
     }
-    return { room_name: payload.room_name, ...(payload.frame_timing === true ? { frame_timing: true } : {}) };
+    return { room_name: payload.room_name };
   } catch {
     throw new Error("Invalid subscribe token");
   }
@@ -81,8 +62,6 @@ export type RealTimeSubscribeClientOptions = {
   apiKey: string;
   integration?: string;
   logger: Logger;
-  createFrameMetadataWorker?: () => Worker;
-  isFrameMetadataRuntimeSupported?: () => boolean;
 };
 
 function mapLiveKitState(state: string): ConnectionState {
@@ -129,12 +108,11 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
   const logger = opts.logger ?? createConsoleLogger("info");
 
   const subscribe = async (options: SubscribeOptions): Promise<RealTimeSubscribeClient> => {
-    const { room_name: roomName, frame_timing: frameTiming } = decodeSubscribeToken(options.token);
+    const { room_name: roomName } = decodeSubscribeToken(options.token);
     const { emitter, emitOrBuffer, flush, stop } = createEventBuffer<SubscribeEvents>();
 
     let observability: RealtimeObservability | undefined;
     let room: Room | undefined;
-    let frameMetadataWorker: Worker | undefined;
     let currentState: ConnectionState = "connecting";
     let remoteStream: MediaStream | null = null;
 
@@ -159,36 +137,7 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
 
       const creds = await fetchWatchStreamCredentials({ baseUrl, apiKey, roomName });
 
-      // The publisher advertised frame timing, so the server appends a packet
-      // trailer to every frame in this room. Without a strip worker the decoder
-      // fails on every frame, so refuse the token rather than join and leave the
-      // consumer staring at a permanently black video element.
-      if (frameTiming) {
-        if (!opts.createFrameMetadataWorker) {
-          throw createFrameMetadataSubscribeUnsupportedError("this platform has no frame-metadata worker");
-        }
-        if (!(opts.isFrameMetadataRuntimeSupported?.() ?? false)) {
-          throw createFrameMetadataSubscribeUnsupportedError("encoded transforms are unavailable");
-        }
-        try {
-          frameMetadataWorker = opts.createFrameMetadataWorker();
-        } catch (error) {
-          throw createFrameMetadataSubscribeUnsupportedError(
-            `failed to create the required worker (${error instanceof Error ? error.message : String(error)})`,
-          );
-        }
-      }
-
-      try {
-        room = new LiveKitRoom({
-          ...REALTIME_CONFIG.livekit.roomOptions,
-          ...(frameMetadataWorker ? { frameMetadata: { worker: frameMetadataWorker } } : {}),
-        });
-      } catch (error) {
-        frameMetadataWorker?.terminate();
-        frameMetadataWorker = undefined;
-        throw error;
-      }
+      room = new LiveKitRoom(REALTIME_CONFIG.livekit.roomOptions);
       const activeRoom = room;
 
       activeRoom.on(RoomEvent.TrackSubscribed, (track: RemoteTrack, _pub, participant: RemoteParticipant) => {
@@ -227,9 +176,6 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
         disconnect: () => {
           observability?.stop();
           stop();
-          // No explicit worker terminate: once the worker is handed to the Room,
-          // LiveKit's FrameMetadataManager owns it and terminates it on
-          // RoomEvent.Disconnected. Terminating here would double-free.
           activeRoom.disconnect().catch(() => {});
         },
         on: emitter.on,
@@ -242,11 +188,6 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
       observability?.stop();
       if (room) {
         room.disconnect().catch(() => {});
-      }
-      frameMetadataWorker?.terminate();
-      if (isDecartSDKError(error)) {
-        logger.error("Realtime subscribe error", { error: error.message });
-        throw error;
       }
       const err = error instanceof Error ? error : new Error(String(error));
       logger.error("Realtime subscribe error", { error: err.message });

--- a/packages/sdk/tests/built-package.mjs
+++ b/packages/sdk/tests/built-package.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { access } from "node:fs/promises";
 import pkg from "../package.json" with { type: "json" };
 
 for (const name of ["File", "Blob", "ReadableStream", "WritableStream", "TransformStream", "DOMException"]) {
@@ -25,11 +24,6 @@ assert.ok(
   buildUserAgent().includes(`decart-js-sdk/${pkg.version}`),
   `User-Agent must carry the real version, got "${buildUserAgent()}"`,
 );
-
-// The browser bundle creates this worker automatically for LiveKit frame
-// metadata. Missing it would make the SDK advertise frame timing without a
-// usable strip transform in package consumers.
-await access(new URL("../dist/realtime/browser/frame-metadata-worker.js", import.meta.url));
 
 const reactNativeCheck = spawnSync(
   process.execPath,

--- a/packages/sdk/tests/frame-metadata-diagnostics.unit.test.ts
+++ b/packages/sdk/tests/frame-metadata-diagnostics.unit.test.ts
@@ -55,22 +55,6 @@ describe("FrameMetadataTracker", () => {
     expect(tracker.snapshot().medianMs).toBe(175);
   });
 
-  it("keeps measuring throughout the session with a rolling latency window", () => {
-    const tracker = new FrameMetadataTracker();
-    tracker.recordFrame(captureTimestamp(0, 100), performance.timeOrigin);
-
-    for (let latency = 0; latency < 350; latency++) {
-      const playoutRelMs = PAST_WARMUP + latency;
-      tracker.recordFrame(captureTimestamp(playoutRelMs, latency), performance.timeOrigin + playoutRelMs);
-    }
-
-    expect(tracker.snapshot()).toMatchObject({
-      medianMs: 200,
-      p90Ms: 320,
-      sampleCount: 300,
-    });
-  });
-
   it("ignores missing and implausible timestamps", () => {
     const tracker = new FrameMetadataTracker();
     tracker.recordFrame(0n, performance.timeOrigin);
@@ -103,11 +87,10 @@ describe("FrameMetadataTracker", () => {
 
   it("correlates LiveKit time-sync events and detaches the listener on reconnect", () => {
     const listeners = new Map<string, (update: { timestamp: number; rtpTimestamp: number }) => void>();
-    // LiveKit's timeSyncUpdate `timestamp` comes from
-    // RTCRtpContributingSource.timestamp, which the spec defines as
-    // `performance.timeOrigin + performance.now()` — i.e. already epoch ms,
-    // matching userTimestamp's epoch microseconds. Drive the event with an
-    // epoch timestamp like a real browser does.
+    // LiveKit's timeSyncUpdate `timestamp` is the sync-source playout time as a
+    // DOMHighResTimeStamp (relative to performance.timeOrigin), whereas
+    // userTimestamp is epoch microseconds. The reader must reconcile the two,
+    // so drive the event with a relative timestamp like the real SDK does.
     const LATENCY_MS = 250;
     let nextUserTimestampUs = 0n;
     const lookupFrameMetadata = vi.fn(() => ({ userTimestamp: nextUserTimestampUs, frameId: 0 }));
@@ -125,14 +108,14 @@ describe("FrameMetadataTracker", () => {
     diagnostics.markStart();
     diagnostics.attachRemoteVideoTrack(track);
 
-    const emit = (playoutEpochMs: number, rtpTimestamp: number) => {
-      nextUserTimestampUs = BigInt(Math.round((playoutEpochMs - LATENCY_MS) * 1_000));
-      listeners.get("timeSyncUpdate")?.({ timestamp: playoutEpochMs, rtpTimestamp });
+    const emit = (playoutRelMs: number, rtpTimestamp: number) => {
+      nextUserTimestampUs = BigInt(Math.round((performance.timeOrigin + playoutRelMs - LATENCY_MS) * 1_000));
+      listeners.get("timeSyncUpdate")?.({ timestamp: playoutRelMs, rtpTimestamp });
     };
 
-    const startEpoch = performance.timeOrigin + performance.now();
-    emit(startEpoch, 1); // first frame within warm-up → sets TTFF only
-    emit(startEpoch + PAST_WARMUP, 2); // steady-state sample
+    const startRel = performance.now();
+    emit(startRel, 1); // first frame within warm-up → sets TTFF only
+    emit(startRel + PAST_WARMUP, 2); // steady-state sample
 
     expect(lookupFrameMetadata).toHaveBeenCalledWith({ rtpTimestamp: 2 });
     expect(diagnostics.snapshot()).toMatchObject({ medianMs: LATENCY_MS, sampleCount: 1 });

--- a/packages/sdk/tests/prepare-connection.unit.test.ts
+++ b/packages/sdk/tests/prepare-connection.unit.test.ts
@@ -14,16 +14,6 @@ const baseArgs = {
   observability: { logger },
 };
 
-// Chromium is the insertable-streams path: it ships createEncodedStreams on
-// both sender and receiver, which is what LiveKit's worker pipeline uses.
-function stubFrameMetadataRuntimeSupport() {
-  vi.stubGlobal("window", {
-    navigator: { userAgent: "Mozilla/5.0 Chrome/141.0.0.0 Safari/537.36" },
-    RTCRtpSender: { prototype: { createEncodedStreams() {} } },
-    RTCRtpReceiver: { prototype: { createEncodedStreams() {} } },
-  });
-}
-
 describe("prepareBrowserConnection frame-timing gating", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -33,7 +23,6 @@ describe("prepareBrowserConnection frame-timing gating", () => {
     // The server appends a packet trailer to every frame once frame timing is
     // advertised; without a strip worker the decoder chokes. So a worker that
     // can't be constructed (e.g. blocked by CSP) must keep frame timing off.
-    stubFrameMetadataRuntimeSupport();
     vi.stubGlobal(
       "Worker",
       class {
@@ -42,18 +31,17 @@ describe("prepareBrowserConnection frame-timing gating", () => {
         }
       },
     );
-    const debug = vi.fn();
+    const warn = vi.fn();
 
-    const prepared = prepareBrowserConnection({ ...baseArgs, logger: { ...logger, debug } });
+    const prepared = prepareBrowserConnection({ ...baseArgs, logger: { ...logger, warn }, debugQuality: true });
 
     expect(prepared.frameTiming).toBe(false);
-    expect(debug).toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
     prepared.dispose();
   });
 
   it("advertises frame timing and owns the worker when it can be created", () => {
     const terminate = vi.fn();
-    stubFrameMetadataRuntimeSupport();
     vi.stubGlobal(
       "Worker",
       class {
@@ -61,7 +49,7 @@ describe("prepareBrowserConnection frame-timing gating", () => {
       },
     );
 
-    const prepared = prepareBrowserConnection(baseArgs);
+    const prepared = prepareBrowserConnection({ ...baseArgs, debugQuality: true });
 
     expect(prepared.frameTiming).toBe(true);
     // The pre-created worker is terminated on dispose when connect never took it.
@@ -69,127 +57,10 @@ describe("prepareBrowserConnection frame-timing gating", () => {
     expect(terminate).toHaveBeenCalledTimes(1);
   });
 
-  it("enables frame timing without the legacy debugQuality flag", () => {
-    const terminate = vi.fn();
-    stubFrameMetadataRuntimeSupport();
-    vi.stubGlobal(
-      "Worker",
-      class {
-        terminate = terminate;
-      },
-    );
-
-    const prepared = prepareBrowserConnection(baseArgs);
-
-    expect(prepared.frameTiming).toBe(true);
-    prepared.dispose();
-  });
-
-  it("leaves frame timing off when encoded transforms are unavailable", () => {
-    const debug = vi.fn();
-    const terminate = vi.fn();
-    vi.stubGlobal(
-      "Worker",
-      class {
-        terminate = terminate;
-      },
-    );
-
-    const prepared = prepareBrowserConnection({ ...baseArgs, logger: { ...logger, debug } });
+  it("leaves frame timing off when debugQuality is disabled", () => {
+    const prepared = prepareBrowserConnection({ ...baseArgs, debugQuality: false });
 
     expect(prepared.frameTiming).toBe(false);
-    expect(terminate).not.toHaveBeenCalled();
-    expect(debug).toHaveBeenCalled();
-    prepared.dispose();
-  });
-
-  it("leaves frame timing off when only sender encoded streams are available", () => {
-    const debug = vi.fn();
-    vi.stubGlobal("window", {
-      navigator: { userAgent: "Mozilla/5.0 Firefox/140.0" },
-      RTCRtpSender: { prototype: { createEncodedStreams() {} } },
-    });
-
-    const prepared = prepareBrowserConnection({ ...baseArgs, logger: { ...logger, debug } });
-
-    expect(prepared.frameTiming).toBe(false);
-    expect(debug).toHaveBeenCalled();
-    prepared.dispose();
-  });
-
-  it("enables frame timing on script-transform browsers without insertable streams", () => {
-    // Safari/Firefox ship RTCRtpScriptTransform and no createEncodedStreams.
-    // Without this branch G2G would silently never run outside Chromium.
-    const terminate = vi.fn();
-    vi.stubGlobal("window", {
-      navigator: {
-        userAgent:
-          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
-      },
-      RTCRtpScriptTransform: class {},
-    });
-    vi.stubGlobal(
-      "Worker",
-      class {
-        terminate = terminate;
-      },
-    );
-
-    const prepared = prepareBrowserConnection(baseArgs);
-
-    expect(prepared.frameTiming).toBe(true);
-    prepared.dispose();
-  });
-
-  it("hands the pre-created worker to the first connect and mints a fresh one per reconnect", () => {
-    // The pre-created worker exists so `frameTiming` is only advertised when a
-    // strip transform is guaranteed. If the handoff broke, the server would
-    // append trailers the room could never strip.
-    const created: object[] = [];
-    stubFrameMetadataRuntimeSupport();
-    vi.stubGlobal(
-      "Worker",
-      class {
-        terminate = vi.fn();
-        constructor() {
-          created.push(this);
-        }
-      },
-    );
-
-    const prepared = prepareBrowserConnection(baseArgs);
-    expect(prepared.frameTiming).toBe(true);
-    expect(created).toHaveLength(1);
-
-    const channelConfig = prepared.createMediaChannel({ logger }) as unknown as {
-      config: { createFrameMetadataWorker?: () => Worker };
-    };
-    const takeWorker = channelConfig.config.createFrameMetadataWorker;
-    expect(takeWorker).toBeTypeOf("function");
-
-    // First connect consumes the pre-created worker; no new one is constructed.
-    expect(takeWorker?.()).toBe(created[0]);
-    expect(created).toHaveLength(1);
-
-    // A reconnect gets a fresh worker — LiveKit terminates the old one with its room.
-    const reconnectWorker = takeWorker?.();
-    expect(created).toHaveLength(2);
-    expect(reconnectWorker).toBe(created[1]);
-
-    prepared.dispose();
-  });
-
-  it("does not rely on Chromium script transforms", () => {
-    const debug = vi.fn();
-    vi.stubGlobal("window", {
-      navigator: { userAgent: "Mozilla/5.0 Chrome/141.0.0.0 Safari/537.36" },
-      RTCRtpScriptTransform: class {},
-    });
-
-    const prepared = prepareBrowserConnection({ ...baseArgs, logger: { ...logger, debug } });
-
-    expect(prepared.frameTiming).toBe(false);
-    expect(debug).toHaveBeenCalled();
     prepared.dispose();
   });
 });

--- a/packages/sdk/tests/react-native-compat.unit.test.ts
+++ b/packages/sdk/tests/react-native-compat.unit.test.ts
@@ -116,6 +116,7 @@ describe("React Native compatibility", () => {
   it.each([
     ["mirror", { mirror: true }],
     ["mirror: auto", { mirror: "auto" as const }],
+    ["debugQuality", { debugQuality: true }],
   ])("rejects unsupported %s sessions", async (_feature, unsupportedOption) => {
     stubReactNative(true);
     const { createDecartClient, models, ERROR_CODES } = await import("../src/index.react-native.js");
@@ -209,64 +210,5 @@ describe("React Native compatibility", () => {
     expect(subscription.isConnected()).toBe(true);
     expect(liveKitMockState.rooms[1]?.connect).toHaveBeenCalledWith("wss://livekit.test", "watch-token");
     subscription.disconnect();
-  });
-
-  it("rejects frame-timed subscribe streams in React Native", async () => {
-    stubReactNative(true);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        Response.json({ livekit_url: "wss://livekit.test", token: "watch-token", room_name: "room-1" }),
-      ),
-    );
-
-    const [{ createRealTimeSubscribeClient }, { createConsoleLogger }] = await Promise.all([
-      import("../src/realtime/subscribe-client.js"),
-      import("../src/utils/logger.js"),
-    ]);
-
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.test",
-      apiKey: "test",
-      logger: createConsoleLogger("error"),
-    });
-
-    await expect(
-      subscriber.subscribe({
-        token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-        onRemoteStream: () => {},
-      }),
-    ).rejects.toMatchObject({
-      code: "UNSUPPORTED_PLATFORM_FEATURE",
-      // React Native has no worker factory at all, so the reason must say that
-      // rather than blaming absent encoded transforms.
-      message: expect.stringContaining("this platform has no frame-metadata worker"),
-    });
-  });
-
-  it("routes frame-timed subscribe rejection through the React Native entry point", async () => {
-    // The rejection only happens because the RN factory omits the worker
-    // options; asserting on subscribe-client alone would not catch a regression
-    // that wired a browser worker into the RN client.
-    stubReactNative(true);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        Response.json({ livekit_url: "wss://livekit.test", token: "watch-token", room_name: "room-1" }),
-      ),
-    );
-
-    const { createDecartClient } = await import("../src/index.react-native.js");
-    const client = createDecartClient({ apiKey: "test" });
-
-    await expect(
-      client.realtime.subscribe({
-        token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-        onRemoteStream: () => {},
-      }),
-    ).rejects.toMatchObject({
-      code: "UNSUPPORTED_PLATFORM_FEATURE",
-      message: expect.stringContaining("this platform has no frame-metadata worker"),
-    });
   });
 });

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -75,8 +75,6 @@ vi.mock("livekit-client", () => ({
   ConnectionState: liveKitMock.ConnectionState,
 }));
 
-const logger = { debug() {}, info() {}, warn() {}, error() {} };
-
 class FakeMediaStream {
   private tracks: unknown[];
 
@@ -334,14 +332,6 @@ describe("Subscribe Token", () => {
     expect(decoded).not.toHaveProperty("port");
   });
 
-  it("preserves the frame-timing requirement in subscribe tokens", async () => {
-    const { encodeSubscribeToken } = await import("../src/realtime/stream-session.js");
-    const { decodeSubscribeToken } = await import("../src/realtime/subscribe-client.js");
-    const token = encodeSubscribeToken("session-abc123", { frameTiming: true });
-
-    expect(decodeSubscribeToken(token)).toEqual({ room_name: "session-abc123", frame_timing: true });
-  });
-
   it("throws on invalid base64 token", async () => {
     const { decodeSubscribeToken } = await import("../src/realtime/subscribe-client.js");
     expect(() => decodeSubscribeToken("not-valid-base64!!!")).toThrow("Invalid subscribe token");
@@ -351,137 +341,6 @@ describe("Subscribe Token", () => {
     const { decodeSubscribeToken } = await import("../src/realtime/subscribe-client.js");
     const token = btoa(JSON.stringify({ sid: "s" }));
     expect(() => decodeSubscribeToken(token)).toThrow("Invalid subscribe token");
-  });
-});
-
-describe("realtime.subscribe", () => {
-  beforeEach(() => {
-    liveKitMock.roomInstances.length = 0;
-    liveKitMock.connectMocks.length = 0;
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () =>
-        Response.json({ livekit_url: "wss://livekit.example.test", token: "watch-token", room_name: "room-1" }),
-      ),
-    );
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("configures a frame-metadata worker for browser subscribe rooms when available", async () => {
-    const { createRealTimeSubscribeClient } = await import("../src/realtime/subscribe-client.js");
-    const worker = { terminate: vi.fn() } as unknown as Worker;
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.example.test",
-      apiKey: "test-key",
-      logger,
-      createFrameMetadataWorker: () => worker,
-      isFrameMetadataRuntimeSupported: () => true,
-    });
-
-    const client = await subscriber.subscribe({
-      token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-      onRemoteStream: () => {},
-    });
-
-    const room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
-    expect(room.options).toMatchObject({ frameMetadata: { worker } });
-    expect(room.connect).toHaveBeenCalledWith("wss://livekit.example.test", "watch-token");
-    client.disconnect();
-  });
-
-  it("terminates the frame-metadata worker when subscribe connect fails", async () => {
-    const { createRealTimeSubscribeClient } = await import("../src/realtime/subscribe-client.js");
-    const worker = { terminate: vi.fn() } as unknown as Worker;
-    liveKitMock.connectMocks.push(() => Promise.reject(new Error("connect failed")));
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.example.test",
-      apiKey: "test-key",
-      logger,
-      createFrameMetadataWorker: () => worker,
-      isFrameMetadataRuntimeSupported: () => true,
-    });
-
-    await expect(
-      subscriber.subscribe({
-        token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-        onRemoteStream: () => {},
-      }),
-    ).rejects.toMatchObject({ code: "WEBRTC_SIGNALING_ERROR" });
-
-    expect(worker.terminate).toHaveBeenCalledTimes(1);
-  });
-
-  it("fails fast when a frame-timed subscribe stream cannot create the worker", async () => {
-    const { createRealTimeSubscribeClient } = await import("../src/realtime/subscribe-client.js");
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.example.test",
-      apiKey: "test-key",
-      logger,
-      isFrameMetadataRuntimeSupported: () => true,
-      createFrameMetadataWorker: () => {
-        throw new Error("worker blocked");
-      },
-    });
-
-    await expect(
-      subscriber.subscribe({
-        token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-        onRemoteStream: () => {},
-      }),
-    ).rejects.toMatchObject({
-      code: "UNSUPPORTED_PLATFORM_FEATURE",
-      message: expect.stringMatching(/requires LiveKit frame metadata.*worker blocked/),
-    });
-    expect(liveKitMock.roomInstances).toHaveLength(0);
-  });
-
-  it("keeps legacy non-frame-timed subscribe tokens working without the worker", async () => {
-    const { createRealTimeSubscribeClient } = await import("../src/realtime/subscribe-client.js");
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.example.test",
-      apiKey: "test-key",
-      logger,
-      isFrameMetadataRuntimeSupported: () => true,
-      createFrameMetadataWorker: () => {
-        throw new Error("worker blocked");
-      },
-    });
-
-    const client = await subscriber.subscribe({
-      token: btoa(JSON.stringify({ room_name: "room-1" })),
-      onRemoteStream: () => {},
-    });
-
-    const room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
-    expect(room.options).not.toHaveProperty("frameMetadata");
-    client.disconnect();
-  });
-
-  it("fails frame-timed subscribe tokens when encoded transforms are unavailable", async () => {
-    const { createRealTimeSubscribeClient } = await import("../src/realtime/subscribe-client.js");
-    const subscriber = createRealTimeSubscribeClient({
-      baseUrl: "https://api.example.test",
-      apiKey: "test-key",
-      logger,
-      createFrameMetadataWorker: () => {
-        throw new Error("should not create");
-      },
-      isFrameMetadataRuntimeSupported: () => false,
-    });
-
-    await expect(
-      subscriber.subscribe({
-        token: btoa(JSON.stringify({ room_name: "room-1", frame_timing: true })),
-        onRemoteStream: () => {},
-      }),
-    ).rejects.toMatchObject({
-      code: "UNSUPPORTED_PLATFORM_FEATURE",
-      message: expect.stringContaining("encoded transforms are unavailable"),
-    });
-    expect(liveKitMock.roomInstances).toHaveLength(0);
   });
 });
 
@@ -930,48 +789,6 @@ describe("StreamSession startup orchestration", () => {
     expect(disconnect).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    { frameTiming: true, expected: { room_name: "room", frame_timing: true } },
-    { frameTiming: false, expected: { room_name: "room" } },
-  ])("propagates frameTiming=$frameTiming into the sessionStarted subscribe token", async ({
-    frameTiming,
-    expected,
-  }) => {
-    // Viewers can only strip packet trailers if the token tells them to build
-    // the worker, so the publisher's frame-timing decision has to survive the
-    // round trip into the token it hands out.
-    const mediaChannel: MediaChannel = {
-      localStream: null,
-      on: vi.fn(),
-      off: vi.fn(),
-      connect: vi.fn().mockResolvedValue(undefined),
-      publishLocalTracks: vi.fn().mockResolvedValue(undefined),
-      replaceVideoTrack: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-    };
-    const { StreamSession } = await import("../src/realtime/stream-session.js");
-    const { decodeSubscribeToken } = await import("../src/realtime/subscribe-client.js");
-    const session = new StreamSession({
-      url: "wss://example.test/realtime",
-      localStream: null,
-      createMediaChannel: () => mediaChannel,
-      frameTiming,
-    });
-    const tokens: string[] = [];
-    session.on("sessionStarted", ({ subscribeToken }) => tokens.push(subscribeToken));
-
-    const connectPromise = session.connect();
-    const ws = FakeWebSocket.instances[0];
-    ws.onopen?.();
-    await flushMicrotasks();
-    sendRoomInfo(ws);
-    await expect(connectPromise).resolves.toBeUndefined();
-
-    expect(tokens).toHaveLength(1);
-    expect(decodeSubscribeToken(tokens[0])).toEqual(expected);
-    session.disconnect();
-  });
-
   it("starts LiveKit after room info, then resolves connect before caller initial-state ack", async () => {
     const { StreamSession } = await import("../src/realtime/stream-session.js");
     const session = new StreamSession({
@@ -1150,21 +967,6 @@ describe("StreamSession startup orchestration", () => {
       localStream.getTracks()[0],
       expect.objectContaining({ frameMetadata: { timestamp: true } }),
     );
-  });
-
-  it("fails the media connection if a requested frame-metadata worker cannot be created", async () => {
-    const localStream = createLocalStream();
-    const channel = createLiveKitMediaChannel({
-      localStream,
-      createFrameMetadataWorker: () => {
-        throw new Error("worker blocked");
-      },
-    });
-
-    await expect(channel.connect({ url: "wss://livekit.example.test", token: "token" })).rejects.toThrow(
-      "worker blocked",
-    );
-    expect(liveKitMock.roomInstances).toHaveLength(0);
   });
 
   it("sends only a lean passthrough join for a bare localStream connect (no set_image bootstrap)", async () => {


### PR DESCRIPTION
Reverts DecartAI/sdk#191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default realtime wire format and viewer compatibility semantics; publishers on the reverted behavior no longer send frame trailers unless `debugQuality` is set, which fixes subscriber breakage but is a behavioral/API contract shift integrators should verify.
> 
> **Overview**
> Reverts default-on browser glass-to-glass (G2G) measurement so frame metadata and packet trailers are only used when publishers explicitly opt in.
> 
> **Publishers** must pass `connect({ debugQuality: true })` to enable LiveKit frame-metadata workers, advertise `frame_timing` to the server, and populate `g2gMs` / `ttffMs` on `stats` and connection quality. Without that flag, sessions behave like standard realtime connects with no frame trailers. Worker creation failures no longer abort the media connection—they log and continue without latency metrics. Deep connectivity preflight still turns on `debugQuality` for its short probe session.
> 
> **Viewers** no longer read `frame_timing` from subscribe tokens or spin up strip workers; `subscribe` uses a plain LiveKit room, so mixed SDK versions and React Native subscribers are not blocked or left with a black video when an upgraded publisher would have advertised timing.
> 
> Docs and the SDK demo page describe G2G as opt-in diagnostic measurement and add a checkbox wired to `debugQuality`. React Native rejects `debugQuality` like other browser-only features. G2G playout timestamp handling is corrected to treat LiveKit `timeSyncUpdate` timestamps as relative to `performance.timeOrigin`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de0f0905a8b50ddfd019418c5222f4eb774eb10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->