### PR TITLE
fix(errors): surface the JSON error detail in REST error messages

### DIFF
--- a/packages/sdk/src/process/request.ts
+++ b/packages/sdk/src/process/request.ts
@@ -1,5 +1,5 @@
 import type { ModelDefinition } from "../shared/model";
-import { buildAuthHeaders, buildFormData } from "../shared/request";
+import { buildAuthHeaders, buildFormData, readErrorBody } from "../shared/request";
 import { createSDKError } from "../utils/errors";
 
 export async function sendRequest({
@@ -30,7 +30,7 @@ export async function sendRequest({
   });
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
+    const errorText = await readErrorBody(response);
     throw createSDKError("PROCESSING_ERROR", `Processing failed: ${response.status} - ${errorText}`);
   }
 

--- a/packages/sdk/src/queue/request.ts
+++ b/packages/sdk/src/queue/request.ts
@@ -1,5 +1,5 @@
 import type { ModelDefinition } from "../shared/model";
-import { buildAuthHeaders, buildFormData } from "../shared/request";
+import { buildAuthHeaders, buildFormData, readErrorBody } from "../shared/request";
 import { createQueueResultError, createQueueStatusError, createQueueSubmitError } from "../utils/errors";
 import type { JobStatusResponse, JobSubmitResponse } from "./types";
 
@@ -42,7 +42,7 @@ export async function submitJob({
   });
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
+    const errorText = await readErrorBody(response);
     throw createQueueSubmitError(`Failed to submit job: ${response.status} - ${errorText}`, response.status);
   }
 
@@ -73,7 +73,7 @@ export async function getJobStatus({
   });
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
+    const errorText = await readErrorBody(response);
     throw createQueueStatusError(`Failed to get job status: ${response.status} - ${errorText}`, response.status);
   }
 
@@ -104,7 +104,7 @@ export async function getJobContent({
   });
 
   if (!response.ok) {
-    const errorText = await response.text().catch(() => "Unknown error");
+    const errorText = await readErrorBody(response);
     throw createQueueResultError(`Failed to get job content: ${response.status} - ${errorText}`, response.status);
   }
 

--- a/packages/sdk/src/shared/request.ts
+++ b/packages/sdk/src/shared/request.ts
@@ -53,6 +53,23 @@ export async function fileInputToBlob(input: FileInput): Promise<Blob | ReactNat
 }
 
 /**
+ * Read an error response body for an SDK error message. The API returns JSON
+ * like {"detail": "Prompt is too long: ..."} — surface the human-readable
+ * detail instead of the raw JSON when present.
+ */
+export async function readErrorBody(response: Response): Promise<string> {
+  const text = await response.text().catch(() => "");
+  if (!text) return "Unknown error";
+  try {
+    const detail = (JSON.parse(text) as { detail?: unknown }).detail;
+    if (typeof detail === "string" && detail) return detail;
+  } catch {
+    // not JSON — fall through to the raw text
+  }
+  return text;
+}
+
+/**
  * Build common headers for API requests.
  */
 export function buildAuthHeaders(options: { apiKey?: string; integration?: string } = {}): HeadersInit {

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -323,6 +323,26 @@ describe("Decart SDK", () => {
           }),
         ).rejects.toThrow("Processing failed");
       });
+
+      it("surfaces the detail field of JSON error bodies", async () => {
+        const detail =
+          "Prompt is too long: 362 tokens (maximum 226, including the end-of-sequence token). Please shorten the prompt.";
+        server.use(
+          http.post(`${BASE_URL}/v1/generate/lucy-pro-i2i`, () => {
+            return HttpResponse.json({ detail }, { status: 400 });
+          }),
+        );
+
+        const testBlob = new Blob(["test-image"], { type: "image/png" });
+
+        await expect(
+          decart.process({
+            model: models.image("lucy-pro-i2i"),
+            prompt: "test",
+            data: testBlob,
+          }),
+        ).rejects.toThrow(`Processing failed: 400 - ${detail}`);
+      });
     });
   });
 });
@@ -662,6 +682,26 @@ describe("Queue API", () => {
           data: testBlob,
         }),
       ).rejects.toThrow("Failed to submit job");
+    });
+
+    it("surfaces the detail field of JSON error bodies", async () => {
+      const detail =
+        "Prompt is too long: 362 tokens (maximum 226, including the end-of-sequence token). Please shorten the prompt.";
+      server.use(
+        http.post("http://localhost/v1/jobs/lucy-pro-v2v", () => {
+          return HttpResponse.json({ detail }, { status: 400 });
+        }),
+      );
+
+      const testBlob = new Blob(["test-video"], { type: "video/mp4" });
+
+      await expect(
+        decart.queue.submit({
+          model: models.video("lucy-pro-v2v"),
+          prompt: "test",
+          data: testBlob,
+        }),
+      ).rejects.toThrow(`Failed to submit job: 400 - ${detail}`);
     });
   });
 


### PR DESCRIPTION
## Context

The API is adding server-side prompt validation: a prompt over the model's token limit is rejected with HTTP 400 and a JSON body like `{"detail": "Prompt is too long: ..."}`. This PR makes that rejection (and any other JSON-detail error) read cleanly in SDK error messages.

## Changes

New `readErrorBody()` helper in `shared/request.ts`, used by `process` and all three `queue` request sites. Before:

```
Processing failed: 400 - {"detail":"Prompt is too long: 362 tokens (maximum 226, including the end-of-sequence token). Please shorten the prompt."}
```

After:

```
Processing failed: 400 - Prompt is too long: 362 tokens (maximum 226, including the end-of-sequence token). Please shorten the prompt.
```

Non-JSON bodies and JSON without a string `detail` fall through to the raw text unchanged.

## Tests

- `process` and `queue.submit` with a 400 JSON-detail body reject with the parsed message (msw). Full unit suite: 280 passed; biome clean.
- Note: `pnpm typecheck` fails on main and on this branch with a pre-existing error in `frame-metadata-diagnostics.ts` (`lookupFrameMetadata` missing on `RemoteVideoTrack`) — unrelated to this change.
