### PR TITLE
feat(models): add lucy-vton-3.5.2

### DIFF
--- a/packages/sdk/src/process/types.ts
+++ b/packages/sdk/src/process/types.ts
@@ -169,6 +169,7 @@ export type ModelSpecificInputs<T extends ModelDefinition> = T["name"] extends "
           | "lucy-vton-2"
           | "lucy-vton-3"
           | "lucy-vton-3.5"
+          | "lucy-vton-3.5.2"
           | "lucy-2.1-vton-2"
           | "lucy-vton-latest"
       ? VideoEdit2Inputs

--- a/packages/sdk/src/shared/model.ts
+++ b/packages/sdk/src/shared/model.ts
@@ -8,6 +8,7 @@ const CANONICAL_MODEL_NAMES = [
   "lucy-vton-2",
   "lucy-vton-3",
   "lucy-vton-3.5",
+  "lucy-vton-3.5.2",
   "lucy-restyle-2",
   "lucy-clip",
   "lucy-image-2",
@@ -19,6 +20,7 @@ const CANONICAL_REALTIME_MODEL_NAMES = [
   "lucy-vton-2",
   "lucy-vton-3",
   "lucy-vton-3.5",
+  "lucy-vton-3.5.2",
   "lucy-restyle-2",
 ] as const;
 const CANONICAL_VIDEO_MODEL_NAMES = [
@@ -28,6 +30,7 @@ const CANONICAL_VIDEO_MODEL_NAMES = [
   "lucy-vton-2",
   "lucy-vton-3",
   "lucy-vton-3.5",
+  "lucy-vton-3.5.2",
   "lucy-restyle-2",
 ] as const;
 const CANONICAL_IMAGE_MODEL_NAMES = ["lucy-image-2"] as const;
@@ -73,6 +76,7 @@ export const realtimeModels = z.union([
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
   z.literal("lucy-vton-3.5"),
+  z.literal("lucy-vton-3.5.2"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -89,6 +93,7 @@ export const videoModels = z.union([
   z.literal("lucy-vton-2"),
   z.literal("lucy-vton-3"),
   z.literal("lucy-vton-3.5"),
+  z.literal("lucy-vton-3.5.2"),
   z.literal("lucy-restyle-2"),
   // Latest aliases (server-side resolution)
   z.literal("lucy-latest"),
@@ -267,6 +272,7 @@ export const modelInputSchemas = {
   "lucy-vton-2": videoEdit2Schema,
   "lucy-vton-3": videoEdit2Schema,
   "lucy-vton-3.5": videoEdit2Schema,
+  "lucy-vton-3.5.2": videoEdit2Schema,
   // Latest aliases (server-side resolution)
   "lucy-latest": videoEdit2Schema,
   "lucy-vton-latest": videoEdit2Schema,
@@ -378,6 +384,14 @@ const _models = {
     "lucy-vton-3.5": {
       urlPath: "/v1/stream",
       name: "lucy-vton-3.5" as const,
+      fps: { ideal: 30, max: 30 },
+      width: 1280,
+      height: 720,
+      inputSchema: z.object({}),
+    },
+    "lucy-vton-3.5.2": {
+      urlPath: "/v1/stream",
+      name: "lucy-vton-3.5.2" as const,
       fps: { ideal: 30, max: 30 },
       width: 1280,
       height: 720,
@@ -514,6 +528,15 @@ const _models = {
       width: 1280,
       height: 720,
       inputSchema: modelInputSchemas["lucy-vton-3.5"],
+    },
+    "lucy-vton-3.5.2": {
+      urlPath: "/v1/generate/lucy-vton-3.5.2",
+      queueUrlPath: "/v1/jobs/lucy-vton-3.5.2",
+      name: "lucy-vton-3.5.2" as const,
+      fps: 20,
+      width: 1280,
+      height: 720,
+      inputSchema: modelInputSchemas["lucy-vton-3.5.2"],
     },
     "lucy-restyle-2": {
       urlPath: "/v1/generate/lucy-restyle-2",

--- a/packages/sdk/tests/unit.test.ts
+++ b/packages/sdk/tests/unit.test.ts
@@ -2476,6 +2476,7 @@ describe("Canonical Model Names", () => {
         "lucy-vton-2",
         "lucy-vton-3",
         "lucy-vton-3.5",
+        "lucy-vton-3.5.2",
         "lucy-restyle-2",
       ]);
       expect(canonicalVideoModels.options).toEqual([
@@ -2485,6 +2486,7 @@ describe("Canonical Model Names", () => {
         "lucy-vton-2",
         "lucy-vton-3",
         "lucy-vton-3.5",
+        "lucy-vton-3.5.2",
         "lucy-restyle-2",
       ]);
       expect(canonicalImageModels.options).toEqual(["lucy-image-2"]);
@@ -2544,7 +2546,7 @@ describe("Canonical Model Names", () => {
     it("lists all models when called without options", () => {
       const listedModels = listModels();
 
-      expect(listedModels).toHaveLength(27);
+      expect(listedModels).toHaveLength(29);
       expect(listedModels.some((model) => model.kind === "realtime" && model.name === "lucy-2.1")).toBe(true);
       expect(listedModels.some((model) => model.kind === "video" && model.name === "lucy-clip")).toBe(true);
       expect(listedModels.some((model) => model.kind === "image" && model.name === "lucy-image-2")).toBe(true);
@@ -2646,6 +2648,15 @@ describe("Canonical Model Names", () => {
       expect(model.height).toBe(720);
     });
 
+    it("lucy-vton-3.5.2 canonical name works", () => {
+      const model = models.realtime("lucy-vton-3.5.2");
+      expect(model.name).toBe("lucy-vton-3.5.2");
+      expect(model.urlPath).toBe("/v1/stream");
+      expect(model.fps).toEqual({ ideal: 30, max: 30 });
+      expect(model.width).toBe(1280);
+      expect(model.height).toBe(720);
+    });
+
     it("lucy-restyle-2 canonical name works", () => {
       const model = models.realtime("lucy-restyle-2");
       expect(model.name).toBe("lucy-restyle-2");
@@ -2704,6 +2715,16 @@ describe("Canonical Model Names", () => {
       expect(model.name).toBe("lucy-vton-3.5");
       expect(model.urlPath).toBe("/v1/generate/lucy-vton-3.5");
       expect(model.queueUrlPath).toBe("/v1/jobs/lucy-vton-3.5");
+      expect(model.fps).toBe(20);
+      expect(model.width).toBe(1280);
+      expect(model.height).toBe(720);
+    });
+
+    it("lucy-vton-3.5.2 as video model works", () => {
+      const model = models.video("lucy-vton-3.5.2");
+      expect(model.name).toBe("lucy-vton-3.5.2");
+      expect(model.urlPath).toBe("/v1/generate/lucy-vton-3.5.2");
+      expect(model.queueUrlPath).toBe("/v1/jobs/lucy-vton-3.5.2");
       expect(model.fps).toBe(20);
       expect(model.width).toBe(1280);
       expect(model.height).toBe(720);


### PR DESCRIPTION
## Human TL;DR
TODO(requester): Fill this in with the human-facing summary before marking the PR ready for review.

## Summary
- Add `lucy-vton-3.5.2` as a canonical realtime and queue/video model in the JS SDK registry.
- Reuse the existing VTON video-edit input schema and 1280x720 model dimensions.
- Add unit coverage for realtime/video factory lookup and public registry expectations.

## Checks
- `pnpm --filter @decartai/sdk test tests/unit.test.ts`
- `pnpm --filter @decartai/sdk typecheck`

## Notes
- Independent Claude Code review could not run because local Claude OAuth is revoked. Codex review also could not inspect the diff due a local bubblewrap sandbox error.

Requested by Peleg in Slack ([#C0B4F8N3H7W](https://decart.slack.com/archives/C0B4F8N3H7W)) - [message link](https://decart.slack.com/archives/C0B4F8N3H7W/p1786466362780419?thread_ts=1786448210.347009&cid=C0B4F8N3H7W)