### PR TITLE
fix(realtime): keep CDN-served sessions working (gate G2G cross-origin)

### DIFF
--- a/packages/sdk/src/realtime/browser/frame-metadata-diagnostics.ts
+++ b/packages/sdk/src/realtime/browser/frame-metadata-diagnostics.ts
@@ -125,12 +125,27 @@ export function createBrowserFrameMetadataDiagnostics(): GlassToGlassDiagnostics
   };
 }
 
+const WORKER_URL = () => new URL("./frame-metadata-worker.js", import.meta.url);
+
 export function createFrameMetadataWorker(): Worker {
-  return new Worker(new URL("./frame-metadata-worker.js", import.meta.url));
+  return new Worker(WORKER_URL());
+}
+
+// A cross-origin worker script (SDK served from a CDN) can't load: Chrome throws,
+// Firefox/Safari hand back a worker that dies async and breaks the room. Exported
+// for tests; non-http(s) URLs (bundler-inlined, tests) aren't restricted.
+export function isFrameMetadataWorkerSameOrigin(workerUrl: URL, pageOrigin: string | undefined): boolean {
+  if (workerUrl.protocol !== "http:" && workerUrl.protocol !== "https:") return true;
+  return workerUrl.origin === pageOrigin;
 }
 
 export function isFrameMetadataRuntimeSupported(): boolean {
   if (typeof window === "undefined") return false;
+  try {
+    if (!isFrameMetadataWorkerSameOrigin(WORKER_URL(), window.location?.origin)) return false;
+  } catch {
+    return false;
+  }
   const maybeWindow = window as typeof window & {
     RTCRtpScriptTransform?: unknown;
     RTCRtpSender?: { prototype?: { createEncodedStreams?: unknown } };

--- a/packages/sdk/src/realtime/subscribe-client.ts
+++ b/packages/sdk/src/realtime/subscribe-client.ts
@@ -168,7 +168,9 @@ export const createRealTimeSubscribeClient = (opts: RealTimeSubscribeClientOptio
           throw createFrameMetadataSubscribeUnsupportedError("this platform has no frame-metadata worker");
         }
         if (!(opts.isFrameMetadataRuntimeSupported?.() ?? false)) {
-          throw createFrameMetadataSubscribeUnsupportedError("encoded transforms are unavailable");
+          throw createFrameMetadataSubscribeUnsupportedError(
+            "encoded transforms are unavailable or the SDK is served cross-origin",
+          );
         }
         try {
           frameMetadataWorker = opts.createFrameMetadataWorker();

--- a/packages/sdk/tests/frame-metadata-diagnostics.unit.test.ts
+++ b/packages/sdk/tests/frame-metadata-diagnostics.unit.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createBrowserFrameMetadataDiagnostics,
   FrameMetadataTracker,
+  isFrameMetadataWorkerSameOrigin,
 } from "../src/realtime/browser/frame-metadata-diagnostics.js";
 
 const PAST_WARMUP = 5_000;
@@ -140,5 +141,19 @@ describe("FrameMetadataTracker", () => {
     diagnostics.markStart();
     expect(track.off).toHaveBeenCalledWith("timeSyncUpdate", expect.any(Function));
     expect(listeners.has("timeSyncUpdate")).toBe(false);
+  });
+});
+
+describe("isFrameMetadataWorkerSameOrigin", () => {
+  const page = "https://shop.example.com";
+
+  it("rejects a cross-origin worker (SDK served from a CDN)", () => {
+    expect(isFrameMetadataWorkerSameOrigin(new URL("https://cdn.example.com/worker.js"), page)).toBe(false);
+    expect(isFrameMetadataWorkerSameOrigin(new URL("https://cdn.example.com/worker.js"), undefined)).toBe(false);
+  });
+
+  it("accepts a same-origin or non-http(s) worker", () => {
+    expect(isFrameMetadataWorkerSameOrigin(new URL(`${page}/worker.js`), page)).toBe(true);
+    expect(isFrameMetadataWorkerSameOrigin(new URL("blob:https://cdn.example.com/1"), page)).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Customers embedding the SDK from a CDN (e.g. Shopify storefronts, where the SDK is served from a different origin than the page) were hitting broken realtime sessions: connections crashed on Firefox, and iOS Safari showed black video while still being billed.

The cause was the glass-to-glass latency measurement, which relies on a background helper that browsers refuse to load when the SDK and the page are on different origins. This now auto-detects that situation and skips the latency measurement, so sessions connect and play normally everywhere.

The only tradeoff — accepted intentionally — is that glass-to-glass latency telemetry is unavailable for cross-origin (CDN) deployments; it continues to work for same-origin setups. Verified in Chromium, Firefox, and WebKit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes subscribe/publish gating for frame-timing rooms; wrong same-origin detection could disable G2G on same-origin or still allow broken CDN joins if frame_timing is forced server-side.
> 
> **Overview**
> CDN-hosted SDK embeds (page origin ≠ script origin) were still attempting glass-to-glass frame-metadata workers, which browsers block or kill asynchronously—breaking realtime on Firefox and leaving black video on Safari.
> 
> **Runtime support** now treats cross-origin `http(s)` worker URLs as unsupported via `isFrameMetadataWorkerSameOrigin`, wired into `isFrameMetadataRuntimeSupported()` so publishers skip `frame_timing` advertisement and subscribers get a clear refusal instead of joining a broken room.
> 
> The subscribe unsupported error text now mentions cross-origin SDK delivery alongside missing encoded transforms. Unit tests cover same-origin, CDN, and `blob:` worker URL cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8855a0a891a92e29854c33d2703445eba8bdbb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->