### PR TITLE
fix(sdk): reject unsupported image URL schemes; document the fetch boundary

### DIFF
--- a/packages/sdk/src/realtime/methods.ts
+++ b/packages/sdk/src/realtime/methods.ts
@@ -10,7 +10,10 @@ const setInputSchema = z
     prompt: z.string().min(1).optional(),
     enhance: z.boolean().optional().default(true),
     /**
-     * - `Blob`/`File`/data:/http(s):/base64 string: bytes traverse the wire as base64.
+     * - `Blob`/`File`/data:/base64 string: bytes traverse the wire as base64.
+     * - `http(s):` URL: fetched, then sent as base64. Browser-oriented — the fetch
+     *   relies on the same-origin policy. Server-side, pass bytes rather than a
+     *   caller-supplied URL (fetching an arbitrary URL from a server is an SSRF risk).
      * - `"file_..."` id (from `client.files.upload(...).id`): sent as a server-side reference.
      */
     image: z

--- a/packages/sdk/src/utils/media.ts
+++ b/packages/sdk/src/utils/media.ts
@@ -19,6 +19,21 @@ export async function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
+/**
+ * Normalizes an image input to a raw base64 string (no `data:` prefix).
+ *
+ * String inputs are interpreted by URL scheme:
+ * - `data:` URL — decoded locally.
+ * - `http:`/`https:` URL — fetched, then encoded. This is a browser-oriented
+ *   convenience that leans on the browser's same-origin policy to bound what
+ *   the fetch can read. Do NOT rely on it server-side (Node/SSR/edge) with a
+ *   caller-supplied URL: fetching an arbitrary URL from a server is an SSRF
+ *   vector, and this helper can't distinguish an internal host from an external
+ *   one. Server-side callers should pass binary (`Blob`/`File`) instead.
+ * - any other string that parses as a URL (e.g. `file:`, `blob:`, `ftp:`) — a
+ *   clear error, rather than being forwarded to the API as if it were base64.
+ * - a string that isn't a URL — assumed to already be raw base64.
+ */
 export async function imageToBase64(image: Blob | File | string): Promise<string> {
   if (typeof image === "string") {
     let url: URL | null = null;
@@ -42,6 +57,12 @@ export async function imageToBase64(image: Blob | File | string): Promise<string
       }
       const imageBlob = await response.blob();
       return blobToBase64(imageBlob);
+    }
+    if (url) {
+      // Parsed as a URL but not a scheme we handle. Returning it verbatim would
+      // send e.g. "file:///etc/passwd" onward as if it were base64 and fail
+      // opaquely at the API — reject it at the call site instead.
+      throw new Error(`Unsupported image URL scheme: ${url.protocol}`);
     }
     return image;
   }

--- a/packages/sdk/tests/media.unit.test.ts
+++ b/packages/sdk/tests/media.unit.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { imageToBase64 } from "../src/utils/media.js";
+
+describe("imageToBase64 (string inputs)", () => {
+  it("returns a raw base64 string unchanged", async () => {
+    const b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgAB";
+    await expect(imageToBase64(b64)).resolves.toBe(b64);
+  });
+
+  it("decodes a data: URL to its base64 payload", async () => {
+    await expect(imageToBase64("data:image/png;base64,AAAA")).resolves.toBe("AAAA");
+  });
+
+  it("throws on a data: URL with no payload", async () => {
+    await expect(imageToBase64("data:,")).rejects.toThrow("Invalid data URL image");
+  });
+
+  it("rejects a file: URL rather than forwarding it as base64", async () => {
+    await expect(imageToBase64("file:///etc/passwd")).rejects.toThrow("Unsupported image URL scheme");
+  });
+
+  it("rejects other non-http URL schemes (blob:, ftp:)", async () => {
+    await expect(imageToBase64("blob:https://example.com/uuid")).rejects.toThrow("Unsupported image URL scheme");
+    await expect(imageToBase64("ftp://example.com/image.png")).rejects.toThrow("Unsupported image URL scheme");
+  });
+});


### PR DESCRIPTION
## Context

Came out of an SSRF discussion about `imageToBase64` accepting a URL string and fetching it. Conclusion: for the **browser** (the primary target) it isn't SSRF — the fetch runs in the user's own browser and is bounded by the same-origin policy. But "always the client" is a convention the package doesn't enforce, and the string branch had a real footgun. This keeps the http(s) auto-fetch (it's a genuine browser convenience) and closes the sharp edges around it.

## Changes

**1. Reject unsupported URL schemes instead of silently forwarding them.** `imageToBase64` (`packages/sdk/src/utils/media.ts`) previously returned *any* string that parsed as a URL but wasn't `data:`/`http(s):` — so `file://`, `blob:`, `ftp://` etc. were passed onward as if they were base64 and failed opaquely deep in the API. It now throws a clear `Unsupported image URL scheme: <proto>` at the call site.

- Raw (non-URL) base64 strings still pass through unchanged — those don't parse as a URL, so behavior is identical.
- `file_...` references never reach this function (every call site guards with `isFileRefId` first), so the reference path is unaffected.

**2. Document the fetch boundary.** Added a doc comment on `imageToBase64` and expanded the public JSDoc on the realtime `image` input: the `http(s)` auto-fetch is browser-oriented and leans on the same-origin policy; server-side callers (Node/SSR/edge) should pass bytes (`Blob`/`File`) rather than a caller-supplied URL, since fetching an arbitrary URL from a server is an SSRF vector the SDK can't discriminate.

**3. Test.** New `tests/media.unit.test.ts` covers the string branches: raw base64 passthrough, `data:` decode, empty-data-URL error, and the new unsupported-scheme rejection.

## Deliberately not done

- **Kept the `http(s)` auto-fetch** — it's a real browser convenience and SOP covers the browser case.
- **Did not add `redirect: "error"`** here (unlike the platform blob-fetch fix): image CDNs legitimately 302, so failing closed on redirect would break valid browser image URLs. Different context, different call.

## Verify

- `npm test` — 305 unit tests pass (5 new).
- `typecheck` clean, `biome check` clean on changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation and docs in the SDK media helper; no auth or server behavior changes, though callers passing exotic URL strings will now get explicit errors instead of opaque API failures.
> 
> **Overview**
> **`imageToBase64`** now fails fast when a string parses as a URL with a scheme other than `data:` or `http(s):` (e.g. `file:`, `blob:`, `ftp:`), instead of treating that string as raw base64 and failing later in the API. Raw base64 strings and existing `data:` / `http(s):` behavior are unchanged.
> 
> Documentation on **`imageToBase64`** and the realtime **`image`** input clarifies that auto-fetching `http(s):` URLs is a browser convenience bounded by same-origin policy, and that server-side callers should pass **`Blob`/`File`** bytes rather than caller-supplied URLs because server-side fetch is an SSRF risk.
> 
> New unit tests in **`media.unit.test.ts`** cover string passthrough, `data:` handling, and unsupported-scheme rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04bd2af4057582e5152514374ae3b3604d52ae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->