### PR TITLE
feat(demo): "Custom model" and "Extra query params" overrides on the example page

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -991,8 +991,14 @@
         // so overwriting it would burn the only key we can mint from. Ephemeral
         // and jwt modes mint on radio change and cache here; connect reads it.
         let mintedCredential = null;
+        let mintInFlight = null;
 
-        async function mintCredential(authMode) {
+        function mintCredential(authMode) {
+            mintInFlight = mintCredentialNow(authMode).finally(() => { mintInFlight = null; });
+            return mintInFlight;
+        }
+
+        async function mintCredentialNow(authMode) {
             mintedCredential = null;
             const parentKey = elements.apiKey.value.trim();
             if (!parentKey) { addLog('Please enter an API key first', 'error'); return; }
@@ -1017,7 +1023,10 @@
             });
         });
 
-        function resolveCredential() {
+        async function resolveCredential() {
+            // A blur on the custom-name field (or an auth-mode switch) may have just started a
+            // mint; the click that follows must see its result, not the cleared slot.
+            if (mintInFlight) await mintInFlight;
             const authMode = document.querySelector('input[name="auth-mode"]:checked').value;
             if (authMode === 'parent') {
                 const parentKey = elements.apiKey.value.trim();
@@ -1240,7 +1249,7 @@
 
         // Connect to Decart
         elements.connectBtn.addEventListener('click', async () => {
-            const apiKey = resolveCredential();
+            const apiKey = await resolveCredential();
             if (!apiKey) return;
 
             if (isCustomModelSelected() && !model.name) {
@@ -1399,7 +1408,7 @@
         });
 
         elements.subscribeBtn.addEventListener('click', async () => {
-            const apiKey = resolveCredential();
+            const apiKey = await resolveCredential();
             if (!apiKey) return;
 
             const token = elements.subscribeTokenInput.value.trim();
@@ -1678,7 +1687,7 @@
         
         // Process video file
         elements.processVideo.addEventListener('click', async () => {
-            const apiKey = resolveCredential();
+            const apiKey = await resolveCredential();
             if (!apiKey) return;
 
             const file = elements.videoFile.files[0];

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -329,6 +329,10 @@
             <input type="text" id="realtime-base-url" placeholder="wss://api3.decart.ai">
         </div>
         <div class="control-group">
+            <label for="query-params">Extra query params (optional, appended to the stream URL):</label>
+            <input type="text" id="query-params" placeholder="pool=moderation-eval&amp;foo=bar">
+        </div>
+        <div class="control-group">
             <label for="model-select">Model:</label>
             <select id="model-select">
                 <optgroup label="Latest (server-resolved)">
@@ -347,7 +351,18 @@
                 <optgroup label="Deprecated aliases">
                     <option value="lucy-2.1-vton-2">Lucy 2.1 VTON 2 (alias for Lucy VTON 2)</option>
                 </optgroup>
+                <optgroup label="Override">
+                    <option value="__custom__">Custom model (any name the API accepts)</option>
+                </optgroup>
             </select>
+        </div>
+        <div class="control-group" id="custom-model-group" style="display: none;">
+            <label for="custom-model-name">Custom model name:</label>
+            <input type="text" id="custom-model-name" placeholder="e.g. lucy-vton-3.6">
+            <div class="inline-controls">
+                <label style="margin: 0; font-weight: normal;">Width <input type="number" id="custom-model-width" min="1" step="1" value="1280" style="width: 90px;"></label>
+                <label style="margin: 0; font-weight: normal;">Height <input type="number" id="custom-model-height" min="1" step="1" value="720" style="width: 90px;"></label>
+            </div>
         </div>
         <div class="control-group">
             <label for="resolution-select">Resolution:</label>
@@ -616,6 +631,11 @@
             apiKey: document.getElementById('api-key'),
             modelSelect: document.getElementById('model-select'),
             realtimeBaseUrl: document.getElementById('realtime-base-url'),
+            queryParams: document.getElementById('query-params'),
+            customModelGroup: document.getElementById('custom-model-group'),
+            customModelName: document.getElementById('custom-model-name'),
+            customModelWidth: document.getElementById('custom-model-width'),
+            customModelHeight: document.getElementById('custom-model-height'),
             resolutionSelect: document.getElementById('resolution-select'),
             codecSelect: document.getElementById('codec-select'),
             passthroughSelect: document.getElementById('passthrough-select'),
@@ -716,6 +736,46 @@
             }
 
             return fallback;
+        }
+
+        // "Custom model" bypasses models.realtime(), which throws for names this SDK build
+        // doesn't list. The object matches the SDK's model definition schema (name, urlPath,
+        // fps, width, height), so connect() accepts it and the API decides whether the name exists.
+        const CUSTOM_MODEL_OPTION = '__custom__';
+
+        function isCustomModelSelected() {
+            return elements.modelSelect.value === CUSTOM_MODEL_OPTION;
+        }
+
+        function buildCustomModel() {
+            const width = Number.parseInt(elements.customModelWidth.value, 10);
+            const height = Number.parseInt(elements.customModelHeight.value, 10);
+            return {
+                name: elements.customModelName.value.trim(),
+                urlPath: '/v1/stream',
+                fps: { ideal: 30, max: 30 },
+                width: Number.isFinite(width) && width > 0 ? width : 1280,
+                height: Number.isFinite(height) && height > 0 ? height : 720,
+            };
+        }
+
+        function resolveSelectedModel() {
+            return isCustomModelSelected() ? buildCustomModel() : models.realtime(elements.modelSelect.value);
+        }
+
+        // "pool=moderation-eval&foo=bar" -> { pool: "moderation-eval", foo: "bar" }; passed to
+        // connect() as queryParams, which the SDK merges into the stream URL (api_key and model win).
+        function parseExtraQueryParams() {
+            const raw = elements.queryParams.value.trim().replace(/^\?/, '');
+            if (!raw) return undefined;
+            const params = Object.fromEntries(new URLSearchParams(raw));
+            return Object.keys(params).length > 0 ? params : undefined;
+        }
+
+        for (const input of [elements.customModelName, elements.customModelWidth, elements.customModelHeight]) {
+            input.addEventListener('input', () => {
+                if (isCustomModelSelected()) model = buildCustomModel();
+            });
         }
 
         elements.cameraFps.value = String(resolveCameraFps(model.fps));
@@ -996,9 +1056,10 @@
         // Model selection handler
         elements.modelSelect.addEventListener('change', (e) => {
             const selectedModel = e.target.value;
-            model = models.realtime(selectedModel);
+            elements.customModelGroup.style.display = selectedModel === CUSTOM_MODEL_OPTION ? '' : 'none';
+            model = resolveSelectedModel();
             elements.cameraFps.value = String(resolveCameraFps(model.fps));
-            addLog(`Selected model: ${selectedModel}`, 'info');
+            addLog(`Selected model: ${model.name || '(custom, no name yet)'}`, 'info');
 
             const authMode = document.querySelector('input[name="auth-mode"]:checked').value;
             if (authMode !== 'parent') mintCredential(authMode);
@@ -1174,6 +1235,11 @@
             const apiKey = resolveCredential();
             if (!apiKey) return;
 
+            if (isCustomModelSelected() && !model.name) {
+                addLog('Custom model selected: enter a model name first', 'error');
+                return;
+            }
+
             if (!localStream) {
                 addLog('Please start camera first', 'error');
                 return;
@@ -1230,9 +1296,15 @@
                 const passthrough = passthroughChoice === '' ? undefined : passthroughChoice === 'true';
                 addLog(`Initial passthrough: ${passthrough === undefined ? 'default (auto)' : passthrough}`, 'info');
 
+                const extraQueryParams = parseExtraQueryParams();
+                if (extraQueryParams) {
+                    addLog(`Extra query params: ${new URLSearchParams(extraQueryParams).toString()}`, 'info');
+                }
+
                 decartRealtime = await decartClient.realtime.connect(localStream, {
                     model,
                     resolution,
+                    ...(extraQueryParams && { queryParams: extraQueryParams }),
                     ...(preferredVideoCodec && { preferredVideoCodec }),
                     onRemoteStream: (stream) => {
                         addLog('Received remote stream from Decart', 'success');

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -778,6 +778,14 @@
             });
         }
 
+        // Ephemeral/JWT credentials are minted for model.name (allowedModels), so a custom name
+        // committed after the mint would leave the credential scoped to the wrong model.
+        elements.customModelName.addEventListener('change', () => {
+            if (!isCustomModelSelected() || !model.name) return;
+            const authMode = document.querySelector('input[name="auth-mode"]:checked').value;
+            if (authMode !== 'parent') mintCredential(authMode);
+        });
+
         elements.cameraFps.value = String(resolveCameraFps(model.fps));
 
         // Logging system
@@ -1062,7 +1070,7 @@
             addLog(`Selected model: ${model.name || '(custom, no name yet)'}`, 'info');
 
             const authMode = document.querySelector('input[name="auth-mode"]:checked').value;
-            if (authMode !== 'parent') mintCredential(authMode);
+            if (authMode !== 'parent' && model.name) mintCredential(authMode);
             
             // If camera is already started, stop it so user can restart with new model settings.
             if (localStream) {


### PR DESCRIPTION
**Opened by Claude Fable 5.1 (Anthropic), operated by @ilay-decart.** Page-only change to the example page that ships as sdk.stage-decart.com; no SDK package code touched.

## What

Two overrides on the example page, next to the existing API key and Realtime Base URL fields:

- **Custom model.** The model dropdown gets an `Override → Custom model` entry that reveals a name + width/height group. It builds a model object matching the SDK's model definition schema (`name`, `urlPath`, `fps`, `width`, `height`) instead of calling `models.realtime()`, which throws for any name this SDK build doesn't list. The API decides whether the name exists.
- **Extra query params.** A text field (`pool=moderation-eval&foo=bar`) parsed with `URLSearchParams` and passed to `realtime.connect()` as `queryParams`. The SDK already supports that option and merges it into the stream URL with `api_key` and `model` winning.
- Connect refuses a custom model with an empty name.

## Why

Evaluation pools serve models the SDK does not list yet and are selected with a `pool=` query param (currently `lucy-vton-3.6` behind `?pool=moderation-eval`, DecartAI/api API-1809). The deployed page could reach neither: the dropdown is hard-coded and the SDK's model lookup rejects unknown names client-side, and there was no way to add a query param. Evaluators had to hand-patch bundles or write raw clients.

## How I tested

- `biome check` and `biome lint` green (the page is outside biome's scope; CI unchanged).
- The page's module script passes `node --check`.
- Playwright smoke against `vite dev` with a fake camera and a bogus key: selected `Custom model`, typed `lucy-vton-3.6` and `pool=moderation-eval&x=1`, clicked Connect. The browser opened

  ```
  wss://api3.decart.ai/v1/stream?pool=moderation-eval&x=1&api_key=…&model=lucy-vton-3.6&resolution=720p&user_agent=decart-js-sdk%2F0.1.22…
  ```

  Custom group hidden until the override is selected; existing dropdown entries behave as before.

## Deploy

sdk.stage-decart.com is built by DecartAI/api's `CD-sdk` workflow from an sdk branch and pinned in gitops (`sdk.imageTag`, currently a June build). After merge, dispatching that workflow on `main` with deploy enabled picks this up, and also brings `lucy-vton-3.5` / `lucy-2.5` to the deployed page.

## Out of scope

Adding `lucy-vton-3.6` to the SDK's canonical model list (a package change with a release) — the custom-model override covers evaluation until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the static SDK example page; no library or auth server logic is modified.
> 
> **Overview**
> **Demo-only** updates to `packages/sdk/index.html` so evaluators can hit unlisted models and pool routing without patching the SDK.
> 
> The model dropdown gains an **Override → Custom model** path that builds a hand-rolled model object (`name`, dimensions, `/v1/stream`) instead of `models.realtime()`, which rejects names absent from this build. Connect blocks an empty custom name. An **Extra query params** field parses `key=value` pairs and forwards them to `realtime.connect()` as `queryParams` (e.g. `pool=moderation-eval`).
> 
> Ephemeral/JWT flows are tightened: credential minting tracks in-flight mints, `resolveCredential()` awaits them before connect/subscribe/process, and changing the custom model name re-mints so `allowedModels` stays aligned with `model.name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8713cec6b111c65813e0cc1317e372a0617422e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->