### PR TITLE
feat(realtime): seed publisher start bitrate at the quality floor

### DIFF
--- a/packages/sdk/src/realtime/config-realtime.ts
+++ b/packages/sdk/src/realtime/config-realtime.ts
@@ -1,3 +1,17 @@
+/** Publish bitrate floor for the primary video layer (bps). */
+const MIN_VIDEO_BITRATE_BPS = 1_100_000;
+/** Publish bitrate cap for the primary video layer (bps). */
+const MAX_VIDEO_BITRATE_BPS = 3_500_000;
+/** Combined max bitrate of livekit-client's default lower simulcast layers (bps); pinned by a unit test. */
+const SIMULCAST_LOWER_LAYERS_BPS = 610_000;
+/** Fraction of the bandwidth estimate available to the video encoders. */
+const BWE_VIDEO_SHARE = 0.8;
+
+/** Bandwidth estimate (kbps) needed for the primary layer to reach `primaryBps`. */
+function estimateKbpsFor(primaryBps: number): number {
+  return Math.round((primaryBps + SIMULCAST_LOWER_LAYERS_BPS) / BWE_VIDEO_SHARE / 1000);
+}
+
 export const REALTIME_CONFIG = {
   signaling: {
     connectTimeoutMs: 60_000,
@@ -33,8 +47,12 @@ export const REALTIME_CONFIG = {
       dynacast: false,
     },
     defaultVideoCodec: "h264",
-    defaultMaxVideoBitrateBps: 3_500_000,
+    defaultMaxVideoBitrateBps: MAX_VIDEO_BITRATE_BPS,
     vp9MaxVideoBitrateBps: 3_000_000,
+    /** Seeds the publisher's bandwidth estimate (a start bitrate, not a minimum). */
+    minVideoBitrateBps: MIN_VIDEO_BITRATE_BPS,
+    simulcastLowerLayersBitrateBps: SIMULCAST_LOWER_LAYERS_BPS,
+    bweVideoShare: BWE_VIDEO_SHARE,
     defaultPublishFps: 30,
   },
   observability: {
@@ -87,8 +105,12 @@ export const REALTIME_CONFIG = {
       loss: { good: 0.001, fair: 0.01, poor: 0.05 },
       /** End-to-end frame drop ratio (0..1), when a frame identity is available. */
       g2gDrop: { good: 0.001, fair: 0.01, poor: 0.05 },
-      /** Upstream headroom = available BWE ÷ the intended publish bitrate (requiredUpstreamKbps). */
-      upstream: { goodRatio: 1.0, fairRatio: 0.8, poorRatio: 0.5, requiredUpstreamKbps: 3500 },
+      /** Available upstream bandwidth bands (kbps). Chromium-only. */
+      upstream: {
+        goodKbps: estimateKbpsFor(MAX_VIDEO_BITRATE_BPS),
+        fairKbps: estimateKbpsFor(MIN_VIDEO_BITRATE_BPS),
+        poorKbps: estimateKbpsFor(MIN_VIDEO_BITRATE_BPS / 2),
+      },
       /** Rendered (inbound) frames-per-second. */
       stall: { goodFps: 20, fairFps: 12, poorFps: 5 },
     },

--- a/packages/sdk/src/realtime/media-channel.ts
+++ b/packages/sdk/src/realtime/media-channel.ts
@@ -15,6 +15,48 @@ import type { RealtimeObservability } from "./observability/realtime-observabili
 
 export type VideoCodec = "h264" | "vp8" | "vp9" | "av1";
 
+const START_BITRATE_PARAM = "x-google-start-bitrate";
+
+/** livekit-client internals (`@internal`) that receive the SFU answer for the publisher connection. */
+type PublisherHost = {
+  engine?: {
+    pcManager?: {
+      publisher?: { setRemoteDescription?: (sd: RTCSessionDescriptionInit, offerId: number) => Promise<boolean> };
+    };
+  };
+};
+
+/** Add `x-google-start-bitrate=<kbps>` to every video codec's fmtp line; libwebrtc reads it from the remote description. */
+export function withVideoStartBitrate(sdp: string, kbps: number): string {
+  const param = `${START_BITRATE_PARAM}=${kbps}`;
+  return sdp
+    .split(/(?=^m=)/m)
+    .map((section) => {
+      if (!section.startsWith("m=video")) return section;
+      const withFmtp = new Set(Array.from(section.matchAll(/^a=fmtp:(\d+) /gm), (m) => m[1]));
+      return (
+        section
+          .replace(/^a=fmtp:\d+ [^\r\n]*/gm, (line) => (line.includes(START_BITRATE_PARAM) ? line : `${line};${param}`))
+          // Codecs with no fmtp line of their own (VP8): add one after the rtpmap.
+          .replace(/^a=rtpmap:(\d+) (?!rtx|red|ulpfec|flexfec)[^\r\n]*(\r?\n)/gim, (line, pt: string, eol: string) =>
+            withFmtp.has(pt) ? line : `${line}a=fmtp:${pt} ${param}${eol}`,
+          )
+      );
+    })
+    .join("");
+}
+
+function usesSimulcast(videoCodec?: VideoCodec): boolean {
+  return (videoCodec ?? REALTIME_CONFIG.livekit.defaultVideoCodec) !== "vp9";
+}
+
+/** Bandwidth-estimator seed (kbps) for the publisher. */
+export function getVideoStartBitrateKbps(videoCodec?: VideoCodec): number {
+  const { minVideoBitrateBps, simulcastLowerLayersBitrateBps, bweVideoShare } = REALTIME_CONFIG.livekit;
+  const lowerLayers = usesSimulcast(videoCodec) ? simulcastLowerLayersBitrateBps : 0;
+  return Math.round((minVideoBitrateBps + lowerLayers) / bweVideoShare / 1000);
+}
+
 export function getDefaultVideoPublishOptions(
   source: TrackPublishOptions["source"],
   videoCodec?: VideoCodec,
@@ -29,7 +71,7 @@ export function getDefaultVideoPublishOptions(
   return {
     source,
     videoCodec: resolvedCodec,
-    simulcast: resolvedCodec !== "vp9",
+    simulcast: usesSimulcast(resolvedCodec),
     videoEncoding: {
       maxBitrate,
       maxFramerate: REALTIME_CONFIG.livekit.defaultPublishFps,
@@ -158,6 +200,7 @@ export class LiveKitMediaChannel implements MediaChannel {
     this.config.observability?.startPhase("webrtc-handshake");
     await room.connect(opts.url, opts.token);
     this.config.observability?.endPhase("webrtc-handshake", { success: true });
+    this.seedStartBitrate(room);
     this.config.observability?.setLiveKitRoom(room);
   }
 
@@ -187,6 +230,24 @@ export class LiveKitMediaChannel implements MediaChannel {
     if (room) {
       room.disconnect().catch(() => {});
     }
+  }
+
+  /**
+   * livekit-client has no start-bitrate option for H264/VP8, so seed the estimator through the
+   * SFU answer. Installed once per room: if livekit-client itself performs a full reconnect it
+   * creates a new publisher transport, and the rest of that session ramps from the default.
+   */
+  private seedStartBitrate(room: Room): void {
+    const publisher = (room as unknown as PublisherHost).engine?.pcManager?.publisher;
+    const original = publisher?.setRemoteDescription;
+    if (!publisher || typeof original !== "function") return;
+    const kbps = getVideoStartBitrateKbps(this.config.videoCodec);
+    publisher.setRemoteDescription = (sd, offerId) =>
+      original.call(
+        publisher,
+        sd.type === "answer" && sd.sdp ? { type: sd.type, sdp: withVideoStartBitrate(sd.sdp, kbps) } : sd,
+        offerId,
+      );
   }
 
   private async publishTracks(stream: MediaStream): Promise<void> {

--- a/packages/sdk/src/realtime/observability/connection-quality.ts
+++ b/packages/sdk/src/realtime/observability/connection-quality.ts
@@ -66,7 +66,7 @@ export type ConnectionQualityThresholds = {
   ttff: { goodMs: number; fairMs: number; poorMs: number };
   loss: { good: number; fair: number; poor: number };
   g2gDrop: { good: number; fair: number; poor: number };
-  upstream: { goodRatio: number; fairRatio: number; poorRatio: number; requiredUpstreamKbps: number };
+  upstream: { goodKbps: number; fairKbps: number; poorKbps: number };
   stall: { goodFps: number; fairFps: number; poorFps: number };
 };
 
@@ -164,22 +164,14 @@ export function scoreMetrics(
 
   const loss = scoreLowerBetter(signals.fractionLost, thresholds.loss.good, thresholds.loss.fair, thresholds.loss.poor);
 
-  // Upstream only: available BWE ÷ the INTENDED publish bitrate. Dividing by the
-  // encoder's adaptive target would mask throttling (it drops with the uplink).
-  // Downstream bitrate is intentionally not scored — it's server-chosen.
+  // Upstream only: available BWE against the configured bands. Scoring the estimate rather
+  // than the encoder's adaptive target keeps a throttled uplink from reading "good".
+  // Downstream bitrate is server-chosen and intentionally not scored.
   let bandwidth: ConnectionQuality = "good";
   if (!options.skipBitrate) {
-    const ratio =
-      signals.availableOutgoingKbps != null
-        ? signals.availableOutgoingKbps / thresholds.upstream.requiredUpstreamKbps
-        : null;
-    bandwidth = scoreHigherBetter(
-      ratio,
-      thresholds.upstream.goodRatio,
-      thresholds.upstream.fairRatio,
-      thresholds.upstream.poorRatio,
-    );
-    // Encoder self-reporting a bandwidth limit is a stronger signal than the ratio.
+    const { goodKbps, fairKbps, poorKbps } = thresholds.upstream;
+    bandwidth = scoreHigherBetter(signals.availableOutgoingKbps, goodKbps, fairKbps, poorKbps);
+    // Encoder self-reporting a bandwidth limit is a stronger signal than the estimate.
     if (signals.qualityLimitationReason === "bandwidth") bandwidth = worst(bandwidth, "fair");
   }
 

--- a/packages/sdk/tests/connection-quality.unit.test.ts
+++ b/packages/sdk/tests/connection-quality.unit.test.ts
@@ -59,7 +59,7 @@ function makeStats(o: StatsOverrides = {}): WebRTCStats {
         },
     connection: {
       currentRoundTripTime: rttSec,
-      availableOutgoingBitrate: o.availableOutgoingBitrate === undefined ? 4_000_000 : o.availableOutgoingBitrate,
+      availableOutgoingBitrate: o.availableOutgoingBitrate === undefined ? 6_000_000 : o.availableOutgoingBitrate,
       selectedCandidatePairs: o.relayed
         ? [{ local: relayCandidate, remote: relayCandidate }]
         : [{ local: hostCandidate, remote: hostCandidate }],
@@ -111,21 +111,34 @@ describe("scoreSnapshot", () => {
   });
 
   it("flags insufficient upstream headroom as a bandwidth problem", () => {
-    // available 1 Mbps vs 3.5 Mbps intended → ratio 0.29 < 0.5 critical
     const { quality, limitingFactor } = scoreSnapshot(makeStats({ availableOutgoingBitrate: 1_000_000 }));
     expect(quality).toBe("critical");
     expect(limitingFactor).toBe("bandwidth");
   });
 
-  it("flags throttled upstream even when the encoder target dropped to match it", () => {
-    // Congestion control cut the encoder target to ~1.2 Mbps to fit a weak uplink.
-    // Scoring against the intended 3.5 Mbps still flags it — the lowered target
-    // must not mask the throttle as "good".
+  it("flags a weak uplink even when the encoder target dropped to match it", () => {
+    // The lowered encoder target must not mask the throttle.
     const { quality, limitingFactor } = scoreSnapshot(
-      makeStats({ availableOutgoingBitrate: 1_200_000, targetBitrateKbps: 1200 }),
+      makeStats({ availableOutgoingBitrate: 900_000, targetBitrateKbps: 900 }),
     );
     expect(quality).toBe("critical");
     expect(limitingFactor).toBe("bandwidth");
+  });
+
+  it("rates an uplink between the fair and good bands as fair, not poor", () => {
+    const { quality, limitingFactor } = scoreSnapshot(
+      makeStats({ availableOutgoingBitrate: 2_500_000, targetBitrateKbps: 1390, qualityLimitationReason: "bandwidth" }),
+    );
+    expect(quality).toBe("fair");
+    expect(limitingFactor).toBe("bandwidth");
+  });
+
+  it("uses the configured bands rather than hard-coded numbers", () => {
+    const { goodKbps, fairKbps, poorKbps } = THRESHOLDS.upstream;
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: goodKbps * 1000 })).quality).toBe("good");
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: fairKbps * 1000 })).quality).toBe("fair");
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: poorKbps * 1000 })).quality).toBe("poor");
+    expect(scoreSnapshot(makeStats({ availableOutgoingBitrate: poorKbps * 1000 - 1000 })).quality).toBe("critical");
   });
 
   it("caps upstream at fair when the encoder reports a bandwidth limitation, even with good BWE", () => {
@@ -241,7 +254,7 @@ describe("ConnectionQualityEvaluator", () => {
 
   it("snaps to the real verdict when warm-up ends (no lingering optimistic good)", () => {
     const evaluator = new ConnectionQualityEvaluator(fastThresholds({ warmupSamples: 3 }));
-    const weakUplink = () => makeStats({ availableOutgoingBitrate: 800_000 }); // ~0.23 ratio → critical
+    const weakUplink = () => makeStats({ availableOutgoingBitrate: 800_000 });
     // Bandwidth is skipped during warm-up, so the provisional verdict is good.
     expect(evaluator.update(weakUplink())).toMatchObject({ quality: "good", warmingUp: true });
     expect(evaluator.update(weakUplink())).toBeNull();

--- a/packages/sdk/tests/realtime.unit.test.ts
+++ b/packages/sdk/tests/realtime.unit.test.ts
@@ -36,6 +36,9 @@ const liveKitMock = vi.hoisted(() => {
     };
     connect = vi.fn().mockImplementation(() => connectMocks.shift()?.() ?? Promise.resolve());
     disconnect = vi.fn().mockResolvedValue(undefined);
+    /** Inner publisher `setRemoteDescription` (livekit-client internal) — kept so tests can see what reached it. */
+    publisherAnswers = vi.fn().mockResolvedValue(true);
+    engine = { pcManager: { publisher: { setRemoteDescription: this.publisherAnswers } } };
     readonly options: unknown;
 
     constructor(options?: unknown) {
@@ -1149,6 +1152,33 @@ describe("StreamSession startup orchestration", () => {
       1,
       localStream.getTracks()[0],
       expect.objectContaining({ frameMetadata: { timestamp: true } }),
+    );
+  });
+
+  it("seeds the publisher's start bitrate on every SFU answer once the room is joined", async () => {
+    const localStream = createLocalStream();
+    const channel = createLiveKitMediaChannel({ localStream, logger });
+
+    await channel.connect({ url: "wss://livekit.example.test", token: "token" });
+
+    const room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
+    const answer =
+      "v=0\r\nm=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 H264/90000\r\na=fmtp:96 packetization-mode=1\r\n";
+    await room.engine.pcManager.publisher.setRemoteDescription({ type: "answer", sdp: answer }, 1);
+    expect(room.publisherAnswers).toHaveBeenCalledWith(
+      { type: "answer", sdp: expect.stringContaining("a=fmtp:96 packetization-mode=1;x-google-start-bitrate=2138") },
+      1,
+    );
+
+    // VP9 publishes a single layer, so no lower-layer budget is added.
+    liveKitMock.roomInstances.length = 0;
+    const vp9 = createLiveKitMediaChannel({ localStream: createLocalStream(), logger, videoCodec: "vp9" });
+    await vp9.connect({ url: "wss://livekit.example.test", token: "token" });
+    const vp9Room = liveKitMock.roomInstances[0] as InstanceType<typeof liveKitMock.MockRoom>;
+    await vp9Room.engine.pcManager.publisher.setRemoteDescription({ type: "answer", sdp: answer }, 1);
+    expect(vp9Room.publisherAnswers).toHaveBeenCalledWith(
+      { type: "answer", sdp: expect.stringContaining("x-google-start-bitrate=1375") },
+      1,
     );
   });
 

--- a/packages/sdk/tests/start-bitrate.unit.test.ts
+++ b/packages/sdk/tests/start-bitrate.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { REALTIME_CONFIG } from "../src/realtime/config-realtime.js";
+import { getVideoStartBitrateKbps, withVideoStartBitrate } from "../src/realtime/media-channel.js";
+
+describe("start bitrate", () => {
+  it("adds x-google-start-bitrate to video codecs (inserting an fmtp line for VP8), never audio, without duplicating", () => {
+    const sdp = [
+      "v=0",
+      "m=audio 9 UDP/TLS/RTP/SAVPF 111",
+      "a=fmtp:111 minptime=10;useinbandfec=1",
+      "m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99",
+      "a=rtpmap:96 H264/90000",
+      "a=fmtp:96 packetization-mode=1;profile-level-id=42e01f",
+      "a=rtpmap:97 rtx/90000",
+      "a=fmtp:97 apt=96",
+      "a=rtpmap:98 VP8/90000",
+      "a=rtpmap:99 rtx/90000",
+      "a=fmtp:99 apt=98",
+      "",
+    ].join("\r\n");
+    const out = withVideoStartBitrate(sdp, 2138);
+    expect(out).toContain("a=fmtp:96 packetization-mode=1;profile-level-id=42e01f;x-google-start-bitrate=2138\r\n");
+    // VP8 has no fmtp line of its own (desktop Safari is pinned to VP8): one is inserted after its rtpmap.
+    expect(out).toContain(
+      "a=rtpmap:98 VP8/90000\r\na=fmtp:98 x-google-start-bitrate=2138\r\na=rtpmap:99 rtx/90000\r\n",
+    );
+    expect(out.match(/^a=fmtp:99 /gm)).toHaveLength(1); // RTX gets no inserted line
+    expect(out).toContain("a=fmtp:111 minptime=10;useinbandfec=1\r\n");
+    expect(withVideoStartBitrate(out, 999)).toBe(out);
+  });
+
+  it("computes the seed from the config (VP9 publishes a single layer)", () => {
+    const { minVideoBitrateBps, simulcastLowerLayersBitrateBps, bweVideoShare } = REALTIME_CONFIG.livekit;
+    expect(getVideoStartBitrateKbps()).toBe(
+      Math.round((minVideoBitrateBps + simulcastLowerLayersBitrateBps) / bweVideoShare / 1000),
+    );
+    expect(getVideoStartBitrateKbps("h264")).toBe(2138);
+    expect(getVideoStartBitrateKbps("vp9")).toBe(1375);
+    expect(getVideoStartBitrateKbps()).toBe(REALTIME_CONFIG.observability.connectionQuality.upstream.fairKbps);
+  });
+
+  it("pins the simulcast lower-layer budget to the installed livekit-client presets", async () => {
+    const { VideoPresets } = await import("livekit-client");
+    expect(VideoPresets.h180.encoding.maxBitrate + VideoPresets.h360.encoding.maxBitrate).toBe(
+      REALTIME_CONFIG.livekit.simulcastLowerLayersBitrateBps,
+    );
+  });
+
+  it("derives the quality bands from the same constants", () => {
+    expect(REALTIME_CONFIG.observability.connectionQuality.upstream).toEqual({
+      goodKbps: 5138,
+      fairKbps: 2138,
+      poorKbps: 1450,
+    });
+  });
+});


### PR DESCRIPTION
Realtime sessions now publish with a bandwidth-estimator start bitrate set at the level the models need for high-quality output, so the first frames the model sees are already at full quality instead of ramping up from WebRTC's default over the first seconds, which left the opening frames blurry or, with simulcast, stuck on a lower-resolution layer.

It is a start bitrate rather than a minimum, so congestion control still backs off within a second or two on weak connections such as congested LTE.

The in-session bandwidth verdict is anchored on the same quality floor, so an uplink that comfortably delivers what the model needs no longer reads as poor.

No public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relies on livekit-client internal `setRemoteDescription` patching and SDP manipulation, which could break on client upgrades; higher initial publish bitrate may briefly stress weak uplinks before congestion control backs off.
> 
> **Overview**
> Realtime publishing now **seeds WebRTC’s bandwidth estimator** at the bitrate the model needs for good input, instead of ramping from libwebrtc’s default—so opening frames are less likely to be blurry or stuck on a lower simulcast layer. Because livekit-client has no H264/VP8 start-bitrate knob, the SDK patches SFU **answers** to add `x-google-start-bitrate` (via `withVideoStartBitrate` and a one-time hook on the publisher’s `setRemoteDescription` after `room.connect`). The seed is derived from shared config: primary floor (~1.1 Mbps), simulcast lower layers (~610 kbps), and an 80% video share of BWE—**2138 kbps** for H264/VP8 simulcast and **1375 kbps** for single-layer VP9.
> 
> **Connection-quality upstream scoring** moves from a ratio against a fixed 3.5 Mbps “required” uplink to absolute **good/fair/poor kbps bands** computed from the same constants (`estimateKbpsFor`), so a healthy uplink that meets the quality floor no longer reads as poor. Encoder `qualityLimitationReason: bandwidth` still caps the verdict at fair.
> 
> No public API changes; coverage adds `start-bitrate.unit.test.ts` and extends realtime/connection-quality tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e653d616ebd9798c1bfab20031942c2af67e325b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->